### PR TITLE
US: Teacher sees tooltips for credentials

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -24,7 +24,11 @@
                         "tsConfig": "tsconfig.app.json",
                         "inlineStyleLanguage": "sass",
                         "assets": ["src/favicon.ico", "src/assets"],
-                        "styles": ["src/styles.sass", "node_modules/bootstrap/scss/bootstrap.scss"],
+                        "styles": [
+                            "src/styles.sass",
+                            "node_modules/bootstrap/scss/bootstrap.scss",
+                            "node_modules/bootstrap-icons/font/bootstrap-icons.css"
+                        ],
                         "scripts": []
                     },
                     "configurations": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "@popperjs/core": "^2.11.6",
                 "axios": "^1.3.5",
                 "bootstrap": "^5.2.3",
+                "bootstrap-icons": "^1.10.5",
                 "date-fns": "^2.30.0",
                 "rxjs": "~7.8.0",
                 "tslib": "^2.3.0",
@@ -4565,6 +4566,21 @@
             "peerDependencies": {
                 "@popperjs/core": "^2.11.6"
             }
+        },
+        "node_modules/bootstrap-icons": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.5.tgz",
+            "integrity": "sha512-oSX26F37V7QV7NCE53PPEL45d7EGXmBgHG3pDpZvcRaKVzWMqIRL9wcqJUyEha1esFtM3NJzvmxFXDxjJYD0jQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/twbs"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/bootstrap"
+                }
+            ]
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@popperjs/core": "^2.11.6",
         "axios": "^1.3.5",
         "bootstrap": "^5.2.3",
+        "bootstrap-icons": "^1.10.5",
         "date-fns": "^2.30.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",

--- a/src/app/components/form-item/form-item.component.html
+++ b/src/app/components/form-item/form-item.component.html
@@ -1,6 +1,10 @@
 <div class="form-item">
     <div class="col-auto col-sm-3 text-center text-sm-end">
         <label [for]="info.propertyID + uuid">{{ info.propertyName }}</label>
+        &nbsp;
+        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{ info.tooltip }}">
+            <i class="bi bi-question-circle"></i>
+        </span>
     </div>
     <div class="col-12 col-sm-6 col-lg-4">
         <input

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -10,6 +10,11 @@
                 ></app-form-item>
             </ng-container>
             <button type="button" class="btn btn-primary" (click)="onSubmitCredential()">Login</button>
+            <p></p>
+            <p></p>
+            <button type="button" target="_blank" class="btn btn-secondary" (click)="openLink()">
+                Having trouble to find credential?
+            </button>
         </form>
     </div>
 </div>

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -15,6 +15,12 @@ type CredentialsFormItemInfoMap = {
     styleUrls: ['./login.component.sass']
 })
 export class LoginComponent {
+    openLink() {
+        window.open(
+            'https://docs.google.com/document/d/1KzO0Aic923z5rmvbmKJJ43suaz4IwG4RhmAtLUyVfeY/edit?usp=sharing',
+            '_blank'
+        );
+    }
     credentials = new TokenATMCredentials();
 
     constructor(
@@ -24,11 +30,41 @@ export class LoginComponent {
     ) {}
 
     static CREDENTIALS_FORM_ITEM_INFO_MAP: CredentialsFormItemInfoMap = {
-        canvasURL: new FormItemInfo('canvasURL', 'Canvas URL', 'url', 'https://canvas.instructure.com'),
-        canvasAccessToken: new FormItemInfo('canvasAccessToken', 'Canvas Access Token', 'password'),
-        qualtricsDataCenter: new FormItemInfo('qualtricsDataCenter', 'Qualtrics Data Center', 'text', ''),
-        qualtricsClientID: new FormItemInfo('qualtricsClientID', 'Qualtrics Client ID', 'text', ''),
-        qualtricsClientSecret: new FormItemInfo('qualtricsClientSecret', 'Qualtrics Client Secret', 'password', '')
+        canvasURL: new FormItemInfo(
+            'canvasURL',
+            'Canvas URL',
+            'url',
+            'https://canvas.instructure.com',
+            'Example: https://canvas.eee.uci.edu/'
+        ),
+        canvasAccessToken: new FormItemInfo(
+            'canvasAccessToken',
+            'Canvas Access Token',
+            'password',
+            '',
+            'Example: 1081~prKixoT8pyE04DPBIgmTod2IhyVTNUj7aVhazDI3UKbwt314ha31c6YXgxCpnOxH'
+        ),
+        qualtricsDataCenter: new FormItemInfo(
+            'qualtricsDataCenter',
+            'Qualtrics Data Center',
+            'text',
+            '',
+            'Example: sjc2'
+        ),
+        qualtricsClientID: new FormItemInfo(
+            'qualtricsClientID',
+            'Qualtrics Client ID',
+            'text',
+            '',
+            'Example: m2fdch523fe62h7ds896b06587fhn650'
+        ),
+        qualtricsClientSecret: new FormItemInfo(
+            'qualtricsClientSecret',
+            'Qualtrics Client Secret',
+            'password',
+            '',
+            'Example: ye8gf6hGdscTFPn3zVs4Z3YI0amMk2zbccx2KJbhKv0JFrbsKFiOKPvctMYP6UjT'
+        )
     };
 
     static CREDENTIALS_ID_LIST: (keyof TokenATMCredentials)[] = [

--- a/src/app/data/form-item-info.ts
+++ b/src/app/data/form-item-info.ts
@@ -3,11 +3,13 @@ export class FormItemInfo {
     propertyName = '';
     propertyType = 'text';
     inputPlaceholder = '';
+    tooltip = '';
 
-    constructor(propertyID = '', propertyName = '', propertyType = 'text', inputPlaceholder = '') {
+    constructor(propertyID = '', propertyName = '', propertyType = 'text', inputPlaceholder = '', tooltip = '') {
         this.propertyID = propertyID;
         this.propertyName = propertyName;
         this.propertyType = propertyType;
         this.inputPlaceholder = inputPlaceholder;
+        this.tooltip = tooltip;
     }
 }


### PR DESCRIPTION
### Story
As a teacher,
I want to have a tooltip for each credential I need to provide as a guideline for finding that credential,
so that I can provide my credentials to Token ATM more easily.

### Acceptance Criteria

Given that Token ATM basic login page,
when users have trouble finding input credentials, they put the mouse on the question mark,
then an example of each credential will pop up.

Given that Token ATM basic login page,
when users have trouble finding input credentials, they could click the tooltip button at the bottom,
then the button will link to a helper document.

Contributor(s):
Katie - TBD
Ray - TBD