### PR TITLE
US: encrypt student record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "axios": "^1.3.5",
                 "bootstrap": "^5.2.3",
                 "bootstrap-icons": "^1.10.5",
+                "compress-json": "^2.1.2",
                 "date-fns": "^2.30.0",
                 "js-base64": "^3.7.5",
                 "rxjs": "~7.8.0",
@@ -4992,6 +4993,11 @@
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
             "dev": true
+        },
+        "node_modules/compress-json": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/compress-json/-/compress-json-2.1.2.tgz",
+            "integrity": "sha512-91247RD8bKQXzRmXUS4zGT250mhw86+J9X8w2L2SGtRE7g0CvzjOETFaFmsDdaXPWv8T7L9iiM7kdcnnH3BH7w=="
         },
         "node_modules/compressible": {
             "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "axios": "^1.3.5",
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.5",
+        "compress-json": "^2.1.2",
         "date-fns": "^2.30.0",
         "js-base64": "^3.7.5",
         "rxjs": "~7.8.0",

--- a/src/app/data/student-record.ts
+++ b/src/app/data/student-record.ts
@@ -1,3 +1,4 @@
+import { fromUnixTime, getUnixTime } from 'date-fns';
 import { ProcessedRequest } from './processed-request';
 import type { Student } from './student';
 import type { TokenATMConfiguration } from './token-atm-configuration';
@@ -6,6 +7,7 @@ export class StudentRecord {
     private _configuration: TokenATMConfiguration;
     private _student: Student;
     private _commentId: string;
+    private _commentDate: Date;
     private _tokenBalance: number;
     private _processedAttemptsMap: Map<number, number>;
     private _processedRequests: ProcessedRequest[];
@@ -19,6 +21,7 @@ export class StudentRecord {
         data: any
     ) {
         if (
+            typeof data['comment_date'] != 'number' ||
             typeof data['processed_attempt_map'] != 'object' ||
             !Array.isArray(data['processed_attempt_map']) ||
             typeof data['processed_requests'] != 'object' ||
@@ -28,6 +31,7 @@ export class StudentRecord {
         this._configuration = configuration;
         this._student = student;
         this._commentId = commentId;
+        this._commentDate = fromUnixTime(data['comment_date']);
         this._tokenBalance = tokenBalance;
         this._processedAttemptsMap = new Map<number, number>();
         for (const entry of data['processed_attempt_map']) {
@@ -56,6 +60,14 @@ export class StudentRecord {
         this._commentId = commentId;
     }
 
+    public get commentDate(): Date {
+        return this._commentDate;
+    }
+
+    public set commentDate(commentDate: Date) {
+        this._commentDate = commentDate;
+    }
+
     public get tokenBalance(): number {
         return this._tokenBalance;
     }
@@ -80,6 +92,7 @@ export class StudentRecord {
 
     public toJSON(): unknown {
         return {
+            comment_date: getUnixTime(this.commentDate),
             processed_attempt_map: [...this._processedAttemptsMap.entries()].map((entry) => {
                 return {
                     token_option_group_id: entry[0],

--- a/src/app/data/submission-comment.ts
+++ b/src/app/data/submission-comment.ts
@@ -1,12 +1,19 @@
 export class SubmissionComment {
     private _id: string;
     private _content: string;
+    private _created_at: Date;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructor(data: any) {
-        if (typeof data['id'] != 'string' || typeof data['comment'] != 'string') throw new Error('Invalid data');
+        if (
+            typeof data['id'] != 'string' ||
+            typeof data['comment'] != 'string' ||
+            typeof data['created_at'] != 'string'
+        )
+            throw new Error('Invalid data');
         this._id = data['id'];
         this._content = data['comment'];
+        this._created_at = new Date(data['created_at']);
     }
 
     public get id(): string {
@@ -15,5 +22,9 @@ export class SubmissionComment {
 
     public get content(): string {
         return this._content;
+    }
+
+    public get created_at(): Date {
+        return this._created_at;
     }
 }

--- a/src/app/data/token-atm-configuration.ts
+++ b/src/app/data/token-atm-configuration.ts
@@ -1,22 +1,41 @@
 import type { Course } from './course';
 import type { TokenOption } from '../token-options/token-option';
 import { TokenOptionGroup } from './token-option-group';
+import type { StudentRecord } from './student-record';
+import { CryptoHelper } from 'app/utils/crypto-helper';
+import { Base64 } from 'js-base64';
+import { TypedArrayHelper } from 'app/utils/typed-array-helper';
+import { compress, decompress } from 'compress-json';
 
 export class TokenATMConfiguration {
     private _course: Course;
     private _logAssignmentId: string;
     private _tokenOptionGroups: TokenOptionGroup[];
+    #encryptionPassword: string;
+    #encryptionSalt: Uint8Array;
+    #encryptionKey?: CryptoKey;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(course: Course, data: any, tokenOptionResolver: (group: TokenOptionGroup, data: any) => TokenOption) {
+    constructor(
+        course: Course,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        data: any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        secureConfig: any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tokenOptionResolver: (group: TokenOptionGroup, data: any) => TokenOption
+    ) {
         this._course = course;
         if (
             typeof data['log_assignment_id'] != 'string' ||
             typeof data['token_option_groups'] != 'object' ||
-            !Array.isArray(data['token_option_groups'])
+            !Array.isArray(data['token_option_groups']) ||
+            typeof secureConfig['password'] != 'string' ||
+            typeof secureConfig['salt'] != 'string'
         )
             throw new Error('Invalid data');
         this._logAssignmentId = data['log_assignment_id'];
+        this.#encryptionPassword = secureConfig['password'];
+        this.#encryptionSalt = Base64.toUint8Array(secureConfig['salt']);
         this._tokenOptionGroups = data['token_option_groups'].map(
             (entry) => new TokenOptionGroup(this, entry, tokenOptionResolver)
         );
@@ -44,5 +63,33 @@ export class TokenATMConfiguration {
         for (const group of this.tokenOptionGroups)
             for (const option of group.tokenOptions) if (option.id == id) return option;
         return undefined;
+    }
+
+    async #generateKey(): Promise<void> {
+        this.#encryptionKey = await CryptoHelper.deriveAESKey(this.#encryptionPassword, this.#encryptionSalt);
+    }
+
+    public async encryptStudentRecord(studentRecord: StudentRecord): Promise<string> {
+        if (this.#encryptionKey == undefined) await this.#generateKey();
+        if (this.#encryptionKey == undefined) throw new Error('AES encryption key generation failed');
+        const transformedStudentRecord = JSON.parse(JSON.stringify(studentRecord));
+        return Base64.fromUint8Array(
+            TypedArrayHelper.contactUint8Array(
+                ...(await CryptoHelper.encryptAES(
+                    this.#encryptionKey,
+                    JSON.stringify(compress(transformedStudentRecord))
+                ))
+            )
+        );
+    }
+
+    public async decryptStudentRecord(encrpytedData: string): Promise<unknown> {
+        if (this.#encryptionKey == undefined) await this.#generateKey();
+        if (this.#encryptionKey == undefined) throw new Error('AES encryption key generation failed');
+        const [iv, data] = TypedArrayHelper.splitUint8Array(
+            Base64.toUint8Array(encrpytedData),
+            CryptoHelper.AES_IV_LENGTH
+        );
+        return decompress(JSON.parse(await CryptoHelper.decryptAES(this.#encryptionKey, data, iv)));
     }
 }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -186,13 +186,79 @@ export class CanvasService {
         );
     }
 
+    public async postComment(
+        courseId: string,
+        studentId: string,
+        assignmentId: string,
+        comment: string
+    ): Promise<SubmissionComment> {
+        const data = await this.apiRequest(
+            `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`,
+            {
+                method: 'put',
+                data: {
+                    comment: {
+                        text_comment: comment
+                    }
+                }
+            }
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const submissionComments = data.submission_comments as any[];
+        for (let i = submissionComments.length - 1; i >= 0; i--) {
+            let result;
+            try {
+                result = new SubmissionComment(submissionComments[i]);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (err: any) {
+                continue;
+            }
+            if (result.content != comment) continue;
+            return result;
+        }
+        throw new Error('Comment creation failed');
+    }
+
+    public async deleteComment(
+        courseId: string,
+        studentId: string,
+        assignmentId: string,
+        commentId: string
+    ): Promise<void> {
+        await this.apiRequest(
+            `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}/comments/${commentId}`,
+            {
+                method: 'delete'
+            }
+        );
+    }
+
+    public async modifyComment(
+        courseId: string,
+        studentId: string,
+        assignmentId: string,
+        commentId: string,
+        comment: string
+    ): Promise<SubmissionComment> {
+        const data = await this.apiRequest(
+            `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}/comments/${commentId}`,
+            {
+                method: 'put',
+                data: {
+                    comment: comment
+                }
+            }
+        );
+        return new SubmissionComment(data);
+    }
+
     public async gradeSubmissionWithPostingComment(
         courseId: string,
         studentId: string,
         assignmentId: string,
         score: number,
         newComment: string
-    ): Promise<string> {
+    ): Promise<SubmissionComment> {
         const data = await this.apiRequest(
             `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`,
             {
@@ -209,7 +275,18 @@ export class CanvasService {
         );
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const submissionComments = data.submission_comments as any[];
-        return submissionComments[submissionComments.length - 1].id ?? '';
+        for (let i = submissionComments.length - 1; i >= 0; i--) {
+            let result;
+            try {
+                result = new SubmissionComment(submissionComments[i]);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (err: any) {
+                continue;
+            }
+            if (result.content != newComment) continue;
+            return result;
+        }
+        throw new Error('Comment creation failed');
     }
 
     public async getAssignmentIdByQuizId(courseId: string, quizId: string): Promise<string> {

--- a/src/app/services/credential-manager.service.ts
+++ b/src/app/services/credential-manager.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import type { TokenATMCredentials } from 'app/data/token-atm-credentials';
+import { CryptoHelper } from 'app/utils/crypto-helper';
 import { Base64 } from 'js-base64';
 
 @Injectable({
@@ -13,61 +14,10 @@ export class CredentialManagerService {
         return result;
     }
 
-    private async deriveAESKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
-        const PBKDF2Key = await window.crypto.subtle.importKey(
-            'raw',
-            new TextEncoder().encode(password),
-            'PBKDF2',
-            false,
-            ['deriveBits', 'deriveKey']
-        );
-        return await window.crypto.subtle.deriveKey(
-            {
-                name: 'PBKDF2',
-                hash: 'SHA-512',
-                salt: salt,
-                iterations: 100000
-            },
-            PBKDF2Key,
-            {
-                name: 'AES-GCM',
-                length: 256
-            },
-            false,
-            ['encrypt', 'decrypt']
-        );
-    }
-
-    private async encrypt(key: CryptoKey, content: string, iv?: Uint8Array): Promise<[Uint8Array, Uint8Array]> {
-        if (iv == undefined) iv = window.crypto.getRandomValues(new Uint8Array(12));
-        const encryptedData = await window.crypto.subtle.encrypt(
-            {
-                name: 'AES-GCM',
-                iv: iv
-            },
-            key,
-            new TextEncoder().encode(content)
-        );
-        return [iv, new Uint8Array(encryptedData)];
-    }
-
-    private async decrypt(key: CryptoKey, encryptedData: Uint8Array, iv: Uint8Array): Promise<string> {
-        return new TextDecoder().decode(
-            await window.crypto.subtle.decrypt(
-                {
-                    name: 'AES-GCM',
-                    iv: iv
-                },
-                key,
-                encryptedData
-            )
-        );
-    }
-
     public async storeCredentials(credentials: TokenATMCredentials, password: string): Promise<void> {
         const salt = window.crypto.getRandomValues(new Uint8Array(32));
-        const key = await this.deriveAESKey(password, salt);
-        const [iv, data] = await this.encrypt(key, JSON.stringify(credentials));
+        const key = await CryptoHelper.deriveAESKey(password, salt);
+        const [iv, data] = await CryptoHelper.encryptAES(key, JSON.stringify(credentials));
         localStorage.setItem('salt', Base64.fromUint8Array(salt));
         localStorage.setItem('iv', Base64.fromUint8Array(iv));
         localStorage.setItem('data', Base64.fromUint8Array(data));
@@ -75,10 +25,10 @@ export class CredentialManagerService {
 
     public async retrieveCredentials(password: string): Promise<TokenATMCredentials> {
         const salt = new Uint8Array(Base64.toUint8Array(this.getStoredItem('salt')));
-        const key = await this.deriveAESKey(password, salt);
+        const key = await CryptoHelper.deriveAESKey(password, salt);
         const iv = new Uint8Array(Base64.toUint8Array(this.getStoredItem('iv')));
         const encryptedData = new Uint8Array(Base64.toUint8Array(this.getStoredItem('data')));
-        const data = await this.decrypt(key, encryptedData, iv);
+        const data = await CryptoHelper.decryptAES(key, encryptedData, iv);
         return JSON.parse(data);
     }
 

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -14,9 +14,16 @@ export class TokenATMConfigurationManagerService {
     ) {}
 
     public async getTokenATMConfiguration(course: Course): Promise<TokenATMConfiguration> {
-        const pageContent = await this.canvasService.getPageContentByName(course.id, 'Token ATM Configuration');
-        const config = JSON.parse(pageContent.substring(3, pageContent.length - 4));
-        return new TokenATMConfiguration(course, config, (group, data) => {
+        let pageContent = await this.canvasService.getPageContentByName(course.id, 'Token ATM Configuration');
+        pageContent = pageContent.substring(3, pageContent.length - 4);
+        let secureContent = await this.canvasService.getPageContentByName(
+            course.id,
+            'Token ATM Encryption Key (PLEASE DO NOT PUBLISH IT)'
+        );
+        secureContent = secureContent.substring(3, secureContent.length - 4);
+        const config = JSON.parse(pageContent),
+            secureConfig = JSON.parse(secureContent);
+        return new TokenATMConfiguration(course, config, secureConfig, (group, data) => {
             return this.tokenOptionResolverRegistry.resolveTokenOption(group, data);
         });
     }

--- a/src/app/utils/crypto-helper.ts
+++ b/src/app/utils/crypto-helper.ts
@@ -1,0 +1,58 @@
+export class CryptoHelper {
+    public static AES_IV_LENGTH = 12;
+
+    public static async deriveAESKey(password: string, salt: Uint8Array): Promise<CryptoKey> {
+        const PBKDF2Key = await window.crypto.subtle.importKey(
+            'raw',
+            new TextEncoder().encode(password),
+            'PBKDF2',
+            false,
+            ['deriveBits', 'deriveKey']
+        );
+        return await window.crypto.subtle.deriveKey(
+            {
+                name: 'PBKDF2',
+                hash: 'SHA-512',
+                salt: salt,
+                iterations: 100000
+            },
+            PBKDF2Key,
+            {
+                name: 'AES-GCM',
+                length: 256
+            },
+            false,
+            ['encrypt', 'decrypt']
+        );
+    }
+
+    public static async encryptAES(
+        key: CryptoKey,
+        content: string,
+        iv?: Uint8Array
+    ): Promise<[Uint8Array, Uint8Array]> {
+        if (iv == undefined) iv = window.crypto.getRandomValues(new Uint8Array(CryptoHelper.AES_IV_LENGTH));
+        const encryptedData = await window.crypto.subtle.encrypt(
+            {
+                name: 'AES-GCM',
+                iv: iv
+            },
+            key,
+            new TextEncoder().encode(content)
+        );
+        return [iv, new Uint8Array(encryptedData)];
+    }
+
+    public static async decryptAES(key: CryptoKey, encryptedData: Uint8Array, iv: Uint8Array): Promise<string> {
+        return new TextDecoder().decode(
+            await window.crypto.subtle.decrypt(
+                {
+                    name: 'AES-GCM',
+                    iv: iv
+                },
+                key,
+                encryptedData
+            )
+        );
+    }
+}

--- a/src/app/utils/typed-array-helper.ts
+++ b/src/app/utils/typed-array-helper.ts
@@ -1,0 +1,12 @@
+export class TypedArrayHelper {
+    public static contactUint8Array(a: Uint8Array, b: Uint8Array): Uint8Array {
+        const result = new Uint8Array(a.length + b.length);
+        result.set(a);
+        result.set(b, a.length);
+        return result;
+    }
+
+    public static splitUint8Array(src: Uint8Array, ind: number): [Uint8Array, Uint8Array] {
+        return [src.subarray(0, ind), src.subarray(ind)];
+    }
+}


### PR DESCRIPTION
### User Story

As a teacher,
I want Token ATM to encrypt data stored in students’ submission comments
so that I can prevent students from modifying their request history.

### Acceptance Criteria

1. Given that a student has some processed requests,when the student look at their Token ATM Log assignment,then they should not be able to extract their request history from the encrypted data without the password & salt used for encryption.
2. Given that a student posts their past encrypted request history as comments on Token ATM Log assignment,when Token ATM process requests for this student,then the comments posted by the student should not be considered as the correct request history and should be removed from the submission comments.

### Testing Note

Since the student record is now encrypted, the reviewer might need to properly design the configuration used for testing in order to check whether students' requests has been approved or not.