### PR TITLE
Support searching course by name & term

### DIFF
--- a/src/app/components/course-selection/course-selection.component.html
+++ b/src/app/components/course-selection/course-selection.component.html
@@ -2,15 +2,27 @@
     <ngb-toast *ngIf="loading; else courseSelectionPanel" [autohide]="false">
         Token ATM is retrieving information from Canvas. Please wait...
     </ngb-toast>
-    <ng-template #courseSelectionPanel
-        ><div class="container text-center align-items-center">
+    <ng-template #courseSelectionPanel>
+        <div class="container text-center align-items-center">
             <h1 class="text-primary">Welcome to Token ATM</h1>
             <p>Please select a course</p>
+            <app-form-item
+                class="my-2"
+                [info]="courseItemInfo"
+                [data]="''"
+                (dataChange)="onCourseNameChange($event)"
+            ></app-form-item>
+            <app-form-item
+                class="my-2"
+                [info]="termItemInfo"
+                [data]="''"
+                (dataChange)="onTermNameChange($event)"
+            ></app-form-item>
             <h2 class="my-4">Courses you’re enrolled in as a Teacher</h2>
             <div class="row gy-3">
                 <app-course-info-item
                     class="col-auto"
-                    *ngFor="let course of coursesEnrolledAsTeacher"
+                    *ngFor="let course of coursesAsTeacher"
                     [course]="course"
                 ></app-course-info-item>
             </div>
@@ -18,7 +30,7 @@
             <div class="row gy-3">
                 <app-course-info-item
                     class="col-auto"
-                    *ngFor="let course of coursesEnrolledAsTA"
+                    *ngFor="let course of coursesAsTA"
                     [course]="course"
                 ></app-course-info-item>
             </div>

--- a/src/app/components/course-selection/course-selection.component.ts
+++ b/src/app/components/course-selection/course-selection.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import type { Course } from 'app/data/course';
+import { FormItemInfo } from 'app/data/form-item-info';
 import { CanvasService } from 'app/services/canvas.service';
 import { DataConversionHelper } from 'app/utils/data-conversion-helper';
 
@@ -12,6 +13,12 @@ export class CourseSelectionComponent implements OnInit {
     loading = true;
     coursesEnrolledAsTeacher: Course[] = [];
     coursesEnrolledAsTA: Course[] = [];
+
+    courseItemInfo = new FormItemInfo('courseName', 'Search for Course', 'text');
+    courseName = '';
+
+    termItemInfo = new FormItemInfo('termName', 'Search for Term', 'text');
+    termName = '';
 
     constructor(@Inject(CanvasService) private canvasService: CanvasService) {}
 
@@ -28,6 +35,30 @@ export class CourseSelectionComponent implements OnInit {
         );
         this.coursesEnrolledAsTA = await DataConversionHelper.convertAsyncIterableToList(
             await this.canvasService.getCourses('ta', 'active')
+        );
+    }
+
+    onCourseNameChange(data: string | null): void {
+        this.courseName = data ?? '';
+    }
+
+    onTermNameChange(data: string | null): void {
+        this.termName = data ?? '';
+    }
+
+    get coursesAsTeacher(): Course[] {
+        return this.coursesEnrolledAsTeacher.filter(
+            (course) =>
+                course.name.toLowerCase().indexOf(this.courseName.toLowerCase()) != -1 &&
+                course.term.toLowerCase().indexOf(this.termName.toLowerCase()) != -1
+        );
+    }
+
+    get coursesAsTA(): Course[] {
+        return this.coursesEnrolledAsTA.filter(
+            (course) =>
+                course.name.toLowerCase().indexOf(this.courseName.toLowerCase()) != -1 &&
+                course.term.toLowerCase().indexOf(this.termName.toLowerCase()) != -1
         );
     }
 }


### PR DESCRIPTION
### User Story

As a teacher, I want to be able to search a course by its name and/or its term in Token ATM so that I can easily locate the course I want to run Token ATM on.

### Acceptance Criteria 

Given that a teacher has provided valid credentials, when the teacher provides searching keyword for the course name and/or the term name, then the courses shown in front of the teacher should be filtered based on the provided keywords.