### PR TITLE
Implement Token ATM Configuration Architecture

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,6 +27,7 @@ import {
     REQUEST_RESOLVER_INJECT_TOKEN
 } from './request-resolvers/request-resolver-registry';
 import { REGISTERED_REQUEST_HANDLERS, REQUEST_HANDLER_INJECT_TOKEN } from './request-handlers/request-handler-registry';
+import { DevTestComponent } from './components/dev-test/dev-test.component';
 
 @NgModule({
     declarations: [
@@ -39,7 +40,8 @@ import { REGISTERED_REQUEST_HANDLERS, REQUEST_HANDLER_INJECT_TOKEN } from './req
         CourseInfoItemComponent,
         RequestProcessComponent,
         TokenOptionConfigurationComponent,
-        StudentListComponent
+        StudentListComponent,
+        DevTestComponent
     ],
     imports: [BrowserModule, AppRoutingModule, FormsModule, NgbModule],
     providers: [

--- a/src/app/components/dashboard/dashboard-routing.ts
+++ b/src/app/components/dashboard/dashboard-routing.ts
@@ -1,9 +1,11 @@
 import type { Component, Type } from '@angular/core';
 import type { Course } from 'app/data/course';
-import type { Routes } from '@angular/router';
+import type { Route, Routes } from '@angular/router';
 import { RequestProcessComponent } from '../request-process/request-process.component';
 import { TokenOptionConfigurationComponent } from '../token-option-configuration/token-option-configuration.component';
 import { StudentListComponent } from '../student-list/student-list.component';
+import { DEV_GUARD } from 'app/utils/dev-guard';
+import { DevTestComponent } from '../dev-test/dev-test.component';
 
 export interface CourseConfigurable {
     configureCourse(course: Course): Promise<void>;
@@ -11,11 +13,14 @@ export interface CourseConfigurable {
 
 type CourseConfigurableComponent = CourseConfigurable & Component;
 
-export type TokenATMDashboardRoute = {
+export type TokenATMDashboardRouteSpecific = {
     name: string;
     path: string;
     component: Type<CourseConfigurableComponent>;
+    isDev?: boolean;
 };
+
+export type TokenATMDashboardRoute = TokenATMDashboardRouteSpecific & Route;
 
 export const TOKEN_ATM_DASHBOARD_ROUTES: TokenATMDashboardRoute[] = [
     {
@@ -32,6 +37,13 @@ export const TOKEN_ATM_DASHBOARD_ROUTES: TokenATMDashboardRoute[] = [
         name: 'Students',
         path: 'students',
         component: StudentListComponent
+    },
+    {
+        name: 'Dev-Test',
+        path: 'dev-test',
+        component: DevTestComponent,
+        canActivate: [DEV_GUARD],
+        isDev: true
     }
 ];
 
@@ -40,7 +52,10 @@ const DEFAULT_ROUTING = 'process-request';
 export function getDashboardRoutes(): Routes {
     return [
         ...TOKEN_ATM_DASHBOARD_ROUTES.map((route: TokenATMDashboardRoute) => {
-            return { path: route.path, component: route.component };
+            return {
+                ...route,
+                name: undefined
+            };
         }),
         {
             path: '',

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnDestroy } from '@angular/core';
+import { Component, Inject, isDevMode, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import type { Course } from 'app/data/course';
 import type { Subscription } from 'rxjs';
@@ -51,7 +51,7 @@ export class DashboardComponent implements OnDestroy {
     }
 
     get routes(): TokenATMDashboardRoute[] {
-        return TOKEN_ATM_DASHBOARD_ROUTES;
+        return TOKEN_ATM_DASHBOARD_ROUTES.filter((route) => isDevMode() || !route.isDev);
     }
 
     async onComponentActivate(component: CourseConfigurable) {

--- a/src/app/components/dev-test/dev-test.component.html
+++ b/src/app/components/dev-test/dev-test.component.html
@@ -1,0 +1,15 @@
+<div appCenter class="flex-column">
+    <button class="btn btn-danger my-3" (click)="onRegenerateContent()">Regenerate Content</button>
+    <button class="btn btn-danger my-3" (click)="onDeleteAll()">Delete All</button>
+    <button class="btn btn-primary my-3" (click)="onCreateConfiguration()">Create Configuration</button>
+    <button class="btn btn-primary my-3" (click)="onAddTokenOptionGroup()">Add Token Option Group</button>
+    <button class="btn btn-primary my-3" (click)="onAddTokenOption()">
+        Add Token Option to the Last Token Option Group
+    </button>
+    <button class="btn btn-danger my-3" (click)="onDeleteFirstTokenOptionGroup()">
+        Delete First Token Option Group
+    </button>
+    <button class="btn btn-danger my-3" (click)="onDeleteFirstTokenOption()">
+        Delete First Token Option in the First Token Option Gorup
+    </button>
+</div>

--- a/src/app/components/dev-test/dev-test.component.html
+++ b/src/app/components/dev-test/dev-test.component.html
@@ -12,4 +12,7 @@
     <button class="btn btn-danger my-3" (click)="onDeleteFirstTokenOption()">
         Delete First Token Option in the First Token Option Gorup
     </button>
+    <button class="btn btn-primary my-3" (click)="onChangeLastTokenOptionGroupPublishState()">
+        Publish/Unpublish Last Token Option Group
+    </button>
 </div>

--- a/src/app/components/dev-test/dev-test.component.html
+++ b/src/app/components/dev-test/dev-test.component.html
@@ -15,4 +15,5 @@
     <button class="btn btn-primary my-3" (click)="onChangeLastTokenOptionGroupPublishState()">
         Publish/Unpublish Last Token Option Group
     </button>
+    <button class="btn btn-danger my-3" (click)="onResetStudentRecord()">Reset all student records</button>
 </div>

--- a/src/app/components/dev-test/dev-test.component.spec.ts
+++ b/src/app/components/dev-test/dev-test.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AxiosService, AxiosServiceFactory } from 'app/services/axios.service';
+
+import { DevTestComponent } from './dev-test.component';
+
+describe('DevTestComponent', () => {
+    let component: DevTestComponent;
+    let fixture: ComponentFixture<DevTestComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [DevTestComponent],
+            providers: [{ provide: AxiosService, useFactory: AxiosServiceFactory.getAxiosService }]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(DevTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -51,6 +51,7 @@ export class DevTestComponent {
                     id: configuration.getFreeTokenOptionGroupId(),
                     quiz_id: '',
                     description: `Just a test <b>token option group</b> ${configuration.tokenOptionGroups.length}`,
+                    is_published: false,
                     token_options: []
                 },
                 configuration.tokenOptionResolver
@@ -75,7 +76,7 @@ export class DevTestComponent {
         );
         const result = await this.manager.updateTokenOptionGroup(group);
         console.log('Add token option finished!');
-        if (!result) console.log('unpublish failed. Need manual update');
+        if (!result) console.log('auto update failed. Need manual update');
     }
 
     async onDeleteFirstTokenOptionGroup(): Promise<void> {
@@ -95,6 +96,20 @@ export class DevTestComponent {
         group.deleteTokenOption(group.tokenOptions[0]);
         const result = await this.manager.updateTokenOptionGroup(group);
         console.log('Delete first token option finished!');
-        if (!result) console.log('unpublish failed. Need manual update');
+        if (!result) console.log('auto update failed. Need manual update');
+    }
+
+    async onChangeLastTokenOptionGroupPublishState(): Promise<void> {
+        if (!this.course) return;
+        const configuration = await this.manager.getTokenATMConfiguration(this.course);
+        const group = configuration.tokenOptionGroups[configuration.tokenOptionGroups.length - 1];
+        if (!group) throw new Error('No token option group in the configuration!');
+        if (group.isPublished) {
+            const result = await this.manager.unpublishTokenOptionGroup(group);
+            console.log('Unpublish operation attempted. Result: ', result);
+        } else {
+            await this.manager.publishTokenOptionGroup(group);
+            console.log('Token option group published!');
+        }
     }
 }

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -1,0 +1,100 @@
+import { Component, Inject } from '@angular/core';
+import type { Course } from 'app/data/course';
+import { TokenOptionGroup } from 'app/data/token-option-group';
+import { TokenATMConfigurationManagerService } from 'app/services/token-atm-configuration-manager.service';
+import { BasicTokenOption } from 'app/token-options/basic-token-option';
+
+@Component({
+    selector: 'app-dev-test',
+    templateUrl: './dev-test.component.html',
+    styleUrls: ['./dev-test.component.sass']
+})
+export class DevTestComponent {
+    course?: Course;
+
+    constructor(@Inject(TokenATMConfigurationManagerService) private manager: TokenATMConfigurationManagerService) {}
+
+    async configureCourse(course: Course): Promise<void> {
+        this.course = course;
+    }
+
+    async onRegenerateContent(): Promise<void> {
+        if (!this.course) return;
+        await this.manager.regenrateContent(await this.manager.getTokenATMConfiguration(this.course));
+        console.log('Regeneration finished!');
+    }
+
+    async onDeleteAll(): Promise<void> {
+        if (!this.course) return;
+        await this.manager.deleteAll(await this.manager.getTokenATMConfiguration(this.course));
+        console.log('Delete all finished!');
+    }
+
+    async onCreateConfiguration(): Promise<void> {
+        if (!this.course) return;
+        const configuration = await this.manager.createTokenATMConfiguration(
+            this.course,
+            'Just Testing',
+            'This is just a test generation of the content'
+        );
+        console.log('Configuration created', configuration);
+    }
+
+    async onAddTokenOptionGroup(): Promise<void> {
+        if (!this.course) return;
+        const configuration = await this.manager.getTokenATMConfiguration(this.course);
+        await this.manager.addNewTokenOptionGroup(
+            new TokenOptionGroup(
+                configuration,
+                {
+                    name: 'Test Token Option Group ' + configuration.tokenOptionGroups.length.toString(),
+                    id: configuration.getFreeTokenOptionGroupId(),
+                    quiz_id: '',
+                    description: `Just a test <b>token option group</b> ${configuration.tokenOptionGroups.length}`,
+                    token_options: []
+                },
+                configuration.tokenOptionResolver
+            )
+        );
+        console.log('Add token option group finished');
+    }
+
+    async onAddTokenOption(): Promise<void> {
+        if (!this.course) return;
+        const configuration = await this.manager.getTokenATMConfiguration(this.course);
+        const group = configuration.tokenOptionGroups[configuration.tokenOptionGroups.length - 1];
+        if (!group) throw new Error('No token option group in the configuration!');
+        group.addTokenOption(
+            new BasicTokenOption(group, {
+                type: 'basic',
+                id: configuration.getFreeTokenOptionId(),
+                name: `Test Token Option ${group.tokenOptions.length}`,
+                description: `Just a test <b>token option</b> ${group.tokenOptions.length}`,
+                token_balance_change: group.tokenOptions.length
+            })
+        );
+        const result = await this.manager.updateTokenOptionGroup(group);
+        console.log('Add token option finished!');
+        if (!result) console.log('unpublish failed. Need manual update');
+    }
+
+    async onDeleteFirstTokenOptionGroup(): Promise<void> {
+        if (!this.course) return;
+        const configuration = await this.manager.getTokenATMConfiguration(this.course);
+        if (!configuration.tokenOptionGroups[0]) throw new Error('No token option group in the configuration!');
+        await this.manager.deleteTokenOptionGroup(configuration.tokenOptionGroups[0]);
+        console.log('Delete first token option group finished!');
+    }
+
+    async onDeleteFirstTokenOption(): Promise<void> {
+        if (!this.course) return;
+        const configuration = await this.manager.getTokenATMConfiguration(this.course);
+        const group = configuration.tokenOptionGroups[0];
+        if (!group) throw new Error('No token option group in the configuration!');
+        if (!group.tokenOptions[0]) throw new Error('No token option in the first token option group!');
+        group.deleteTokenOption(group.tokenOptions[0]);
+        const result = await this.manager.updateTokenOptionGroup(group);
+        console.log('Delete first token option finished!');
+        if (!result) console.log('unpublish failed. Need manual update');
+    }
+}

--- a/src/app/data/token-atm-configuration.ts
+++ b/src/app/data/token-atm-configuration.ts
@@ -10,7 +10,12 @@ import { compress, decompress } from 'compress-json';
 export class TokenATMConfiguration {
     private _course: Course;
     private _logAssignmentId: string;
+    private _uid: string;
+    private _suffix: string;
+    private _description: string;
     private _tokenOptionGroups: TokenOptionGroup[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private _tokenOptionResolver: (group: TokenOptionGroup, data: any) => TokenOption;
     #encryptionPassword: string;
     #encryptionSalt: Uint8Array;
     #encryptionKey?: CryptoKey;
@@ -27,6 +32,9 @@ export class TokenATMConfiguration {
         this._course = course;
         if (
             typeof data['log_assignment_id'] != 'string' ||
+            typeof data['uid'] != 'string' ||
+            (typeof data['suffix'] != 'undefined' && typeof data['suffix'] != 'string') ||
+            (typeof data['description'] != 'undefined' && typeof data['description'] != 'string') ||
             typeof data['token_option_groups'] != 'object' ||
             !Array.isArray(data['token_option_groups']) ||
             typeof secureConfig['password'] != 'string' ||
@@ -34,8 +42,12 @@ export class TokenATMConfiguration {
         )
             throw new Error('Invalid data');
         this._logAssignmentId = data['log_assignment_id'];
+        this._uid = data['uid'];
+        this._suffix = data['suffix'] ?? '';
+        this._description = data['description'] ?? '';
         this.#encryptionPassword = secureConfig['password'];
         this.#encryptionSalt = Base64.toUint8Array(secureConfig['salt']);
+        this._tokenOptionResolver = tokenOptionResolver;
         this._tokenOptionGroups = data['token_option_groups'].map(
             (entry) => new TokenOptionGroup(this, entry, tokenOptionResolver)
         );
@@ -49,8 +61,29 @@ export class TokenATMConfiguration {
         return this._logAssignmentId;
     }
 
+    public set logAssignmentId(logAssignmentId: string) {
+        this._logAssignmentId = logAssignmentId;
+    }
+
+    public get uid(): string {
+        return this._uid;
+    }
+
+    public get suffix(): string {
+        return this._suffix;
+    }
+
+    public get description(): string {
+        return this._description;
+    }
+
     public get tokenOptionGroups(): TokenOptionGroup[] {
         return this._tokenOptionGroups;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public get tokenOptionResolver(): (group: TokenOptionGroup, data: any) => TokenOption {
+        return this._tokenOptionResolver;
     }
 
     public getTokenOptionGroupById(id: number): TokenOptionGroup | undefined {
@@ -63,6 +96,52 @@ export class TokenATMConfiguration {
         for (const group of this.tokenOptionGroups)
             for (const option of group.tokenOptions) if (option.id == id) return option;
         return undefined;
+    }
+
+    public addTokenOptionGroup(group: TokenOptionGroup) {
+        this._tokenOptionGroups.push(group);
+    }
+
+    public deleteTokenOptionGroup(group: TokenOptionGroup) {
+        const index = this._tokenOptionGroups.indexOf(group);
+        if (index == -1) throw new Error('Token option group does not exist');
+        this._tokenOptionGroups.splice(index, 1);
+    }
+
+    public getFreeTokenOptionGroupId(): number {
+        const usedIds = new Set(this.tokenOptionGroups.map((entry) => entry.id));
+        for (let id = 0; ; id++) {
+            if (!usedIds.has(id)) return id;
+        }
+    }
+
+    public getFreeTokenOptionId(): number {
+        const usedIds = new Set();
+        for (const group of this.tokenOptionGroups) {
+            for (const tokenOption of group.tokenOptions) {
+                usedIds.add(tokenOption.id);
+            }
+        }
+        for (let id = 0; ; id++) {
+            if (!usedIds.has(id)) return id;
+        }
+    }
+
+    public toJSON(): object {
+        return {
+            log_assignment_id: this.logAssignmentId,
+            uid: this.uid,
+            suffix: this.suffix,
+            description: this.description,
+            token_option_groups: this.tokenOptionGroups.map((entry) => entry.toJSON())
+        };
+    }
+
+    public getSecureConfig(): object {
+        return {
+            password: this.#encryptionPassword,
+            salt: Base64.fromUint8Array(this.#encryptionSalt)
+        };
     }
 
     async #generateKey(): Promise<void> {

--- a/src/app/data/token-option-group.ts
+++ b/src/app/data/token-option-group.ts
@@ -7,6 +7,7 @@ export class TokenOptionGroup {
     private _id: number;
     private _quizId: string;
     private _description: string;
+    private _isPublished: boolean;
     private _tokenOptions: TokenOption[];
 
     constructor(
@@ -22,6 +23,7 @@ export class TokenOptionGroup {
             typeof data['id'] != 'number' ||
             typeof data['quiz_id'] != 'string' ||
             (typeof data['description'] != 'undefined' && typeof data['description'] != 'string') ||
+            typeof data['is_published'] != 'boolean' ||
             typeof data['token_options'] != 'object' ||
             !Array.isArray(data['token_options'])
         )
@@ -30,6 +32,7 @@ export class TokenOptionGroup {
         this._id = data['id'];
         this._quizId = data['quiz_id'];
         this._description = data['description'] ?? '';
+        this._isPublished = data['is_published'];
         this._tokenOptions = data['token_options'].map((entry) => tokenOptionResolver(this, entry));
     }
 
@@ -57,6 +60,14 @@ export class TokenOptionGroup {
         return this._description;
     }
 
+    public get isPublished(): boolean {
+        return this._isPublished;
+    }
+
+    public set isPublished(isPublished: boolean) {
+        this._isPublished = isPublished;
+    }
+
     public get tokenOptions(): TokenOption[] {
         return this._tokenOptions;
     }
@@ -77,6 +88,7 @@ export class TokenOptionGroup {
             id: this.id,
             quiz_id: this.quizId,
             description: this.description,
+            is_published: this.isPublished,
             token_options: this.tokenOptions.map((entry) => entry.toJSON())
         };
     }

--- a/src/app/data/token-option-group.ts
+++ b/src/app/data/token-option-group.ts
@@ -6,6 +6,7 @@ export class TokenOptionGroup {
     private _name: string;
     private _id: number;
     private _quizId: string;
+    private _description: string;
     private _tokenOptions: TokenOption[];
 
     constructor(
@@ -20,6 +21,7 @@ export class TokenOptionGroup {
             typeof data['name'] != 'string' ||
             typeof data['id'] != 'number' ||
             typeof data['quiz_id'] != 'string' ||
+            (typeof data['description'] != 'undefined' && typeof data['description'] != 'string') ||
             typeof data['token_options'] != 'object' ||
             !Array.isArray(data['token_options'])
         )
@@ -27,6 +29,7 @@ export class TokenOptionGroup {
         this._name = data['name'];
         this._id = data['id'];
         this._quizId = data['quiz_id'];
+        this._description = data['description'] ?? '';
         this._tokenOptions = data['token_options'].map((entry) => tokenOptionResolver(this, entry));
     }
 
@@ -46,7 +49,35 @@ export class TokenOptionGroup {
         return this._quizId;
     }
 
+    public set quizId(quizId: string) {
+        this._quizId = quizId;
+    }
+
+    public get description(): string {
+        return this._description;
+    }
+
     public get tokenOptions(): TokenOption[] {
         return this._tokenOptions;
+    }
+
+    public addTokenOption(tokenOption: TokenOption): void {
+        this._tokenOptions.push(tokenOption);
+    }
+
+    public deleteTokenOption(tokenOption: TokenOption): void {
+        const index = this._tokenOptions.indexOf(tokenOption);
+        if (index == -1) throw new Error('Token option does not exist');
+        this._tokenOptions.splice(index, 1);
+    }
+
+    public toJSON(): object {
+        return {
+            name: this.name,
+            id: this.id,
+            quiz_id: this.quizId,
+            description: this.description,
+            token_options: this.tokenOptions.map((entry) => entry.toJSON())
+        };
     }
 }

--- a/src/app/instruction-generators/description-transformer.ts
+++ b/src/app/instruction-generators/description-transformer.ts
@@ -1,0 +1,21 @@
+import type { TokenOption } from 'app/token-options/token-option';
+import { TokenOptionInstructionTransformer } from './token-option-instruction-transformer';
+
+type Descriptable = {
+    description: string;
+};
+
+export class DescriptionTransformer extends TokenOptionInstructionTransformer<Descriptable> {
+    public get infoDescription(): string {
+        return 'Description';
+    }
+
+    public process(tokenOptions: TokenOption[]): string[] {
+        return tokenOptions.map((tokenOption) => this.validate(tokenOption)?.description ?? '');
+    }
+
+    public validate(tokenOption: TokenOption): Descriptable | undefined {
+        const value = (tokenOption as unknown as Descriptable).description;
+        return value == undefined ? undefined : (tokenOption as unknown as Descriptable);
+    }
+}

--- a/src/app/instruction-generators/due-time-transformer.ts
+++ b/src/app/instruction-generators/due-time-transformer.ts
@@ -1,0 +1,25 @@
+import type { TokenOption } from 'app/token-options/token-option';
+import { format } from 'date-fns';
+import { TokenOptionInstructionTransformer } from './token-option-instruction-transformer';
+
+type HasDueTime = {
+    dueTime: Date;
+};
+
+export class DueTimeTransformer extends TokenOptionInstructionTransformer<HasDueTime> {
+    public get infoDescription(): string {
+        return 'Due At';
+    }
+
+    public process(tokenOptions: TokenOption[]): string[] {
+        return tokenOptions.map((tokenOption) => {
+            const convertedObject = this.validate(tokenOption);
+            return convertedObject == undefined ? '' : format(convertedObject.dueTime, 'MMM dd, YYYY kk:mm:ss');
+        });
+    }
+
+    public validate(tokenOption: TokenOption): HasDueTime | undefined {
+        const value = (tokenOption as unknown as HasDueTime).dueTime;
+        return value == undefined ? undefined : (tokenOption as unknown as HasDueTime);
+    }
+}

--- a/src/app/instruction-generators/due-time-transformer.ts
+++ b/src/app/instruction-generators/due-time-transformer.ts
@@ -14,7 +14,7 @@ export class DueTimeTransformer extends TokenOptionInstructionTransformer<HasDue
     public process(tokenOptions: TokenOption[]): string[] {
         return tokenOptions.map((tokenOption) => {
             const convertedObject = this.validate(tokenOption);
-            return convertedObject == undefined ? '' : format(convertedObject.dueTime, 'MMM dd, YYYY kk:mm:ss');
+            return convertedObject == undefined ? '' : format(convertedObject.dueTime, 'MMM dd, yyyy kk:mm:ss');
         });
     }
 

--- a/src/app/instruction-generators/html-table-generator.ts
+++ b/src/app/instruction-generators/html-table-generator.ts
@@ -1,0 +1,41 @@
+import type { TokenOption } from 'app/token-options/token-option';
+import { TokenOptionInstructionGenerator } from './token-option-instruction-generator';
+import type { TokenOptionInstructionTransformer } from './token-option-instruction-transformer';
+
+export class HTMLTableGenerator extends TokenOptionInstructionGenerator {
+    constructor(private transformers: TokenOptionInstructionTransformer<object>[]) {
+        super();
+    }
+    public process(tokenOptions: TokenOption[]): string {
+        const values: [string, string[]][] = [];
+        for (const transformer of this.transformers) {
+            if (!transformer.hasValidTokenOption(tokenOptions)) continue;
+            values.push([transformer.infoDescription, transformer.process(tokenOptions)]);
+        }
+        if (values.length == 0) return '';
+        const rows: string[][] = [];
+        for (let i = 0; i < tokenOptions.length; i++) {
+            const row: string[] = [];
+            for (let j = 0; j < values.length; j++) {
+                const value = values[j]?.[1]?.[i];
+                if (value == undefined) continue;
+                row.push(value);
+            }
+            rows.push(row);
+        }
+        return [
+            '<table>',
+            '<thead>',
+            '<tr>',
+            ...values.map((entry) => `<th style="text-align: center;">${entry[0]}</th>`),
+            '</tr>',
+            '</thead>',
+            '<tbody>',
+            ...rows.map(
+                (row) => `<tr>${row.map((entry) => `<td style="text-align: center;">${entry}</td>`).join('')}</tr>`
+            ),
+            '</tbody>',
+            '</table>'
+        ].join('');
+    }
+}

--- a/src/app/instruction-generators/instruction-connector.ts
+++ b/src/app/instruction-generators/instruction-connector.ts
@@ -1,0 +1,12 @@
+import type { TokenOption } from 'app/token-options/token-option';
+import { TokenOptionInstructionGenerator } from './token-option-instruction-generator';
+
+export class InstructionConnector extends TokenOptionInstructionGenerator {
+    constructor(private generators: TokenOptionInstructionGenerator[], private separator = '') {
+        super();
+    }
+
+    public process(tokenOptions: TokenOption[]): string {
+        return this.generators.map((generator) => generator.process(tokenOptions)).join(this.separator);
+    }
+}

--- a/src/app/instruction-generators/name-transformer.ts
+++ b/src/app/instruction-generators/name-transformer.ts
@@ -1,0 +1,21 @@
+import type { TokenOption } from 'app/token-options/token-option';
+import { TokenOptionInstructionTransformer } from './token-option-instruction-transformer';
+
+type HasName = {
+    name: string;
+};
+
+export class NameTransformer extends TokenOptionInstructionTransformer<HasName> {
+    public get infoDescription(): string {
+        return 'Token Option';
+    }
+
+    public process(tokenOptions: TokenOption[]): string[] {
+        return tokenOptions.map((tokenOption) => this.validate(tokenOption)?.name ?? '');
+    }
+
+    public validate(tokenOption: TokenOption): HasName | undefined {
+        const value = (tokenOption as unknown as HasName).name;
+        return value == undefined ? undefined : (tokenOption as unknown as HasName);
+    }
+}

--- a/src/app/instruction-generators/start-time-transformer.ts
+++ b/src/app/instruction-generators/start-time-transformer.ts
@@ -1,0 +1,25 @@
+import type { TokenOption } from 'app/token-options/token-option';
+import { format } from 'date-fns';
+import { TokenOptionInstructionTransformer } from './token-option-instruction-transformer';
+
+type HasStartTime = {
+    startTime: Date;
+};
+
+export class StartTimeTransformer extends TokenOptionInstructionTransformer<HasStartTime> {
+    public get infoDescription(): string {
+        return 'Start At';
+    }
+
+    public process(tokenOptions: TokenOption[]): string[] {
+        return tokenOptions.map((tokenOption) => {
+            const convertedObject = this.validate(tokenOption);
+            return convertedObject == undefined ? '' : format(convertedObject.startTime, 'MMM dd, YYYY kk:mm:ss');
+        });
+    }
+
+    public validate(tokenOption: TokenOption): HasStartTime | undefined {
+        const value = (tokenOption as unknown as HasStartTime).startTime;
+        return value == undefined ? undefined : (tokenOption as unknown as HasStartTime);
+    }
+}

--- a/src/app/instruction-generators/start-time-transformer.ts
+++ b/src/app/instruction-generators/start-time-transformer.ts
@@ -14,7 +14,7 @@ export class StartTimeTransformer extends TokenOptionInstructionTransformer<HasS
     public process(tokenOptions: TokenOption[]): string[] {
         return tokenOptions.map((tokenOption) => {
             const convertedObject = this.validate(tokenOption);
-            return convertedObject == undefined ? '' : format(convertedObject.startTime, 'MMM dd, YYYY kk:mm:ss');
+            return convertedObject == undefined ? '' : format(convertedObject.startTime, 'MMM dd, yyyy kk:mm:ss');
         });
     }
 

--- a/src/app/instruction-generators/token-balance-change-transformer.ts
+++ b/src/app/instruction-generators/token-balance-change-transformer.ts
@@ -1,0 +1,21 @@
+import type { TokenOption } from 'app/token-options/token-option';
+import { TokenOptionInstructionTransformer } from './token-option-instruction-transformer';
+
+type HasTokenBalanceChange = {
+    tokenBalanceChange: number;
+};
+
+export class TokenBalanceChangeTransformer extends TokenOptionInstructionTransformer<HasTokenBalanceChange> {
+    public get infoDescription(): string {
+        return 'Token Balance Change';
+    }
+
+    public process(tokenOptions: TokenOption[]): string[] {
+        return tokenOptions.map((tokenOption) => this.validate(tokenOption)?.tokenBalanceChange?.toString() ?? '');
+    }
+
+    public validate(tokenOption: TokenOption): HasTokenBalanceChange | undefined {
+        const value = (tokenOption as unknown as HasTokenBalanceChange).tokenBalanceChange;
+        return value == undefined ? undefined : (tokenOption as unknown as HasTokenBalanceChange);
+    }
+}

--- a/src/app/instruction-generators/token-option-instruction-generator.ts
+++ b/src/app/instruction-generators/token-option-instruction-generator.ts
@@ -1,0 +1,5 @@
+import type { TokenOption } from 'app/token-options/token-option';
+
+export abstract class TokenOptionInstructionGenerator {
+    public abstract process(tokenOptions: TokenOption[]): string;
+}

--- a/src/app/instruction-generators/token-option-instruction-transformer.ts
+++ b/src/app/instruction-generators/token-option-instruction-transformer.ts
@@ -1,0 +1,17 @@
+import type { TokenOption } from 'app/token-options/token-option';
+
+export abstract class TokenOptionInstructionTransformer<S> {
+    public abstract process(tokenOptions: TokenOption[]): string[];
+
+    public abstract validate(tokenOption: TokenOption): S | undefined;
+
+    public abstract get infoDescription(): string;
+
+    public hasValidTokenOption(tokenOptions: TokenOption[]): boolean {
+        if (tokenOptions.length == 0) return false;
+        for (const tokenOption of tokenOptions) {
+            if (this.validate(tokenOption) == undefined) return false;
+        }
+        return true;
+    }
+}

--- a/src/app/quiz-questions/multiple-choice-question.ts
+++ b/src/app/quiz-questions/multiple-choice-question.ts
@@ -1,0 +1,34 @@
+import { QuizQuestion } from './quiz-question';
+
+export class MultipleChoiceQuestion extends QuizQuestion {
+    private _options: string[];
+
+    constructor(name = 'Question', text = '', pointsPossible = 0, options: string[] = []) {
+        super(name, text, pointsPossible);
+        this._options = options;
+    }
+
+    public get options(): string[] {
+        return this._options;
+    }
+
+    public get questionType(): string {
+        return 'multiple_choice_question';
+    }
+
+    public override toJSON(): object {
+        const answers = this.options.map((optionText) => {
+            return {
+                answer_text: optionText,
+                answer_weight: 0
+            };
+        });
+        if (answers[0]) {
+            answers[0].answer_weight = 100;
+        }
+        return {
+            ...super.toJSON(),
+            answers: answers
+        };
+    }
+}

--- a/src/app/quiz-questions/quiz-question.ts
+++ b/src/app/quiz-questions/quiz-question.ts
@@ -1,0 +1,34 @@
+export abstract class QuizQuestion {
+    private _name: string;
+    private _text: string;
+    private _pointsPossible: number;
+
+    constructor(name = 'Question', text = '', pointsPossible = 0) {
+        this._name = name;
+        this._text = text;
+        this._pointsPossible = pointsPossible;
+    }
+
+    public get name(): string {
+        return this._name;
+    }
+
+    public get text(): string {
+        return this._text;
+    }
+
+    public get pointsPossible(): number {
+        return this._pointsPossible;
+    }
+
+    public abstract get questionType(): string;
+
+    public toJSON(): object {
+        return {
+            question_name: this.name,
+            question_text: this.text,
+            question_type: this.questionType,
+            points_possible: this.pointsPossible
+        };
+    }
+}

--- a/src/app/request-resolvers/request-resolver-registry.ts
+++ b/src/app/request-resolvers/request-resolver-registry.ts
@@ -43,7 +43,8 @@ export class RequestResolverRegistry {
             if (tokenOption.prompt != quizSubmissionDetail.answers[0]) continue;
             return this.getRequestResolver(tokenOption.type).resolve(tokenOption, quizSubmissionDetail);
         }
-        // TODO: handle empty answer request (should be invalid)
+        // TODO: handle empty answer request (should be reject)
+        // TODO: handle unrecognized request (could be outdated, should be rejected)
         throw new Error('Invalid request');
     }
 }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -647,7 +647,7 @@ export class CanvasService {
                     quiz_type: quizType,
                     assignment_group_id: assignmentGroupId,
                     allowed_attempts: -1,
-                    published: true
+                    published: false
                 }
             }
         });
@@ -664,17 +664,22 @@ export class CanvasService {
         quizId: string,
         published = true,
         notifyUpdate = false
-    ): Promise<string> {
-        const result = await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`, {
-            method: 'put',
-            data: {
-                quiz: {
-                    published: published,
-                    notify_of_update: notifyUpdate
+    ): Promise<boolean> {
+        try {
+            await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`, {
+                method: 'put',
+                data: {
+                    quiz: {
+                        published: published,
+                        notify_of_update: notifyUpdate
+                    }
                 }
-            }
-        });
-        return result.id;
+            });
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            return false;
+        }
+        return true;
     }
 
     public async modifyQuiz(

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -313,6 +313,22 @@ export class CanvasService {
         return new SubmissionComment(data);
     }
 
+    public async gradeSubmission(
+        courseId: string,
+        studentId: string,
+        assignmentId: string,
+        score: number
+    ): Promise<void> {
+        await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`, {
+            method: 'put',
+            data: {
+                submission: {
+                    posted_grade: score.toString()
+                }
+            }
+        });
+    }
+
     public async gradeSubmissionWithPostingComment(
         courseId: string,
         studentId: string,

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -1,26 +1,77 @@
 import { Inject, Injectable } from '@angular/core';
 import type { Course } from 'app/data/course';
 import { TokenATMConfiguration } from 'app/data/token-atm-configuration';
+import type { TokenOptionGroup } from 'app/data/token-option-group';
+import { DescriptionTransformer } from 'app/instruction-generators/description-transformer';
+import { DueTimeTransformer } from 'app/instruction-generators/due-time-transformer';
+import { HTMLTableGenerator } from 'app/instruction-generators/html-table-generator';
+import { NameTransformer } from 'app/instruction-generators/name-transformer';
+import { StartTimeTransformer } from 'app/instruction-generators/start-time-transformer';
+import { TokenBalanceChangeTransformer } from 'app/instruction-generators/token-balance-change-transformer';
+import { MultipleChoiceQuestion } from 'app/quiz-questions/multiple-choice-question';
 import { TokenOptionResolverRegistry } from 'app/token-option-resolvers/token-option-resolver-registry';
+import { Base64 } from 'js-base64';
 import { CanvasService } from './canvas.service';
 
 @Injectable({
     providedIn: 'root'
 })
 export class TokenATMConfigurationManagerService {
+    private static TOKEN_ATM_CONFIGURATION_PAGE_NAME = 'Token ATM Configuration';
+    private static TOKEN_ATM_SECURE_CONFIGURATION_PAGE_NAME = 'Token ATM Encryption Key (PLEASE DO NOT PUBLISH IT)';
+    private static TOKEN_ATM_ASSIGNMENT_GROUP_PREFIX = 'Token ATM';
+    private static TOKEN_ATM_MODULE_PREFIX = 'Token ATM';
+    private static TOKEN_ATM_QUIZ_PREFIX = 'Token ATM Request Submission - ';
+    private static TOKEN_ATM_LOG_ASSIGNMENT_NAME = 'Token ATM Log';
+
     constructor(
         @Inject(CanvasService) private canvasService: CanvasService,
         @Inject(TokenOptionResolverRegistry) private tokenOptionResolverRegistry: TokenOptionResolverRegistry
     ) {}
 
-    public async getTokenATMConfiguration(course: Course): Promise<TokenATMConfiguration> {
-        let pageContent = await this.canvasService.getPageContentByName(course.id, 'Token ATM Configuration');
+    private async readConfigurationFromPage(course: Course, pageName: string): Promise<string> {
+        let pageContent = await this.canvasService.getPageContentByName(course.id, pageName);
         pageContent = pageContent.substring(3, pageContent.length - 4);
-        let secureContent = await this.canvasService.getPageContentByName(
-            course.id,
-            'Token ATM Encryption Key (PLEASE DO NOT PUBLISH IT)'
+        return pageContent;
+    }
+
+    private async writeConfigurationToPage(course: Course, pageId: string, pageContent: string): Promise<void> {
+        await this.canvasService.modifyPage(course.id, pageId, `<p>${pageContent}</p>`);
+    }
+
+    private async saveConfiguration(configuration: TokenATMConfiguration): Promise<void> {
+        const pageId = await this.canvasService.getPageIdByName(
+            configuration.course.id,
+            TokenATMConfigurationManagerService.TOKEN_ATM_CONFIGURATION_PAGE_NAME
         );
-        secureContent = secureContent.substring(3, secureContent.length - 4);
+        this.writeConfigurationToPage(configuration.course, pageId, JSON.stringify(configuration));
+    }
+
+    private async getAssignmentGroupId(configuration: TokenATMConfiguration): Promise<string> {
+        return await this.canvasService.getAssignmentGroupIdByName(
+            configuration.course.id,
+            TokenATMConfigurationManagerService.TOKEN_ATM_ASSIGNMENT_GROUP_PREFIX +
+                ` - ${configuration.uid} - ${configuration.suffix}`
+        );
+    }
+
+    private async getModuleId(configuration: TokenATMConfiguration): Promise<string> {
+        return await this.canvasService.getModuleIdByName(
+            configuration.course.id,
+            TokenATMConfigurationManagerService.TOKEN_ATM_MODULE_PREFIX +
+                ` - ${configuration.uid} - ${configuration.suffix}`
+        );
+    }
+
+    public async getTokenATMConfiguration(course: Course): Promise<TokenATMConfiguration> {
+        const pageContent = await this.readConfigurationFromPage(
+            course,
+            TokenATMConfigurationManagerService.TOKEN_ATM_CONFIGURATION_PAGE_NAME
+        );
+        const secureContent = await this.readConfigurationFromPage(
+            course,
+            TokenATMConfigurationManagerService.TOKEN_ATM_SECURE_CONFIGURATION_PAGE_NAME
+        );
         const config = JSON.parse(pageContent),
             secureConfig = JSON.parse(secureContent);
         return new TokenATMConfiguration(course, config, secureConfig, (group, data) => {
@@ -28,5 +79,167 @@ export class TokenATMConfigurationManagerService {
         });
     }
 
-    // TODO: write save function for TokenATMConfiguration (quiz refresh && configu update)
+    public async updateTokenOptionGroup(tokenOptionGroup: TokenOptionGroup): Promise<boolean> {
+        const courseId = tokenOptionGroup.configuration.course.id,
+            quizId = tokenOptionGroup.quizId;
+        const canUnpublish = await this.canvasService.canQuizUnpublished(courseId, quizId);
+        if (canUnpublish) await this.canvasService.changeQuizPublishState(courseId, quizId, false);
+        await this.canvasService.clearQuizQuestions(courseId, quizId);
+        await this.canvasService.modifyQuiz(courseId, quizId, tokenOptionGroup.name, tokenOptionGroup.description);
+        const question = new MultipleChoiceQuestion(
+            'Choose a token option',
+            new HTMLTableGenerator([
+                new NameTransformer(),
+                new StartTimeTransformer(),
+                new DueTimeTransformer(),
+                new TokenBalanceChangeTransformer(),
+                new DescriptionTransformer()
+            ]).process(tokenOptionGroup.tokenOptions),
+            0,
+            tokenOptionGroup.tokenOptions.map((tokenOption) => tokenOption.prompt)
+        );
+        await this.canvasService.createQuizQuestions(courseId, quizId, [question]);
+        // TODO: support rendering multiple quiz questions
+        await this.saveConfiguration(tokenOptionGroup.configuration);
+        if (canUnpublish) await this.canvasService.changeQuizPublishState(courseId, quizId, true);
+        return canUnpublish;
+    }
+
+    public async addNewTokenOptionGroup(
+        tokenOptionGroup: TokenOptionGroup,
+        assignmentGroupId?: string,
+        moduleId?: string,
+        addToConfiguration = true
+    ): Promise<void> {
+        if (addToConfiguration) tokenOptionGroup.configuration.addTokenOptionGroup(tokenOptionGroup);
+        const courseId = tokenOptionGroup.configuration.course.id;
+        if (assignmentGroupId == undefined)
+            assignmentGroupId = await this.getAssignmentGroupId(tokenOptionGroup.configuration);
+        const quizName = TokenATMConfigurationManagerService.TOKEN_ATM_QUIZ_PREFIX + tokenOptionGroup.name;
+        const quizId = await this.canvasService.createQuiz(
+            courseId,
+            assignmentGroupId,
+            quizName,
+            tokenOptionGroup.description
+        );
+        tokenOptionGroup.quizId = quizId;
+        if (moduleId == undefined) moduleId = await this.getModuleId(tokenOptionGroup.configuration);
+        await this.canvasService.addModuleItem(courseId, moduleId, 'Quiz', quizId);
+        await this.updateTokenOptionGroup(tokenOptionGroup);
+        await this.canvasService.changeQuizPublishState(courseId, quizId, true);
+    }
+
+    public async deleteTokenOptionGroup(
+        tokenOptionGroup: TokenOptionGroup,
+        deleteFromConfiguration = true
+    ): Promise<void> {
+        if (deleteFromConfiguration) tokenOptionGroup.configuration.deleteTokenOptionGroup(tokenOptionGroup);
+        await this.canvasService.deleteQuiz(tokenOptionGroup.configuration.course.id, tokenOptionGroup.quizId);
+        if (deleteFromConfiguration) await this.saveConfiguration(tokenOptionGroup.configuration);
+    }
+
+    public async deleteGeneratedContent(configuration: TokenATMConfiguration) {
+        await this.canvasService.deleteAssignmentGroup(
+            configuration.course.id,
+            await this.getAssignmentGroupId(configuration)
+        );
+        await this.canvasService.deleteModule(configuration.course.id, await this.getModuleId(configuration));
+        await this.canvasService.deletePage(
+            configuration.course.id,
+            TokenATMConfigurationManagerService.TOKEN_ATM_SECURE_CONFIGURATION_PAGE_NAME
+        );
+    }
+
+    public async generateContent(configuration: TokenATMConfiguration) {
+        const courseId = configuration.course.id;
+        // Generate secure config page
+        await this.canvasService.createPage(
+            courseId,
+            TokenATMConfigurationManagerService.TOKEN_ATM_SECURE_CONFIGURATION_PAGE_NAME,
+            `<p>${JSON.stringify(configuration.getSecureConfig())}</p>`
+        );
+
+        // Generate module & assignment group
+        const assignmentGroupId = await this.canvasService.createAssignmentGroup(
+            courseId,
+            TokenATMConfigurationManagerService.TOKEN_ATM_ASSIGNMENT_GROUP_PREFIX +
+                ` - ${configuration.uid} - ${configuration.suffix}`
+        );
+        const moduleId = await this.canvasService.createModule(
+            courseId,
+            TokenATMConfigurationManagerService.TOKEN_ATM_MODULE_PREFIX +
+                ` - ${configuration.uid} - ${configuration.suffix}`
+        );
+        await this.canvasService.publishModule(courseId, moduleId);
+
+        // Generate log assignment
+        const logAssignmentId = await this.canvasService.createAssignment(
+            courseId,
+            assignmentGroupId,
+            TokenATMConfigurationManagerService.TOKEN_ATM_LOG_ASSIGNMENT_NAME,
+            configuration.description
+        );
+        await this.canvasService.addModuleItem(courseId, moduleId, 'Assignment', logAssignmentId);
+        configuration.logAssignmentId = logAssignmentId;
+
+        // Generate token option groups' quizzes
+        for (const tokenOptionGroup of configuration.tokenOptionGroups) {
+            await this.addNewTokenOptionGroup(tokenOptionGroup, assignmentGroupId, moduleId, false);
+        }
+        await this.saveConfiguration(configuration);
+    }
+
+    public async deleteAll(configuration: TokenATMConfiguration): Promise<void> {
+        await this.deleteGeneratedContent(configuration);
+        await this.canvasService.deletePage(
+            configuration.course.id,
+            await this.canvasService.getPageIdByName(
+                configuration.course.id,
+                TokenATMConfigurationManagerService.TOKEN_ATM_CONFIGURATION_PAGE_NAME
+            )
+        );
+    }
+
+    public async createTokenATMConfiguration(
+        course: Course,
+        suffix = '',
+        description = ''
+    ): Promise<TokenATMConfiguration> {
+        const configuration = new TokenATMConfiguration(
+            course,
+            {
+                log_assignment_id: '',
+                // https://stackoverflow.com/a/47496558
+                uid: [...Array(8)]
+                    .map(() => Math.random().toString(36)[2])
+                    .join('')
+                    .toUpperCase(),
+                suffix: suffix,
+                description: description,
+                token_option_groups: []
+            },
+            {
+                password: [...Array(32)].map(() => Math.random().toString(36)[2]).join(''),
+                salt: Base64.fromUint8Array(window.crypto.getRandomValues(new Uint8Array(32)))
+            },
+            (group, data) => {
+                return this.tokenOptionResolverRegistry.resolveTokenOption(group, data);
+            }
+        );
+        await this.canvasService.createPage(
+            course.id,
+            TokenATMConfigurationManagerService.TOKEN_ATM_CONFIGURATION_PAGE_NAME,
+            `<p>${JSON.stringify(configuration)}</p>`
+        );
+        await this.generateContent(configuration);
+        return configuration;
+    }
+
+    public async regenrateContent(configuration: TokenATMConfiguration): Promise<void> {
+        await this.deleteGeneratedContent(configuration);
+        await this.generateContent(configuration);
+    }
+
+    // TODO: support reordering of token option groups and token options
+    // TODO: support unpublished token option group
 }

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -270,7 +270,7 @@ export class TokenATMConfigurationManagerService {
         return configuration;
     }
 
-    public async regenrateContent(configuration: TokenATMConfiguration): Promise<void> {
+    public async regenerateContent(configuration: TokenATMConfiguration): Promise<void> {
         await this.deleteGeneratedContent(configuration);
         await this.generateContent(configuration);
     }

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -276,5 +276,4 @@ export class TokenATMConfigurationManagerService {
     }
 
     // TODO: support reordering of token option groups and token options
-    // TODO: support unpublished token option group
 }

--- a/src/app/token-options/earn-by-module-token-option.ts
+++ b/src/app/token-options/earn-by-module-token-option.ts
@@ -1,5 +1,5 @@
 import type { TokenOptionGroup } from 'app/data/token-option-group';
-import { fromUnixTime } from 'date-fns';
+import { fromUnixTime, getUnixTime } from 'date-fns';
 import { TokenOption } from './token-option';
 
 export class EarnByModuleTokenOption extends TokenOption {
@@ -38,5 +38,15 @@ export class EarnByModuleTokenOption extends TokenOption {
 
     public get gradeThreshold(): number {
         return this._gradeThreshold;
+    }
+
+    public override toJSON(): object {
+        return {
+            ...super.toJSON(),
+            module_name: this.moduleName,
+            module_id: this.moduleId,
+            start_time: getUnixTime(this.startTime),
+            grade_threshold: this.gradeThreshold
+        };
     }
 }

--- a/src/app/token-options/token-option.ts
+++ b/src/app/token-options/token-option.ts
@@ -5,6 +5,7 @@ export abstract class TokenOption {
     private _type: string;
     private _id: number;
     private _name: string;
+    private _description: string;
     private _tokenBalanceChange: number;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,12 +15,14 @@ export abstract class TokenOption {
             typeof data['type'] != 'string' ||
             typeof data['id'] != 'number' ||
             typeof data['name'] != 'string' ||
+            (typeof data['description'] != 'undefined' && typeof data['description'] != 'string') ||
             typeof data['token_balance_change'] != 'number'
         )
             throw new Error('Invalid data');
         this._type = data['type'];
         this._id = data['id'];
         this._name = data['name'];
+        this._description = data['description'] ?? '';
         this._tokenBalanceChange = data['token_balance_change'];
     }
 
@@ -39,11 +42,25 @@ export abstract class TokenOption {
         return this._name;
     }
 
+    public get description(): string {
+        return this._description;
+    }
+
     public get tokenBalanceChange(): number {
         return this._tokenBalanceChange;
     }
 
     public get prompt(): string {
         return 'Request for ' + this.name;
+    }
+
+    public toJSON(): object {
+        return {
+            type: this.type,
+            id: this.id,
+            name: this.name,
+            description: this.description,
+            token_balance_change: this.tokenBalanceChange
+        };
     }
 }

--- a/src/app/utils/dev-guard.ts
+++ b/src/app/utils/dev-guard.ts
@@ -1,0 +1,5 @@
+import { isDevMode } from '@angular/core';
+
+export const DEV_GUARD = () => {
+    return isDevMode();
+};


### PR DESCRIPTION
### Testing Note

This branch has breaking changes on the Token ATM configuration data structure. Previous Token ATM configuration won't be recognized as valid configuration anymore.

You could use the buttons in Dev-Test page (only shows when Angular is in development mode) to test the architecture. Here are the functionalities of these buttons:

1. Regenerate Content: All content related to Token ATM in the current course will be deleted except for the configuration itself. After that, content (student record encryption key, module, assignment group, log assignment, and request submission quizzes) will be generated again. This will cause all students' request history and token balance being dropped since the log assignment is re-created. This feature is designed to ease testing and migration between courses.
2. Delete All: All content related to Token ATM in the current course will be deleted (including the configuration).
3. Create Configuration: A new Token ATM configuration will be created, while the relevant content (student record encryption key, module, assignment group, and log assignment) will also be created. This feature only works for a course that don't have existing Token ATM configuration (could use "Delete All" to achieve that). This feature is designed to allow teacher initialize Token ATM for a course.
4. Add Token Option Group: A token option group will be added to Token ATM configuration. The request submission quiz for it will also be created, published, and added to module and assignment group. A valid Token ATM configuration is required.
5. Add Token Optionto the Last Token Option Group: A basic token option will be added to the last token option group of the Token ATM Configuration. The request submission quiz will be updated if no one has taken the quiz (see note below). A valid Token ATM configuration and at least one token option group is required.
6. Delete First Token Option Group: The first token option group will be deleted from the Token ATM configuration. The request submission quiz for it will also be deleted. A valid Token ATM configuration and at least one token option group is required.
7. Delete First Token Option in the First Token Option Group: The first token option of the first token option group will be deleted from the Token ATM Configuration. The request submission quiz will be updated if no one has taken the quiz (see note below). A valid Token ATM configuration, at laest one token option group, and at least one token option in the first token option group is required.

You could also modify the code in `dev-test.component.ts` to test it furthermore.

Note: [\[Ref 1\]](https://community.canvaslms.com/t5/Canvas-Question-Forum/Saving-Quizzes-w-API/m-p/226406) [\[Ref 2\]](https://community.canvaslms.com/t5/Canvas-Question-Forum/How-to-save-quiz-via-canvas-API/m-p/480447) Canvas prevents the quiz being automatically and programmatically changed after students have taken it. The teacher has to manually publish the change (by clicking a "Save It Now" button in the quiz management interface). No documented API could get this done automatically, while it's quite hard to reverse engineering it in the remaining time (it seems that Canvas issues a special authenticity_token for it). Also, no documented API could know whether the change is saved or not. The current plan is to popup a modal when the teacher did such a modification to inform them that a manual operation is needed.