### PR TITLE
User Stories: Show & Adjust Indvidual Student Record

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,9 @@ import { TokenOptionDisplayComponent } from './components/token-option-display/t
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
+import { StudentRecordDisplayComponent } from './components/student-record-display/student-record-display.component';
+import { ConfirmationModalComponent } from './components/confirmation-modal/confirmation-modal.component';
+import { ModalModule } from 'ngx-bootstrap/modal';
 
 @NgModule({
     declarations: [
@@ -48,7 +51,9 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
         StudentListComponent,
         DevTestComponent,
         TokenOptionGroupDisplayComponent,
-        TokenOptionDisplayComponent
+        TokenOptionDisplayComponent,
+        StudentRecordDisplayComponent,
+        ConfirmationModalComponent
     ],
     imports: [
         BrowserModule,
@@ -57,7 +62,8 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
         NgbModule,
         BsDropdownModule.forRoot(),
         BrowserAnimationsModule,
-        CollapseModule.forRoot()
+        CollapseModule.forRoot(),
+        ModalModule.forRoot()
     ],
     providers: [
         { provide: AxiosService, useFactory: AxiosServiceFactory.getAxiosService },

--- a/src/app/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/components/confirmation-modal/confirmation-modal.component.html
@@ -1,0 +1,37 @@
+<ng-container *ngIf="onResolve">
+    <div class="modal-header">
+        <h4 class="modal-title pull-left">{{ heading }}</h4>
+        <button
+            type="button"
+            class="btn-close close pull-right"
+            aria-label="Close"
+            (click)="onResolve(false)"
+            [disabled]="disableButton"
+        >
+            <span aria-hidden="true" class="visually-hidden">&times;</span>
+        </button>
+    </div>
+    <div class="modal-body message">
+        {{ message }}
+    </div>
+    <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-outline-secondary me-4"
+            (click)="onResolve(false)"
+            [disabled]="disableButton"
+        >
+            {{ noText }}
+        </button>
+        <button
+            type="button"
+            class="btn"
+            (click)="onResolve(true)"
+            [class.btn-danger]="isDanger"
+            [class.btn-primary]="!isDanger"
+            [disabled]="disableButton"
+        >
+            {{ yesText }}
+        </button>
+    </div>
+</ng-container>

--- a/src/app/components/confirmation-modal/confirmation-modal.component.sass
+++ b/src/app/components/confirmation-modal/confirmation-modal.component.sass
@@ -1,0 +1,2 @@
+.message
+    white-space: pre-line

--- a/src/app/components/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/app/components/confirmation-modal/confirmation-modal.component.spec.ts
@@ -1,0 +1,22 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { ConfirmationModalComponent } from './confirmation-modal.component';
+
+// describe('ConfirmationModalComponent', () => {
+//     let component: ConfirmationModalComponent;
+//     let fixture: ComponentFixture<ConfirmationModalComponent>;
+
+//     beforeEach(async () => {
+//         await TestBed.configureTestingModule({
+//             declarations: [ConfirmationModalComponent]
+//         }).compileComponents();
+
+//         fixture = TestBed.createComponent(ConfirmationModalComponent);
+//         component = fixture.componentInstance;
+//         fixture.detectChanges();
+//     });
+
+//     it('should create', () => {
+//         expect(component).toBeTruthy();
+//     });
+// });

--- a/src/app/components/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/components/confirmation-modal/confirmation-modal.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'app-confirmation-modal',
+    templateUrl: './confirmation-modal.component.html',
+    styleUrls: ['./confirmation-modal.component.sass']
+})
+export class ConfirmationModalComponent {
+    @Input() message = '';
+    @Input() heading = 'Confrimation';
+    @Input() noText = 'Cancel';
+    @Input() yesText = 'Yes';
+    @Input() isDanger = false;
+    @Input() disableButton = false;
+    @Input() onResolve?: (result: boolean) => void;
+}

--- a/src/app/components/dashboard/dashboard-routing.ts
+++ b/src/app/components/dashboard/dashboard-routing.ts
@@ -1,4 +1,3 @@
-import type { Component, Type } from '@angular/core';
 import type { Course } from 'app/data/course';
 import type { Route, Routes } from '@angular/router';
 import { RequestProcessComponent } from '../request-process/request-process.component';
@@ -6,6 +5,7 @@ import { TokenOptionConfigurationComponent } from '../token-option-configuration
 import { StudentListComponent } from '../student-list/student-list.component';
 import { DEV_GUARD } from 'app/utils/dev-guard';
 import { DevTestComponent } from '../dev-test/dev-test.component';
+import type { Component, Type } from '@angular/core';
 
 export interface CourseConfigurable {
     configureCourse(course: Course): Promise<void>;
@@ -15,7 +15,6 @@ type CourseConfigurableComponent = CourseConfigurable & Component;
 
 export type TokenATMDashboardRouteSpecific = {
     name: string;
-    path: string;
     component: Type<CourseConfigurableComponent>;
     isDev?: boolean;
 };
@@ -54,7 +53,9 @@ export function getDashboardRoutes(): Routes {
         ...TOKEN_ATM_DASHBOARD_ROUTES.map((route: TokenATMDashboardRoute) => {
             return {
                 ...route,
-                name: undefined
+                name: undefined,
+                isDev: undefined,
+                hidden: undefined
             };
         }),
         {

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -22,7 +22,9 @@
             </ng-container>
         </ul>
     </div>
-    <div class="flex-grow-1 overflow-auto dashboard-component-container">
-        <router-outlet (activate)="onComponentActivate($event)"></router-outlet>
+    <div class="overflow-auto vh-100 flex-grow-1">
+        <div class="flex-grow-1 dashboard-component-container">
+            <router-outlet (activate)="onComponentActivate($event)"></router-outlet>
+        </div>
     </div>
 </div>

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -12,9 +12,12 @@
         <ul class="nav nav-pills flex-column align-items-center">
             <ng-container *ngFor="let route of routes">
                 <li class="nav-item">
-                    <span class="nav-link fs-4 text-dark" [routerLink]="route.path" routerLinkActive="fw-bold">{{
-                        route.name
-                    }}</span>
+                    <span
+                        class="nav-link fs-4 text-dark is-link"
+                        [routerLink]="route.path"
+                        routerLinkActive="fw-bold"
+                        >{{ route.name }}</span
+                    >
                 </li>
             </ng-container>
         </ul>

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -4,7 +4,6 @@ import type { Course } from 'app/data/course';
 import type { Subscription } from 'rxjs';
 import { CourseConfigurable, TokenATMDashboardRoute, TOKEN_ATM_DASHBOARD_ROUTES } from './dashboard-routing';
 import { CanvasService } from 'app/services/canvas.service';
-// import { User } from 'app/data/user';
 
 @Component({
     selector: 'app-dashboard',
@@ -14,7 +13,6 @@ import { CanvasService } from 'app/services/canvas.service';
 export class DashboardComponent implements OnDestroy {
     private courseSubscription: Subscription | undefined;
     course: Course | undefined;
-    // user: User | undefined;
     avatarUrl?: string;
     name: string | undefined;
     email: string | undefined;
@@ -26,8 +24,6 @@ export class DashboardComponent implements OnDestroy {
             const course = this.router.getCurrentNavigation()?.extras.state;
             if (!course) return;
             this.configureCourse(course as Course);
-            // const user = this.router.getCurrentNavigation()?.extras.state;
-            // if (!course) return;
             this.configureUserInformation('self');
         });
     }
@@ -42,7 +38,6 @@ export class DashboardComponent implements OnDestroy {
 
     private configureCourse(course: Course) {
         this.course = course;
-        // TODO: retrieve other information and display
     }
 
     ngOnDestroy(): void {
@@ -54,8 +49,10 @@ export class DashboardComponent implements OnDestroy {
         return TOKEN_ATM_DASHBOARD_ROUTES.filter((route) => isDevMode() || !route.isDev);
     }
 
-    async onComponentActivate(component: CourseConfigurable) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async onComponentActivate(component: any) {
         if (!this.course) return;
-        await component.configureCourse(this.course);
+        if ('configureCourse' in component && typeof component['configureCourse'] == 'function')
+            await (component as CourseConfigurable).configureCourse(this.course);
     }
 }

--- a/src/app/components/student-list/student-list.component.html
+++ b/src/app/components/student-list/student-list.component.html
@@ -44,8 +44,8 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr *ngFor="let student of students">
-                        <td (click)="navigateToStudent(student)" class="is-link">{{ student.name }}</td>
+                    <tr *ngFor="let student of students" (click)="navigateToStudent(student)" class="is-link">
+                        <td>{{ student.name }}</td>
                         <td>{{ student.email }}</td>
                         <td>{{ studentGrades.get(student.id) ?? 0 }}</td>
                     </tr>

--- a/src/app/components/student-list/student-list.component.html
+++ b/src/app/components/student-list/student-list.component.html
@@ -2,7 +2,7 @@
     <ngb-toast [autohide]="false"> Token ATM is retrieving information from Canvas. Please wait... </ngb-toast>
 </div>
 <ng-template #studentListPanel>
-    <div appCenter *ngIf="students && studentGrades" class="flex-column" [class.is-hidden]="isShowingIndividualStudent">
+    <div *ngIf="students && studentGrades" class="flex-column m-5" [class.is-hidden]="isShowingIndividualStudent">
         <div class="d-flex align-self-stretch mx-5">
             <button
                 class="btn btn-outline-info"
@@ -69,7 +69,7 @@
             </button>
         </div>
     </div>
-    <div appCenter [class.is-hidden]="!isShowingIndividualStudent">
+    <div class="m-5" [class.is-hidden]="!isShowingIndividualStudent">
         <app-student-record-display #individaulStudentRecordDisplay (goBack)="onGoBack()"></app-student-record-display>
     </div>
 </ng-template>

--- a/src/app/components/student-list/student-list.component.html
+++ b/src/app/components/student-list/student-list.component.html
@@ -1,110 +1,75 @@
-<!-- <!DOCTYPE html>
-<html>
-    <head>
-        <title>Student Information</title>
-        <style>
-            /* Style the information bar */
-            .info-bar {
-                display: flex;
-                justify-content: space-between;
-                background-color: lightgray;
-                padding: 10px;
-                font-weight: bold;
-            }
-
-            /* Style the student cards */
-            .student-card {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                padding: 10px;
-                border-bottom: 1px solid gray;
-            }
-
-            /* Style the search button */
-            .search-button {
-                float: right;
-                margin-top: 10px;
-                margin-right: 10px;
-            }
-        </style>
-    </head>
-    <body>
-        <button class="search-button">Search</button>
-        <div class="info-bar">
-            <div>Student Name</div>
-            <div>Token Balance</div>
-            <div>Manage Button</div>
+<div *ngIf="!students || !studentGrades; else studentListPanel" appCenter>
+    <ngb-toast [autohide]="false"> Token ATM is retrieving information from Canvas. Please wait... </ngb-toast>
+</div>
+<ng-template #studentListPanel>
+    <div appCenter *ngIf="students && studentGrades" class="flex-column" [class.is-hidden]="isShowingIndividualStudent">
+        <div class="d-flex align-self-stretch mx-5">
+            <button
+                class="btn btn-outline-info"
+                [disabled]="!students.hasPrevPage() || isFetchingInfo"
+                (click)="prev()"
+            >
+                Prev
+            </button>
+            <div ngbDropdown class="d-inline-block mx-auto">
+                <button type="button" class="btn btn-outline-primary" ngbDropdownToggle>
+                    Select Number of Students
+                </button>
+                <div ngbDropdownMenu>
+                    <button
+                        ngbDropdownItem
+                        *ngFor="let possiblePageCnt of POSSIBLE_PAGE_CNTS"
+                        (click)="changePageSize(possiblePageCnt)"
+                        [class.active]="possiblePageCnt === pageCnt"
+                    >
+                        {{ possiblePageCnt }}
+                    </button>
+                </div>
+            </div>
+            <button
+                class="btn btn-outline-info"
+                [disabled]="!students.hasNextPage() || isFetchingInfo"
+                (click)="next()"
+            >
+                Next
+            </button>
         </div>
         <div>
-            <div class="student-card">
-                <div>Student 1</div>
-                <div>10</div>
-                <button>Manage</button>
-            </div>
-            <div class="student-card">
-                <div>Student 2</div>
-                <div>20</div>
-                <button>Manage</button>
-            </div>
-            <div class="student-card">
-                <div>Student 3</div>
-                <div>30</div>
-                <button>Manage</button>
-            </div>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Student</th>
+                        <th>Email</th>
+                        <th>Token Balance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr *ngFor="let student of students">
+                        <td (click)="navigateToStudent(student)" class="is-link">{{ student.name }}</td>
+                        <td>{{ student.email }}</td>
+                        <td>{{ studentGrades.get(student.id) ?? 0 }}</td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
-    </body>
-</html> -->
-<div appCenter *ngIf="students && studentGrades" class="flex-column">
-    <div class="d-flex align-self-stretch mx-5">
-        <button class="btn btn-outline-info" [disabled]="!students.hasPrevPage() || isFetchingInfo" (click)="prev()">
-            Prev
-        </button>
-        <div ngbDropdown class="d-inline-block mx-auto">
-            <button type="button" class="btn btn-outline-primary" ngbDropdownToggle>Select Number of Students</button>
-            <div ngbDropdownMenu>
-                <button
-                    ngbDropdownItem
-                    *ngFor="let possiblePageCnt of POSSIBLE_PAGE_CNTS"
-                    (click)="changePageSize(possiblePageCnt)"
-                    [class.active]="possiblePageCnt === pageCnt"
-                >
-                    {{ possiblePageCnt }}
-                </button>
-            </div>
+        <div class="d-flex align-self-stretch mx-5">
+            <button
+                class="btn btn-outline-info me-auto"
+                [disabled]="!students.hasPrevPage() || isFetchingInfo"
+                (click)="prev()"
+            >
+                Prev
+            </button>
+            <button
+                class="btn btn-outline-info"
+                [disabled]="!students.hasNextPage() || isFetchingInfo"
+                (click)="next()"
+            >
+                Next
+            </button>
         </div>
-        <button class="btn btn-outline-info" [disabled]="!students.hasNextPage() || isFetchingInfo" (click)="next()">
-            Next
-        </button>
     </div>
-    <div>
-        <table class="table">
-            <thead>
-                <tr>
-                    <th>Student</th>
-                    <th>Email</th>
-                    <th>Token Balance</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr *ngFor="let student of students">
-                    <td>{{ student.name }}</td>
-                    <td>{{ student.email }}</td>
-                    <td>{{ studentGrades.get(student.id) ?? 0 }}</td>
-                </tr>
-            </tbody>
-        </table>
+    <div appCenter [class.is-hidden]="!isShowingIndividualStudent">
+        <app-student-record-display #individaulStudentRecordDisplay (goBack)="onGoBack()"></app-student-record-display>
     </div>
-    <div class="d-flex align-self-stretch mx-5">
-        <button
-            class="btn btn-outline-info me-auto"
-            [disabled]="!students.hasPrevPage() || isFetchingInfo"
-            (click)="prev()"
-        >
-            Prev
-        </button>
-        <button class="btn btn-outline-info" [disabled]="!students.hasNextPage() || isFetchingInfo" (click)="next()">
-            Next
-        </button>
-    </div>
-</div>
+</ng-template>

--- a/src/app/components/student-list/student-list.component.sass
+++ b/src/app/components/student-list/student-list.component.sass
@@ -2,3 +2,5 @@ th, td
     text-align: center
     padding-left: 1rem
     padding-right: 1rem
+.is-hidden
+    display: none !important

--- a/src/app/components/student-list/student-list.component.ts
+++ b/src/app/components/student-list/student-list.component.ts
@@ -53,6 +53,7 @@ export class StudentListComponent implements CourseConfigurable {
 
     private async getStudentGrades(): Promise<void> {
         if (!this.course || !this.configuration || !this.students) return;
+        this.studentGrades = undefined;
         this.studentGrades = await this.canvasService.getStudentsGrades(
             this.course.id,
             this.configuration.logAssignmentId,

--- a/src/app/components/student-list/student-list.component.ts
+++ b/src/app/components/student-list/student-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, ViewChild } from '@angular/core';
 import type { Course } from 'app/data/course';
 import type { Student } from 'app/data/student';
 import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
@@ -6,6 +6,7 @@ import { CanvasService } from 'app/services/canvas.service';
 import { TokenATMConfigurationManagerService } from 'app/services/token-atm-configuration-manager.service';
 import type { PaginatedView } from 'app/utils/paginated-view';
 import type { CourseConfigurable } from '../dashboard/dashboard-routing';
+import type { StudentRecordDisplayComponent } from '../student-record-display/student-record-display.component';
 
 @Component({
     selector: 'app-student-list',
@@ -23,6 +24,9 @@ export class StudentListComponent implements CourseConfigurable {
     studentGrades?: Map<string, number>;
     isFetchingInfo = false;
     pageCnt: number = this.DEFAULT_PAGE_CNT;
+    isShowingIndividualStudent = false;
+    @ViewChild('individaulStudentRecordDisplay')
+    individaulStudentRecordDisplay?: StudentRecordDisplayComponent;
 
     constructor(
         @Inject(CanvasService) private canvasService: CanvasService,
@@ -71,22 +75,14 @@ export class StudentListComponent implements CourseConfigurable {
         await this.getStudentGrades();
         this.isFetchingInfo = false;
     }
+
+    navigateToStudent(student: Student): void {
+        if (!this.configuration || !this.individaulStudentRecordDisplay) return;
+        this.isShowingIndividualStudent = true;
+        this.individaulStudentRecordDisplay.configureStudent(this.configuration, student);
+    }
+
+    onGoBack() {
+        this.isShowingIndividualStudent = false;
+    }
 }
-
-//TODO Dropdown menu for page size
-//two buttons to change page
-//
-
-//     constructor(@Inject(CanvasService) private canvasService: CanvasService) {}
-
-//     ngOnInit() {
-//         this.loading = true;
-//         this.fetchCourses().then(() => {
-//             this.loading = false;
-//         });
-//     }
-
-//     private async fetchCourses() {
-//         this.coursesEnrolledAsTeacher = await DataConversionHelper.convertAsyncIterableToList(
-//             await this.canvasService.getCourses('student', 'active')
-//         );

--- a/src/app/components/student-record-display/student-record-display.component.html
+++ b/src/app/components/student-record-display/student-record-display.component.html
@@ -1,0 +1,83 @@
+<div appCenter>
+    <ngb-toast *ngIf="!studentRecord; else studentRecordPanel" [autohide]="false">
+        Token ATM is retrieving information from Canvas. Please wait...
+    </ngb-toast>
+    <ng-template #studentRecordPanel>
+        <div class="d-flex flex-column">
+            <div><button (click)="onGoBack()" class="btn btn-outline-primary mb-1 ms-5">Back</button></div>
+            <ng-container *ngIf="studentRecord">
+                <div class="row m-5">
+                    <div class="col-4 card">
+                        <div class="card-body">
+                            <h5 class="card-titile">Student Information</h5>
+                            <div class="card-text">
+                                <ul class="list-group list-group-flush my-auto">
+                                    <li class="list-group-item">Canvas User ID: {{ studentRecord.student.id }}</li>
+                                    <li class="list-group-item">Name: {{ studentRecord.student.name }}</li>
+                                    <li *ngIf="studentRecord.student.email !== ''" class="list-group-item">
+                                        Email: {{ studentRecord.student.email }}
+                                    </li>
+                                    <li class="list-group-item">
+                                        Current Token Balance: {{ studentRecord.tokenBalance }}
+                                        {{ studentRecord.tokenBalance === 1 ? 'token' : 'tokens' }}
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-4"></div>
+                    <div class="col-4 card">
+                        <div class="card-body">
+                            <h5 class="card-titile">Token Balance Adjustment</h5>
+                            <div class="card-text">
+                                <div class="mb-3">
+                                    <label> Token Adjustment Count </label>
+                                    <input
+                                        type="number"
+                                        class="form-control"
+                                        value="0"
+                                        [(ngModel)]="tokenAdjustmentCount"
+                                    />
+                                </div>
+                                <div class="mb-3">
+                                    <label> Message </label>
+                                    <textarea class="form-control" [(ngModel)]="tokenAdjustmentMessage"></textarea>
+                                </div>
+                                <button class="btn btn-primary" (click)="onAddManualChange()">Add</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 card my-5">
+                        <div class="card-body">
+                            <h5 class="card-titile">Request History</h5>
+                            <div class="card-text">
+                                <table class="table table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Token Option Name</th>
+                                            <th scope="col">Submitted Time</th>
+                                            <th scope="col">Processed Time</th>
+                                            <th scope="col">Status</th>
+                                            <th scope="col">Token Balance Change</th>
+                                            <th scope="col">Message</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr *ngFor="let processedRequest of studentRecord.processedRequests.reverse()">
+                                            <td>{{ processedRequest.tokenOptionName }}</td>
+                                            <td>{{ formatDate(processedRequest.submitTime) }}</td>
+                                            <td>{{ formatDate(processedRequest.processTime) }}</td>
+                                            <td>{{ processedRequest.isApproved ? 'Approved' : 'Rejected' }}</td>
+                                            <td>{{ processedRequest.tokenBalanceChange }}</td>
+                                            <td>{{ processedRequest.message }}</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </ng-container>
+        </div>
+    </ng-template>
+</div>

--- a/src/app/components/student-record-display/student-record-display.component.html
+++ b/src/app/components/student-record-display/student-record-display.component.html
@@ -1,83 +1,81 @@
-<div appCenter>
-    <ngb-toast *ngIf="!studentRecord; else studentRecordPanel" [autohide]="false">
-        Token ATM is retrieving information from Canvas. Please wait...
-    </ngb-toast>
-    <ng-template #studentRecordPanel>
-        <div class="d-flex flex-column">
-            <div><button (click)="onGoBack()" class="btn btn-outline-primary mb-1 ms-5">Back</button></div>
-            <ng-container *ngIf="studentRecord">
-                <div class="row m-5">
-                    <div class="col-4 card">
-                        <div class="card-body">
-                            <h5 class="card-titile">Student Information</h5>
-                            <div class="card-text">
-                                <ul class="list-group list-group-flush my-auto">
-                                    <li class="list-group-item">Canvas User ID: {{ studentRecord.student.id }}</li>
-                                    <li class="list-group-item">Name: {{ studentRecord.student.name }}</li>
-                                    <li *ngIf="studentRecord.student.email !== ''" class="list-group-item">
-                                        Email: {{ studentRecord.student.email }}
-                                    </li>
-                                    <li class="list-group-item">
-                                        Current Token Balance: {{ studentRecord.tokenBalance }}
-                                        {{ studentRecord.tokenBalance === 1 ? 'token' : 'tokens' }}
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-4"></div>
-                    <div class="col-4 card">
-                        <div class="card-body">
-                            <h5 class="card-titile">Token Balance Adjustment</h5>
-                            <div class="card-text">
-                                <div class="mb-3">
-                                    <label> Token Adjustment Count </label>
-                                    <input
-                                        type="number"
-                                        class="form-control"
-                                        value="0"
-                                        [(ngModel)]="tokenAdjustmentCount"
-                                    />
-                                </div>
-                                <div class="mb-3">
-                                    <label> Message </label>
-                                    <textarea class="form-control" [(ngModel)]="tokenAdjustmentMessage"></textarea>
-                                </div>
-                                <button class="btn btn-primary" (click)="onAddManualChange()">Add</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-12 card my-5">
-                        <div class="card-body">
-                            <h5 class="card-titile">Request History</h5>
-                            <div class="card-text">
-                                <table class="table table-striped">
-                                    <thead>
-                                        <tr>
-                                            <th scope="col">Token Option Name</th>
-                                            <th scope="col">Submitted Time</th>
-                                            <th scope="col">Processed Time</th>
-                                            <th scope="col">Status</th>
-                                            <th scope="col">Token Balance Change</th>
-                                            <th scope="col">Message</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr *ngFor="let processedRequest of studentRecord.processedRequests.reverse()">
-                                            <td>{{ processedRequest.tokenOptionName }}</td>
-                                            <td>{{ formatDate(processedRequest.submitTime) }}</td>
-                                            <td>{{ formatDate(processedRequest.processTime) }}</td>
-                                            <td>{{ processedRequest.isApproved ? 'Approved' : 'Rejected' }}</td>
-                                            <td>{{ processedRequest.tokenBalanceChange }}</td>
-                                            <td>{{ processedRequest.message }}</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
+<div appCenter *ngIf="!studentRecord; else studentRecordPanel">
+    <ngb-toast [autohide]="false"> Token ATM is retrieving information from Canvas. Please wait... </ngb-toast>
+</div>
+<ng-template #studentRecordPanel>
+    <div class="d-flex flex-column">
+        <div><button (click)="onGoBack()" class="btn btn-outline-primary mb-1 ms-5">Back</button></div>
+        <ng-container *ngIf="studentRecord">
+            <div class="row m-5">
+                <div class="col-5 card">
+                    <div class="card-body">
+                        <h5 class="card-titile">Student Information</h5>
+                        <div class="card-text">
+                            <ul class="list-group list-group-flush my-auto">
+                                <li class="list-group-item">Canvas User ID: {{ studentRecord.student.id }}</li>
+                                <li class="list-group-item">Name: {{ studentRecord.student.name }}</li>
+                                <li *ngIf="studentRecord.student.email !== ''" class="list-group-item">
+                                    Email: {{ studentRecord.student.email }}
+                                </li>
+                                <li class="list-group-item">
+                                    Current Token Balance: {{ studentRecord.tokenBalance }}
+                                    {{ studentRecord.tokenBalance === 1 ? 'token' : 'tokens' }}
+                                </li>
+                            </ul>
                         </div>
                     </div>
                 </div>
-            </ng-container>
-        </div>
-    </ng-template>
-</div>
+                <div class="col-2"></div>
+                <div class="col-5 card">
+                    <div class="card-body">
+                        <h5 class="card-titile">Token Balance Adjustment</h5>
+                        <div class="card-text">
+                            <div class="mb-3">
+                                <label> Token Adjustment Count </label>
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    value="0"
+                                    [(ngModel)]="tokenAdjustmentCount"
+                                />
+                            </div>
+                            <div class="mb-3">
+                                <label> Message </label>
+                                <textarea class="form-control" [(ngModel)]="tokenAdjustmentMessage"></textarea>
+                            </div>
+                            <button class="btn btn-primary" (click)="onAddManualChange()">Add</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 card my-5">
+                    <div class="card-body">
+                        <h5 class="card-titile">Request History</h5>
+                        <div class="card-text overflow-auto">
+                            <table class="table table-striped">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Token Option Name</th>
+                                        <th scope="col">Submitted Time</th>
+                                        <th scope="col">Processed Time</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Token Balance Change</th>
+                                        <th scope="col">Message</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr *ngFor="let processedRequest of studentRecord.processedRequests.reverse()">
+                                        <td>{{ processedRequest.tokenOptionName }}</td>
+                                        <td>{{ formatDate(processedRequest.submitTime) }}</td>
+                                        <td>{{ formatDate(processedRequest.processTime) }}</td>
+                                        <td>{{ processedRequest.isApproved ? 'Approved' : 'Rejected' }}</td>
+                                        <td>{{ processedRequest.tokenBalanceChange }}</td>
+                                        <td>{{ processedRequest.message }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </ng-container>
+    </div>
+</ng-template>

--- a/src/app/components/student-record-display/student-record-display.component.sass
+++ b/src/app/components/student-record-display/student-record-display.component.sass
@@ -1,0 +1,2 @@
+th, td
+    text-align: center

--- a/src/app/components/student-record-display/student-record-display.component.spec.ts
+++ b/src/app/components/student-record-display/student-record-display.component.spec.ts
@@ -1,0 +1,22 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { StudentRecordDisplayComponent } from './student-record-display.component';
+
+// describe('StudentRecordDisplayComponent', () => {
+//     let component: StudentRecordDisplayComponent;
+//     let fixture: ComponentFixture<StudentRecordDisplayComponent>;
+
+//     beforeEach(async () => {
+//         await TestBed.configureTestingModule({
+//             declarations: [StudentRecordDisplayComponent]
+//         }).compileComponents();
+
+//         fixture = TestBed.createComponent(StudentRecordDisplayComponent);
+//         component = fixture.componentInstance;
+//         fixture.detectChanges();
+//     });
+
+//     it('should create', () => {
+//         expect(component).toBeTruthy();
+//     });
+// });

--- a/src/app/components/student-record-display/student-record-display.component.ts
+++ b/src/app/components/student-record-display/student-record-display.component.ts
@@ -1,0 +1,74 @@
+import { Component, EventEmitter, Inject, Output } from '@angular/core';
+import { ProcessedRequest } from 'app/data/processed-request';
+import type { Student } from 'app/data/student';
+import type { StudentRecord } from 'app/data/student-record';
+import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
+import { ModalConfirmationService } from 'app/services/modal-confirmation.service';
+import { StudentRecordManagerService } from 'app/services/student-record-manager.service';
+import { format, getUnixTime } from 'date-fns';
+
+@Component({
+    selector: 'app-student-record-display',
+    templateUrl: './student-record-display.component.html',
+    styleUrls: ['./student-record-display.component.sass']
+})
+export class StudentRecordDisplayComponent {
+    configuration?: TokenATMConfiguration;
+    student?: Student;
+    studentRecord?: StudentRecord;
+    tokenAdjustmentCount = 0;
+    tokenAdjustmentMessage = '';
+    @Output() goBack = new EventEmitter<void>();
+
+    constructor(
+        @Inject(StudentRecordManagerService) private recordManagerService: StudentRecordManagerService,
+        @Inject(ModalConfirmationService) private modalConfirmationService: ModalConfirmationService
+    ) {}
+
+    public async configureStudent(configuration: TokenATMConfiguration, student: Student): Promise<void> {
+        this.studentRecord = undefined;
+        this.configuration = configuration;
+        this.student = student;
+        this.studentRecord = await this.recordManagerService.getStudentRecord(this.configuration, this.student);
+    }
+
+    formatDate(date: Date): string {
+        return format(date, 'MMM dd, yyyy kk:mm:ss');
+    }
+
+    async onAddManualChange(): Promise<void> {
+        if (!this.configuration || !this.studentRecord) return;
+        const [modalRef, result] = await this.modalConfirmationService.createConfirmationModal(
+            `Do you really want to change student token balance by ${
+                this.tokenAdjustmentCount.toString() +
+                (this.tokenAdjustmentMessage == ''
+                    ? '?'
+                    : ` with the following message?\n${this.tokenAdjustmentMessage}`)
+            }`
+        );
+        if (result) {
+            if (modalRef.content) modalRef.content.disableButton = true;
+            const nowTime = getUnixTime(new Date());
+            await this.recordManagerService.logProcessedRequest(
+                this.configuration,
+                this.studentRecord,
+                new ProcessedRequest(this.configuration, this.studentRecord.student, {
+                    token_option_id: -1,
+                    token_option_name: 'Manual Adjustment',
+                    is_approved: true,
+                    message: this.tokenAdjustmentMessage,
+                    submit_time: nowTime,
+                    process_time: nowTime,
+                    token_balance_change: this.tokenAdjustmentCount
+                })
+            );
+        }
+        this.tokenAdjustmentCount = 0;
+        this.tokenAdjustmentMessage = '';
+        modalRef.hide();
+    }
+
+    onGoBack(): void {
+        this.goBack.next();
+    }
+}

--- a/src/app/components/student-record-display/student-record-display.component.ts
+++ b/src/app/components/student-record-display/student-record-display.component.ts
@@ -38,6 +38,8 @@ export class StudentRecordDisplayComponent {
 
     async onAddManualChange(): Promise<void> {
         if (!this.configuration || !this.studentRecord) return;
+        if (this.tokenAdjustmentCount == null) return;
+        if (this.tokenAdjustmentMessage == null) this.tokenAdjustmentMessage = '';
         const [modalRef, result] = await this.modalConfirmationService.createConfirmationModal(
             `Do you really want to change student token balance by ${
                 this.tokenAdjustmentCount.toString() +

--- a/src/app/components/student-record-display/student-record-display.component.ts
+++ b/src/app/components/student-record-display/student-record-display.component.ts
@@ -27,6 +27,8 @@ export class StudentRecordDisplayComponent {
 
     public async configureStudent(configuration: TokenATMConfiguration, student: Student): Promise<void> {
         this.studentRecord = undefined;
+        this.tokenAdjustmentCount = 0;
+        this.tokenAdjustmentMessage = '';
         this.configuration = configuration;
         this.student = student;
         this.studentRecord = await this.recordManagerService.getStudentRecord(this.configuration, this.student);
@@ -64,9 +66,9 @@ export class StudentRecordDisplayComponent {
                     token_balance_change: this.tokenAdjustmentCount
                 })
             );
+            this.tokenAdjustmentCount = 0;
+            this.tokenAdjustmentMessage = '';
         }
-        this.tokenAdjustmentCount = 0;
-        this.tokenAdjustmentMessage = '';
         modalRef.hide();
     }
 

--- a/src/app/data/processed-request.ts
+++ b/src/app/data/processed-request.ts
@@ -12,6 +12,7 @@ export class ProcessedRequest {
     private _isApproved: boolean;
     private _submitTime: Date;
     private _processTime: Date;
+    private _tokenBalanceChange: number;
     private _message?: string;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -22,7 +23,8 @@ export class ProcessedRequest {
             typeof data['is_approved'] != 'boolean' ||
             (typeof data['message'] != 'undefined' && typeof data['message'] != 'string') ||
             typeof data['submit_time'] != 'number' ||
-            typeof data['process_time'] != 'number'
+            typeof data['process_time'] != 'number' ||
+            typeof data['token_balance_change'] != 'number'
         )
             throw new Error('Invalid data');
         this._configuration = configuration;
@@ -34,6 +36,7 @@ export class ProcessedRequest {
         this._submitTime = fromUnixTime(data['submit_time']);
         this._processTime = fromUnixTime(data['process_time']);
         this._message = data['message'];
+        this._tokenBalanceChange = data['token_balance_change'];
     }
 
     public get configuration(): TokenATMConfiguration {
@@ -68,6 +71,10 @@ export class ProcessedRequest {
         return this._message ?? '';
     }
 
+    public get tokenBalanceChange(): number {
+        return this._tokenBalanceChange;
+    }
+
     public toJSON(): unknown {
         return {
             token_option_id: this._tokenOptionId,
@@ -75,7 +82,8 @@ export class ProcessedRequest {
             is_approved: this.isApproved,
             submit_time: getUnixTime(this.submitTime),
             process_time: getUnixTime(this.processTime),
-            message: this._message
+            message: this.message,
+            token_balance_change: this.tokenBalanceChange
         };
     }
 }

--- a/src/app/data/student-record.ts
+++ b/src/app/data/student-record.ts
@@ -77,12 +77,13 @@ export class StudentRecord {
     }
 
     public logProcessedRequest(processedRequest: ProcessedRequest) {
-        if (!processedRequest.tokenOption) throw new Error('Invalid processed request');
-        if (processedRequest.isApproved) this._tokenBalance += processedRequest.tokenOption.tokenBalanceChange;
-        this._processedAttemptsMap.set(
-            processedRequest.tokenOption.group.id,
-            (this._processedAttemptsMap.get(processedRequest.tokenOption.group.id) ?? 0) + 1
-        );
+        this._tokenBalance += processedRequest.tokenBalanceChange;
+        if (processedRequest.tokenOption) {
+            this._processedAttemptsMap.set(
+                processedRequest.tokenOption.group.id,
+                (this._processedAttemptsMap.get(processedRequest.tokenOption.group.id) ?? 0) + 1
+            );
+        }
         this._processedRequests.push(processedRequest);
     }
 

--- a/src/app/request-handlers/basic-request-handler.ts
+++ b/src/app/request-handlers/basic-request-handler.ts
@@ -26,7 +26,8 @@ export class BasicRequestHandler extends RequestHandler<BasicTokenOption, BasicR
             is_approved: true,
             submit_time: getUnixTime(request.submittedTime),
             process_time: getUnixTime(new Date()),
-            message: 'This basic request is approved.'
+            message: 'This basic request is approved.',
+            token_balance_change: request.tokenOption.tokenBalanceChange
         });
     }
 

--- a/src/app/request-handlers/earn-by-module-request-handler.ts
+++ b/src/app/request-handlers/earn-by-module-request-handler.ts
@@ -41,7 +41,8 @@ export class EarnByModuleRequestHandler extends RequestHandler<EarnByModuleToken
             is_approved: !guardExecutor.isRejected,
             submit_time: getUnixTime(request.submittedTime),
             process_time: getUnixTime(new Date()),
-            message: guardExecutor.message
+            message: guardExecutor.message,
+            token_balance_change: guardExecutor.isRejected ? 0 : request.tokenOption.tokenBalanceChange
         });
     }
     public get type(): string {

--- a/src/app/services/modal-confirmation.service.spec.ts
+++ b/src/app/services/modal-confirmation.service.spec.ts
@@ -1,0 +1,16 @@
+// import { TestBed } from '@angular/core/testing';
+
+// import { ModalConfirmationService } from './modal-confirmation.service';
+
+// describe('ModalConfirmationService', () => {
+//     let service: ModalConfirmationService;
+
+//     beforeEach(() => {
+//         TestBed.configureTestingModule({});
+//         service = TestBed.inject(ModalConfirmationService);
+//     });
+
+//     it('should be created', () => {
+//         expect(service).toBeTruthy();
+//     });
+// });

--- a/src/app/services/modal-confirmation.service.ts
+++ b/src/app/services/modal-confirmation.service.ts
@@ -1,0 +1,40 @@
+import { Inject, Injectable } from '@angular/core';
+import { ConfirmationModalComponent } from 'app/components/confirmation-modal/confirmation-modal.component';
+import { BsModalRef, BsModalService, ModalOptions } from 'ngx-bootstrap/modal';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ModalConfirmationService {
+    constructor(@Inject(BsModalService) private modalService: BsModalService) {}
+
+    public async createConfirmationModal(
+        message: string,
+        heading = 'Confirmation',
+        isDanger = false,
+        noText = 'Cancel',
+        yesText = 'Yes'
+    ): Promise<[BsModalRef<ConfirmationModalComponent>, boolean]> {
+        let modalResolve: (result: boolean) => void;
+        const promise = new Promise<boolean>((resolve) => {
+            modalResolve = resolve;
+        });
+        const initialState: ModalOptions = {
+            initialState: {
+                message: message,
+                heading: heading,
+                isDanger: isDanger,
+                noText: noText,
+                yesText: yesText,
+                onResolve: (result: boolean) => {
+                    modalResolve(result);
+                }
+            },
+            backdrop: 'static',
+            keyboard: false
+        };
+        const modalRef = this.modalService.show(ConfirmationModalComponent, initialState);
+        const result = await promise;
+        return [modalRef, result];
+    }
+}

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -80,6 +80,7 @@ export class RequestProcessManagerService {
         const allRequests: [StudentRecord, TokenATMRequest<TokenOption>[]][] = [];
         let studentCnt = 0,
             requestCnt = 0;
+        // TODO: change the API endpoint to get the email
         for await (const student of await this.canvasService.getCourseStudentEnrollments(configuration.course.id)) {
             if (!quizSubmissionMap.has(student.id)) continue;
             const quizSubmissions = quizSubmissionMap.get(student.id);

--- a/src/app/services/student-record-manager.service.ts
+++ b/src/app/services/student-record-manager.service.ts
@@ -98,6 +98,7 @@ export class StudentRecordManagerService {
         studentRecord: StudentRecord,
         processedRequest: ProcessedRequest
     ) {
+        const oldTokenBalance = studentRecord.tokenBalance;
         studentRecord.logProcessedRequest(processedRequest);
         // generate a new comment
         this.canvasService.postComment(
@@ -109,7 +110,9 @@ export class StudentRecordManagerService {
             }\nSubmitted at: ${format(processedRequest.submitTime, 'MMM dd, yyyy kk:mm:ss')}\nProcessed at: ${format(
                 processedRequest.processTime,
                 'MMM dd, yyyy kk:mm:ss'
-            )}${processedRequest.message != '' ? `\nMessage: ${processedRequest.message}` : ''}`
+            )}\nToken Balance Change: ${oldTokenBalance} -> ${studentRecord.tokenBalance}${
+                processedRequest.message != '' ? `\nMessage: ${processedRequest.message}` : ''
+            }`
         );
         await this.writeStudentRecordToCanvas(configuration, studentRecord);
     }

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -6,3 +6,6 @@
     @extend .justify-content-center
     @extend .align-items-center
     @extend .mb-2
+
+.is-link
+    cursor: pointer


### PR DESCRIPTION
Note: This pull request contains breaking changes to the student record data structure. You need to delete all exisiting student records (could be done using the last button in Dev-Test page) and then re-process them.

### User Sotries

1. As a teacher, I want to view transactions of tokens of a specific student so that I can obtain detailed information about that student’s interaction with Token ATM.
2. As a teacher, I want to be able to adjust token balance for any specific student so that I can manually correct some mistakes.

### Acceptance Criteria

1. Given that a teahcer is viewing the list of students in Token ATM dashboard, when the teacher clicks an entry in the student list, then the student record (name, email, token balance, and processed requests) of the student in the click entry will be shown.
2. Given that a teacher is viewing the student record of a specific student in Token ATM dashboard, when the teacher clicks the "Back" button, then the teacher will be navigated back to thelist of students.
3. Given that a teacher is viewing the student record of a specific student in Token ATM dashboard, when the teacher provides valid information for token adjustment count and message and press the "Add" button, then a modal will be shown to ask the teacher to confirm this manual adjustment.
4. Given that a teacher is prompted by a modal to confirm a manual token balance adjustment, when the teacher clicks "Cancel" or clicks the "X" button in the top-right corner, then the modal should close without processing a manual token balance adjustment.
5. Given that a teacher is prompted by a modal to confirm a manual token balance adjustment, when the teacher clicks "Yes"button, then a manual token balance adjustment will be processed, and the modal will close after the processing is completed.