### PR TITLE
Bugfix for request history ordering & Prepare for Live Testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "bootstrap-icons": "^1.10.5",
                 "compress-json": "^2.1.2",
                 "date-fns": "^2.30.0",
+                "html-dom-parser": "^3.1.7",
                 "js-base64": "^3.7.5",
                 "ngx-bootstrap": "^10.2.0",
                 "rxjs": "~7.8.0",
@@ -5714,7 +5715,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7521,6 +7521,29 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/html-dom-parser": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.7.tgz",
+            "integrity": "sha512-cDgNF4YgF6J3H+d9mcldGL19p0GzVdS3iGuDNzYWQpU47q3+IRM85X3Xo07E+nntF4ek4s78A9V24EwxlPTjig==",
+            "dependencies": {
+                "domhandler": "5.0.3",
+                "htmlparser2": "8.0.2"
+            }
+        },
+        "node_modules/html-dom-parser/node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
         "node_modules/html-entities": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
@@ -7532,6 +7555,75 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
+        },
+        "node_modules/htmlparser2": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+            "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1",
+                "entities": "^4.4.0"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/domutils": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "bootstrap-icons": "^1.10.5",
         "compress-json": "^2.1.2",
         "date-fns": "^2.30.0",
+        "html-dom-parser": "^3.1.7",
         "js-base64": "^3.7.5",
         "ngx-bootstrap": "^10.2.0",
         "rxjs": "~7.8.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { StudentRecordDisplayComponent } from './components/student-record-displ
 import { ConfirmationModalComponent } from './components/confirmation-modal/confirmation-modal.component';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { NotificationModalComponent } from './components/notification-modal/notification-modal.component';
+import { ConfigurationComponent } from './components/configuration/configuration.component';
 
 @NgModule({
     declarations: [
@@ -55,7 +56,8 @@ import { NotificationModalComponent } from './components/notification-modal/noti
         TokenOptionDisplayComponent,
         StudentRecordDisplayComponent,
         ConfirmationModalComponent,
-        NotificationModalComponent
+        NotificationModalComponent,
+        ConfigurationComponent
     ],
     imports: [
         BrowserModule,

--- a/src/app/components/configuration/configuration.component.html
+++ b/src/app/components/configuration/configuration.component.html
@@ -1,0 +1,26 @@
+<div *ngIf="!course; else configurationPanel" appCenter>
+    <ngb-toast [autohide]="false"> Token ATM is retrieving information from Canvas. Please wait... </ngb-toast>
+</div>
+<ng-template #configurationPanel>
+    <div appCenter class="flex-column">
+        <button class="btn btn-primary my-3" (click)="onCreateTestingConfiguration()" [disabled]="isProcessing">
+            Create Testing Configuration
+        </button>
+        <button class="btn btn-danger my-3" (click)="onDeleteAll()" [disabled]="isProcessing">
+            Delete All Token-ATM related content
+        </button>
+    </div>
+</ng-template>
+
+<ng-template #moduleNameModal>
+    <div class="modal-header">
+        <h4 class="modal-title pull-left">Provide course preparation module name</h4>
+    </div>
+    <div class="modal-body">
+        <label for="renameText">The name of the course preparation module:</label>
+        <input type="text" class="form-control" id="renameText" [(ngModel)]="moduleName" />
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-outline-primary mx-2" (click)="onInputModuleName()">Submit</button>
+    </div>
+</ng-template>

--- a/src/app/components/configuration/configuration.component.spec.ts
+++ b/src/app/components/configuration/configuration.component.spec.ts
@@ -1,0 +1,22 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { ConfigurationComponent } from './configuration.component';
+
+// describe('ConfigurationComponent', () => {
+//     let component: ConfigurationComponent;
+//     let fixture: ComponentFixture<ConfigurationComponent>;
+
+//     beforeEach(async () => {
+//         await TestBed.configureTestingModule({
+//             declarations: [ConfigurationComponent]
+//         }).compileComponents();
+
+//         fixture = TestBed.createComponent(ConfigurationComponent);
+//         component = fixture.componentInstance;
+//         fixture.detectChanges();
+//     });
+
+//     it('should create', () => {
+//         expect(component).toBeTruthy();
+//     });
+// });

--- a/src/app/components/configuration/configuration.component.ts
+++ b/src/app/components/configuration/configuration.component.ts
@@ -1,0 +1,190 @@
+import { Component, Inject, TemplateRef, ViewChild } from '@angular/core';
+import type { Course } from 'app/data/course';
+import { TokenOptionGroup } from 'app/data/token-option-group';
+import { CanvasService } from 'app/services/canvas.service';
+import { ModalManagerService } from 'app/services/modal-manager.service';
+import { TokenATMConfigurationManagerService } from 'app/services/token-atm-configuration-manager.service';
+import { BasicTokenOption } from 'app/token-options/basic-token-option';
+import { EarnByModuleTokenOption } from 'app/token-options/earn-by-module-token-option';
+import { getUnixTime } from 'date-fns';
+import { Base64 } from 'js-base64';
+import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
+import type { CourseConfigurable } from '../dashboard/dashboard-routing';
+
+@Component({
+    selector: 'app-configuration',
+    templateUrl: './configuration.component.html',
+    styleUrls: ['./configuration.component.sass']
+})
+export class ConfigurationComponent implements CourseConfigurable {
+    isProcessing = false;
+    course?: Course;
+
+    @ViewChild('moduleNameModal') moduleNameModalTemplate?: TemplateRef<unknown>;
+    moduleNameModalRef?: BsModalRef<unknown>;
+    moduleNamePromiseResolve?: () => void;
+    moduleName?: string;
+
+    constructor(
+        @Inject(TokenATMConfigurationManagerService)
+        private configurationManagerService: TokenATMConfigurationManagerService,
+        @Inject(CanvasService) private canvasService: CanvasService,
+        @Inject(BsModalService) private modalSerivce: BsModalService,
+        @Inject(ModalManagerService) private modalManagerSerivce: ModalManagerService
+    ) {}
+
+    async configureCourse(course: Course): Promise<void> {
+        this.course = course;
+    }
+
+    async onCreateTestingConfiguration(): Promise<void> {
+        if (!this.course) return;
+        this.isProcessing = true;
+        try {
+            await this.canvasService.getPageIdByName(this.course.id, 'Token ATM Configuration');
+            this.isProcessing = false;
+            await this.modalManagerSerivce.createNotificationModal(
+                `There is an existing configuration for this course.`
+            );
+            return;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            // no configuration is there
+        }
+        try {
+            const configuration = await this.configurationManagerService.createTokenATMConfiguration(
+                this.course,
+                '(Complete to earn 1 TOKEN)',
+                'This is just a test generation of the content' // TODO: explanation?
+            );
+            const basicGroup = new TokenOptionGroup(
+                configuration,
+                {
+                    name: 'Earn & Spend Tokens (Test)',
+                    id: configuration.nextFreeTokenOptionGroupId,
+                    quiz_id: '',
+                    description: Base64.encode(String.raw`<p>Students,</p>
+            <p>To earn an extra token to be applied to your final exam, please help us try out a new system developed by your fellow UCI students in their ICS capstone course. The purpose of this programming is take make the Token process more automatic - so students don't have to wait for the Head TA to manually process token counts.</p>
+            <p>All you need to do is complete this quiz to let their programming (called a Token ATM) know you want to earn a token. You still need to wait for the Head TA to trigger the automatic request processing. To see if your request was approved, look at the Token ATM Log.&nbsp; The Token ATM Log displays your token balance and information about the requests you've made.</p>
+            <p>Thanks for helping us test out the Token ATM!</p>`),
+                    is_published: true,
+                    token_options: []
+                },
+                configuration.tokenOptionResolver
+            );
+            await this.configurationManagerService.addNewTokenOptionGroup(basicGroup);
+            basicGroup.addTokenOption(
+                new BasicTokenOption(basicGroup, {
+                    type: 'basic',
+                    id: configuration.nextFreeTokenOptionId,
+                    name: 'Earn 0.5 test tokens',
+                    description: Base64.encode(
+                        'The test tokens you obtained by requesting this token option is just for testing purpose and will not influence your real token counts'
+                    ),
+                    token_balance_change: 0.5
+                })
+            );
+            basicGroup.addTokenOption(
+                new BasicTokenOption(basicGroup, {
+                    type: 'basic',
+                    id: configuration.nextFreeTokenOptionId,
+                    name: 'Spend 1 test token',
+                    description: Base64.encode(
+                        'The test tokens you spent by requesting this token option is just for testing purpose and will not influence your real token counts'
+                    ),
+                    token_balance_change: -1
+                })
+            );
+            await this.configurationManagerService.updateTokenOptionGroup(basicGroup);
+            const moduleGroup = new TokenOptionGroup(
+                configuration,
+                {
+                    name: 'Course Preparation Token (Test)',
+                    id: configuration.nextFreeTokenOptionGroupId,
+                    quiz_id: '',
+                    description: Base64.encode(String.raw`<div id="quiz-instructions" class="user_content enhanced">
+            <div class="description user_content teacher-version enhanced">
+            <p>Students,</p>
+            <p>To earn an extra token to be applied to your final exam, please help us try out a new system developed by your fellow UCI students in their ICS capstone course. The purpose of this programming is take make the Token process more automatic - so students don't have to wait for the Head TA to manually process token counts.</p>
+            <p>All you need to do is complete this quiz to let their programming (called a Token ATM) know you want to earn a token. You still need to wait for the Head TA to trigger the automatic request processing. To see if your request was approved, look at the Token ATM Log.&nbsp; The Token ATM Log displays your token balance and information about the requests you've made.</p>
+            <p>Thanks for helping us test out the Token ATM!</p>
+            </div>
+            </div>`),
+                    is_published: true,
+                    token_options: []
+                },
+                configuration.tokenOptionResolver
+            );
+            await this.configurationManagerService.addNewTokenOptionGroup(moduleGroup);
+            this.moduleName = 'Course Preparation (Must pass with 70% or higher to earn 1 TOKEN)';
+            this.moduleNameModalRef = this.modalSerivce.show(this.moduleNameModalTemplate as TemplateRef<unknown>, {
+                backdrop: 'static',
+                keyboard: false
+            });
+            const moduleNamePromise = new Promise<void>((resolve) => {
+                this.moduleNamePromiseResolve = resolve;
+            });
+            await moduleNamePromise;
+            const moduleId = await this.canvasService.getModuleIdByName(this.course.id, this.moduleName as string);
+            moduleGroup.addTokenOption(
+                new EarnByModuleTokenOption(moduleGroup, {
+                    type: 'earn-by-module',
+                    id: configuration.nextFreeTokenOptionId,
+                    name: `Course Preparation Token`,
+                    description: Base64.encode(
+                        `To get this test token, you need to pass the Course Preparation Module with a score no less than 70% of the total score. The test token you got is just for testing purpose and will not influence your real token counts`
+                    ),
+                    token_balance_change: 1,
+                    module_name: 'Course Preparation (Must pass with 70% or higher to earn 1 TOKEN)',
+                    module_id: moduleId,
+                    start_time: getUnixTime(new Date()),
+                    grade_threshold: 0.7
+                })
+            );
+            await this.configurationManagerService.updateTokenOptionGroup(moduleGroup);
+            this.isProcessing = false;
+            await this.modalManagerSerivce.createNotificationModal('Testing Configuration Created!');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            await this.modalManagerSerivce.createNotificationModal(
+                `Error occured when creating test configuration: ${err}`,
+                'Error'
+            );
+            this.isProcessing = false;
+        }
+    }
+
+    async onDeleteAll(): Promise<void> {
+        if (!this.course) return;
+        this.isProcessing = true;
+        const [modalRef, result] = await this.modalManagerSerivce.createConfirmationModal(
+            'Do you really want to delete all Token ATM related content from this course?',
+            'Confirmation',
+            true
+        );
+        modalRef.hide();
+        if (!result) {
+            this.isProcessing = false;
+            return;
+        }
+        try {
+            const configuration = await this.configurationManagerService.getTokenATMConfiguration(this.course);
+            await this.configurationManagerService.deleteAll(configuration);
+            this.isProcessing = false;
+            await this.modalManagerSerivce.createNotificationModal('All Token ATM related content are deleted!');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (err: any) {
+            await this.modalManagerSerivce.createNotificationModal(
+                `Error occured when deleting Token ATM related content: ${err}\nYou could delete the Token ATM content manually by deleting two pages prefixed with Token ATM, one assignment group prefixed with Token ATM, and one module prefixed with Token ATM. Sorry for the inconvenience!`,
+                'Error'
+            );
+            this.isProcessing = false;
+        }
+    }
+
+    onInputModuleName(): void {
+        if (!this.moduleNameModalRef || !this.moduleNamePromiseResolve) return;
+        this.moduleNameModalRef.hide();
+        this.moduleNamePromiseResolve();
+    }
+}

--- a/src/app/components/dashboard/dashboard-routing.ts
+++ b/src/app/components/dashboard/dashboard-routing.ts
@@ -6,6 +6,7 @@ import { StudentListComponent } from '../student-list/student-list.component';
 import { DEV_GUARD } from 'app/utils/dev-guard';
 import { DevTestComponent } from '../dev-test/dev-test.component';
 import type { Component, Type } from '@angular/core';
+import { ConfigurationComponent } from '../configuration/configuration.component';
 
 export interface CourseConfigurable {
     configureCourse(course: Course): Promise<void>;
@@ -36,6 +37,11 @@ export const TOKEN_ATM_DASHBOARD_ROUTES: TokenATMDashboardRoute[] = [
         name: 'Students',
         path: 'students',
         component: StudentListComponent
+    },
+    {
+        name: 'Configuration',
+        path: 'configuration',
+        component: ConfigurationComponent
     },
     {
         name: 'Dev-Test',

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -6,6 +6,7 @@ import { TokenATMConfigurationManagerService } from 'app/services/token-atm-conf
 import { BasicTokenOption } from 'app/token-options/basic-token-option';
 import { EarnByModuleTokenOption } from 'app/token-options/earn-by-module-token-option';
 import { getUnixTime } from 'date-fns';
+import { Base64 } from 'js-base64';
 
 @Component({
     selector: 'app-dev-test',
@@ -56,7 +57,9 @@ export class DevTestComponent {
                     name: 'Test Token Option Group ' + configuration.tokenOptionGroups.length.toString(),
                     id: configuration.nextFreeTokenOptionGroupId,
                     quiz_id: '',
-                    description: `Just a test <b>token option group</b> ${configuration.tokenOptionGroups.length}`,
+                    description: Base64.encode(
+                        `Just a test <b>token option group</b> ${configuration.tokenOptionGroups.length}`
+                    ),
                     is_published: false,
                     token_options: []
                 },
@@ -76,7 +79,7 @@ export class DevTestComponent {
                 type: 'basic',
                 id: configuration.nextFreeTokenOptionId,
                 name: `Test Token Option ${group.tokenOptions.length}`,
-                description: `Just a test <b>token option</b> ${group.tokenOptions.length}`,
+                description: Base64.encode(`Just a test <b>token option</b> ${group.tokenOptions.length}`),
                 token_balance_change: group.tokenOptions.length
             })
         );
@@ -149,7 +152,7 @@ export class DevTestComponent {
                 name: 'Pass Module',
                 id: configuration.nextFreeTokenOptionGroupId,
                 quiz_id: '',
-                description: 'Pass module with a specific grade threshold to get tokens!',
+                description: Base64.encode('Pass module with a specific grade threshold to get tokens!'),
                 is_published: true,
                 token_options: []
             },
@@ -161,7 +164,7 @@ export class DevTestComponent {
                 type: 'earn-by-module',
                 id: configuration.nextFreeTokenOptionId,
                 name: `getting tokens by passing module 1`,
-                description: `Passing Module 1 with a score no less than 70% of the total score`,
+                description: Base64.encode(`Passing Module 1 with a score no less than 70% of the total score`),
                 token_balance_change: 1,
                 module_name: 'Module 1',
                 module_id: '12612114',
@@ -174,7 +177,7 @@ export class DevTestComponent {
                 type: 'earn-by-module',
                 id: configuration.nextFreeTokenOptionId,
                 name: `getting tokens by passing module 2`,
-                description: `Passing Module 1 with a score no less than 80% of the total score`,
+                description: Base64.encode(`Passing Module 1 with a score no less than 80% of the total score`),
                 token_balance_change: 2,
                 module_name: 'Module 2',
                 module_id: '12612167',
@@ -189,7 +192,9 @@ export class DevTestComponent {
                 name: 'Basic Token Options (Testing)',
                 id: configuration.nextFreeTokenOptionGroupId,
                 quiz_id: '',
-                description: 'Test Token ATM with these basic token options whose requests are always get approved!',
+                description: Base64.encode(
+                    'Test Token ATM with these basic token options whose requests are always get approved!'
+                ),
                 is_published: true,
                 token_options: []
             },
@@ -201,7 +206,7 @@ export class DevTestComponent {
                 type: 'basic',
                 id: configuration.nextFreeTokenOptionId,
                 name: `basic token option 1`,
-                description: `Just a test <b>token option</b>`,
+                description: Base64.encode(`Just a test <b>token option</b>`),
                 token_balance_change: 100
             })
         );
@@ -210,7 +215,7 @@ export class DevTestComponent {
                 type: 'basic',
                 id: configuration.nextFreeTokenOptionId,
                 name: `basic token option 2`,
-                description: `Just a test <b>token option</b>`,
+                description: Base64.encode(`Just a test <b>token option</b>`),
                 token_balance_change: 0.5
             })
         );
@@ -219,7 +224,7 @@ export class DevTestComponent {
                 type: 'basic',
                 id: configuration.nextFreeTokenOptionId,
                 name: `basic token option 3`,
-                description: `Just a test <b>token option</b>`,
+                description: Base64.encode(`Just a test <b>token option</b>`),
                 token_balance_change: -100
             })
         );

--- a/src/app/components/student-record-display/student-record-display.component.ts
+++ b/src/app/components/student-record-display/student-record-display.component.ts
@@ -75,8 +75,8 @@ export class StudentRecordDisplayComponent {
     onGoBack(): void {
         this.goBack.next();
     }
+
     get processedRequests(): ProcessedRequest[] | undefined {
-        if (!this.studentRecord) return undefined;
-        return this.studentRecord.processedRequests.reverse();
+        return this.studentRecord?.processedRequests.slice(0).reverse();
     }
 }

--- a/src/app/data/token-atm-configuration.ts
+++ b/src/app/data/token-atm-configuration.ts
@@ -37,10 +37,8 @@ export class TokenATMConfiguration {
             typeof data['uid'] != 'string' ||
             (typeof data['suffix'] != 'undefined' && typeof data['suffix'] != 'string') ||
             (typeof data['description'] != 'undefined' && typeof data['description'] != 'string') ||
-            (typeof data['next_free_token_option_group_id'] != 'undefined' &&
-                typeof data['next_free_token_option_group_id'] != 'number') ||
-            (typeof data['next_free_token_option_id'] != 'undefined' &&
-                typeof data['next_free_token_option_id'] != 'number') ||
+            typeof data['next_free_token_option_group_id'] != 'number' ||
+            typeof data['next_free_token_option_id'] != 'number' ||
             typeof data['token_option_groups'] != 'object' ||
             !Array.isArray(data['token_option_groups']) ||
             typeof secureConfig['password'] != 'string' ||
@@ -50,7 +48,7 @@ export class TokenATMConfiguration {
         this._logAssignmentId = data['log_assignment_id'];
         this._uid = data['uid'];
         this._suffix = data['suffix'] ?? '';
-        this._description = data['description'] ?? '';
+        this._description = data['description'] ? Base64.decode(data['description']) : '';
         this.#encryptionPassword = secureConfig['password'];
         this.#encryptionSalt = Base64.toUint8Array(secureConfig['salt']);
         this._tokenOptionResolver = tokenOptionResolver;
@@ -153,7 +151,7 @@ export class TokenATMConfiguration {
             log_assignment_id: this.logAssignmentId,
             uid: this.uid,
             suffix: this.suffix,
-            description: this.description,
+            description: Base64.encode(this.description),
             next_free_token_option_group_id: this.nextFreeTokenOptionGroupId,
             next_free_token_option_id: this.nextFreeTokenOptionId,
             token_option_groups: this.tokenOptionGroups.map((entry) => entry.toJSON())

--- a/src/app/data/token-option-group.ts
+++ b/src/app/data/token-option-group.ts
@@ -1,5 +1,6 @@
 import type { TokenATMConfiguration } from './token-atm-configuration';
 import type { TokenOption } from '../token-options/token-option';
+import { Base64 } from 'js-base64';
 
 export class TokenOptionGroup {
     private _configuration: TokenATMConfiguration;
@@ -31,7 +32,7 @@ export class TokenOptionGroup {
         this._name = data['name'];
         this._id = data['id'];
         this._quizId = data['quiz_id'];
-        this._description = data['description'] ?? '';
+        this._description = data['description'] ? Base64.decode(data['description']) : '';
         this._isPublished = data['is_published'];
         this._tokenOptions = data['token_options'].map((entry) => tokenOptionResolver(this, entry));
     }
@@ -88,7 +89,7 @@ export class TokenOptionGroup {
             name: this.name,
             id: this.id,
             quiz_id: this.quizId,
-            description: this.description,
+            description: Base64.encode(this.description),
             is_published: this.isPublished,
             token_options: this.tokenOptions.map((entry) => entry.toJSON())
         };

--- a/src/app/quiz-questions/multiple-choice-question.ts
+++ b/src/app/quiz-questions/multiple-choice-question.ts
@@ -19,13 +19,9 @@ export class MultipleChoiceQuestion extends QuizQuestion {
     public override toJSON(): object {
         const answers = this.options.map((optionText) => {
             return {
-                answer_text: optionText,
-                answer_weight: 0
+                answer_text: optionText
             };
         });
-        if (answers[0]) {
-            answers[0].answer_weight = 100;
-        }
         return {
             ...super.toJSON(),
             answers: answers

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -77,27 +77,31 @@ export class CanvasService {
 
     private async safeGuardForAssignment(courseId: string, assignmentId: string): Promise<void> {
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}`);
-        if (!data.name.includes('Token ATM')) throw new Error('Safe guard for assignment is violated!');
+        if (!data.name.includes('Token ATM') || data.id != assignmentId)
+            throw new Error('Safe guard for assignment is violated!');
     }
 
     private async safeGuardForQuiz(courseId: string, quizId: string): Promise<void> {
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`);
-        if (!data.title.includes('Token ATM')) throw new Error('Safe guard for quiz is violated!');
+        if (!data.title.includes('Token ATM') || data.id != quizId) throw new Error('Safe guard for quiz is violated!');
     }
 
     private async safeGuardForAssignmentGroup(courseId: string, assignmentGroupId: string): Promise<void> {
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/assignment_groups/${assignmentGroupId}`);
-        if (!data.name.includes('Token ATM')) throw new Error('Safe guard for assignment group is violated!');
+        if (!data.name.includes('Token ATM') || data.id != assignmentGroupId)
+            throw new Error('Safe guard for assignment group is violated!');
     }
 
     private async safeGuardForModule(courseId: string, moduleId: string): Promise<void> {
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/modules/${moduleId}`);
-        if (!data.name.includes('Token ATM')) throw new Error('Safe guard for module is violated!');
+        if (!data.name.includes('Token ATM') || data.id != moduleId)
+            throw new Error('Safe guard for module is violated!');
     }
 
     private async safeGuardForPage(courseId: string, pageId: string): Promise<void> {
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/pages/${pageId}`);
-        if (!data.title.includes('Token ATM')) throw new Error('Safe guard for page is violated!');
+        if (!data.title.includes('Token ATM') || data.page_id != pageId)
+            throw new Error('Safe guard for page is violated!');
     }
 
     public async getCourses(
@@ -772,6 +776,7 @@ export class CanvasService {
                     quiz_type: quizType,
                     assignment_group_id: assignmentGroupId,
                     allowed_attempts: 100, // TODO: temporarily apply a constraint for quiz submission attempt before implementing student record pagination
+                    points_possible: 0,
                     published: false
                 }
             }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -657,12 +657,10 @@ export class CanvasService {
                 if (!moduleItem.contentId) continue;
                 switch (moduleItem.type) {
                     case 'Assignment': {
-                        await this.safeGuardForAssignment(courseId, moduleItem.contentId);
                         this.deleteAssignment(courseId, moduleItem.contentId);
                         break;
                     }
                     case 'Quiz': {
-                        await this.safeGuardForQuiz(courseId, moduleItem.contentId);
                         await this.deleteQuiz(courseId, moduleItem.contentId);
                         break;
                     }
@@ -773,7 +771,7 @@ export class CanvasService {
                     description: description,
                     quiz_type: quizType,
                     assignment_group_id: assignmentGroupId,
-                    allowed_attempts: -1,
+                    allowed_attempts: 100, // TODO: temporarily apply a constraint for quiz submission attempt before implementing student record pagination
                     published: false
                 }
             }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -75,6 +75,31 @@ export class CanvasService {
         });
     }
 
+    private async safeGuardForAssignment(courseId: string, assignmentId: string): Promise<void> {
+        const data = await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}`);
+        if (!data.name.includes('Token ATM')) throw new Error('Safe guard for assignment is violated!');
+    }
+
+    private async safeGuardForQuiz(courseId: string, quizId: string): Promise<void> {
+        const data = await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`);
+        if (!data.title.includes('Token ATM')) throw new Error('Safe guard for quiz is violated!');
+    }
+
+    private async safeGuardForAssignmentGroup(courseId: string, assignmentGroupId: string): Promise<void> {
+        const data = await this.apiRequest(`/api/v1/courses/${courseId}/assignment_groups/${assignmentGroupId}`);
+        if (!data.name.includes('Token ATM')) throw new Error('Safe guard for assignment group is violated!');
+    }
+
+    private async safeGuardForModule(courseId: string, moduleId: string): Promise<void> {
+        const data = await this.apiRequest(`/api/v1/courses/${courseId}/modules/${moduleId}`);
+        if (!data.name.includes('Token ATM')) throw new Error('Safe guard for module is violated!');
+    }
+
+    private async safeGuardForPage(courseId: string, pageId: string): Promise<void> {
+        const data = await this.apiRequest(`/api/v1/courses/${courseId}/pages/${pageId}`);
+        if (!data.title.includes('Token ATM')) throw new Error('Safe guard for page is violated!');
+    }
+
     public async getCourses(
         enrollmentType: 'teacher' | 'ta' = 'teacher',
         enrollmentState: 'active' | 'invited_or_pending' = 'active'
@@ -128,6 +153,7 @@ export class CanvasService {
     }
 
     public async deletePage(courseId: string, pageId: string): Promise<void> {
+        await this.safeGuardForPage(courseId, pageId);
         await this.apiRequest(`/api/v1/courses/${courseId}/pages/${pageId}`, {
             method: 'delete'
         });
@@ -163,6 +189,7 @@ export class CanvasService {
         notifyUpdate = false,
         published = false
     ): Promise<string> {
+        await this.safeGuardForPage(courseId, pageId);
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/pages/${pageId}`, {
             method: 'put',
             data: {
@@ -248,6 +275,7 @@ export class CanvasService {
         assignmentId: string,
         commentId: string
     ): Promise<void> {
+        await this.safeGuardForAssignment(courseId, assignmentId);
         await this.apiRequest(
             `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}/comments/${commentId}`,
             {
@@ -262,6 +290,7 @@ export class CanvasService {
         assignmentId: string,
         comment: string
     ): Promise<SubmissionComment> {
+        await this.safeGuardForAssignment(courseId, assignmentId);
         const data = await this.apiRequest(
             `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`,
             {
@@ -295,6 +324,7 @@ export class CanvasService {
         assignmentId: string,
         commentId: string
     ): Promise<void> {
+        await this.safeGuardForAssignment(courseId, assignmentId);
         await this.apiRequest(
             `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}/comments/${commentId}`,
             {
@@ -310,6 +340,7 @@ export class CanvasService {
         commentId: string,
         comment: string
     ): Promise<SubmissionComment> {
+        await this.safeGuardForAssignment(courseId, assignmentId);
         const data = await this.apiRequest(
             `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}/comments/${commentId}`,
             {
@@ -328,6 +359,7 @@ export class CanvasService {
         assignmentId: string,
         score: number
     ): Promise<void> {
+        await this.safeGuardForAssignment(courseId, assignmentId);
         await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`, {
             method: 'put',
             data: {
@@ -345,6 +377,7 @@ export class CanvasService {
         score: number,
         newComment: string
     ): Promise<SubmissionComment> {
+        await this.safeGuardForAssignment(courseId, assignmentId);
         const data = await this.apiRequest(
             `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`,
             {
@@ -574,6 +607,7 @@ export class CanvasService {
     }
 
     public async deleteAssignment(courseId: string, assignmentId: string): Promise<void> {
+        await this.safeGuardForAssignment(courseId, assignmentId);
         await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}`, {
             method: 'delete'
         });
@@ -592,6 +626,7 @@ export class CanvasService {
     }
 
     public async publishModule(courseId: string, moduleId: string): Promise<string> {
+        await this.safeGuardForModule(courseId, moduleId);
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/modules/${moduleId}`, {
             method: 'put',
             data: {
@@ -604,6 +639,7 @@ export class CanvasService {
     }
 
     public async deleteModule(courseId: string, moduleId: string, deleteAllModuleItems = false): Promise<void> {
+        await this.safeGuardForModule(courseId, moduleId);
         if (deleteAllModuleItems) {
             const moduleItems = new PaginatedResult<ModuleItemInfo>(
                 await this.rawAPIRequest(`/api/v1/courses/${courseId}/modules/${moduleId}/items`, {
@@ -621,10 +657,12 @@ export class CanvasService {
                 if (!moduleItem.contentId) continue;
                 switch (moduleItem.type) {
                     case 'Assignment': {
+                        await this.safeGuardForAssignment(courseId, moduleItem.contentId);
                         this.deleteAssignment(courseId, moduleItem.contentId);
                         break;
                     }
                     case 'Quiz': {
+                        await this.safeGuardForQuiz(courseId, moduleItem.contentId);
                         await this.deleteQuiz(courseId, moduleItem.contentId);
                         break;
                     }
@@ -655,6 +693,7 @@ export class CanvasService {
         type: 'Assignment' | 'Quiz',
         contentId: string
     ): Promise<string> {
+        await this.safeGuardForModule(courseId, moduleId);
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/modules/${moduleId}/items`, {
             method: 'post',
             data: {
@@ -695,6 +734,7 @@ export class CanvasService {
     }
 
     public async deleteAssignmentGroup(courseId: string, assignmentGroupId: string): Promise<void> {
+        await this.safeGuardForAssignmentGroup(courseId, assignmentGroupId);
         await this.apiRequest(`/api/v1/courses/${courseId}/assignment_groups/${assignmentGroupId}`, {
             method: 'delete'
         });
@@ -712,6 +752,7 @@ export class CanvasService {
     }
 
     public async deleteQuiz(courseId: string, quizId: string): Promise<void> {
+        await this.safeGuardForQuiz(courseId, quizId);
         await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`, {
             method: 'delete'
         });
@@ -751,6 +792,7 @@ export class CanvasService {
         published = true,
         notifyUpdate = false
     ): Promise<boolean> {
+        await this.safeGuardForQuiz(courseId, quizId);
         try {
             await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`, {
                 method: 'put',
@@ -775,6 +817,7 @@ export class CanvasService {
         description?: string,
         notifyUpdate = false
     ): Promise<string> {
+        await this.safeGuardForQuiz(courseId, quizId);
         const result = await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`, {
             method: 'put',
             data: {
@@ -789,6 +832,7 @@ export class CanvasService {
     }
 
     public async changeQuizLockDate(courseId: string, quizId: string, lockDate: Date | null): Promise<void> {
+        await this.safeGuardForQuiz(courseId, quizId);
         await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`, {
             method: 'put',
             data: {
@@ -800,6 +844,7 @@ export class CanvasService {
     }
 
     public async clearQuizQuestions(courseId: string, quizId: string): Promise<void> {
+        await this.safeGuardForQuiz(courseId, quizId);
         const quizQuestionIds = new PaginatedResult<string>(
             await this.rawAPIRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions`, {
                 params: {
@@ -820,6 +865,7 @@ export class CanvasService {
     }
 
     public async createQuizQuestions(courseId: string, quizId: string, quizQuestions: QuizQuestion[]): Promise<void> {
+        await this.safeGuardForQuiz(courseId, quizId);
         for (const quizQuestion of quizQuestions) {
             await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions`, {
                 method: 'post',

--- a/src/app/token-options/token-option.ts
+++ b/src/app/token-options/token-option.ts
@@ -1,3 +1,4 @@
+import { Base64 } from 'js-base64';
 import type { TokenOptionGroup } from '../data/token-option-group';
 
 export abstract class TokenOption {
@@ -22,7 +23,7 @@ export abstract class TokenOption {
         this._type = data['type'];
         this._id = data['id'];
         this._name = data['name'];
-        this._description = data['description'] ?? '';
+        this._description = data['description'] ? Base64.decode(data['description']) : '';
         this._tokenBalanceChange = data['token_balance_change'];
     }
 
@@ -61,7 +62,7 @@ export abstract class TokenOption {
             type: this.type,
             id: this.id,
             name: this.name,
-            description: this.description,
+            description: Base64.encode(this.description),
             token_balance_change: this.tokenBalanceChange
         };
     }


### PR DESCRIPTION
Note: This pull request contains breaking changes. You need to manually remove Token ATM from previous courses (delete two pages prefixed with Token ATM, one assignment group prefixed with Token ATM, and one module prefixed with Token ATM). To conduct the live testing, you **have to** merge this pull request since UCI Canvas have special behaviors on pages (add a script tag), which breaks the original configuration resolving process.

Following features are added:

1. Safety Guard: For any operation that could cause change on Canvas, Token ATM will check whether the object being operated on has "Token ATM" in their name. If not, an error will be thrown. This is to prevent Token ATM from destroying the course.
2. Quiz Attempt Limit: Currently, each quiz is limited to only have 100 attempts. This is to prevent the comment length exceeeds the maximum length that Canvas supports. Pagination will be implemented to resolve this issue.
3. Configuration page: A configuration page is added. A teacher could now create a testing configuration from that page. When creating the testing configuration, the teacher will be prompt for the module name of the course preparation module. Also, there is a button to delete all Token ATM related content from the current course.