### PR TITLE
User Story: create configuration

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -55,6 +55,7 @@ import { SpendForLabDataTokenOptionFieldComponent } from './components/form-fiel
 import { SpendForAssignmentResubmissionTokenOptionFieldComponent } from './components/form-fields/token-option-fields/spend-for-assignment-resubmission-token-option-field/spend-for-assignment-resubmission-token-option-field.component';
 import { WithdrawLabDataTokenOptionFieldComponent } from './components/form-fields/token-option-fields/withdraw-lab-data-token-option-field/withdraw-lab-data-token-option-field.component';
 import { WithdrawAssignmentResubmissionOptionFieldComponent } from './components/form-fields/token-option-fields/withdraw-assignment-resubmission-option-field/withdraw-assignment-resubmission-option-field.component';
+import { CreateConfigurationModalComponent } from './components/create-configuration-modal/create-configuration-modal.component';
 
 @NgModule({
     declarations: [
@@ -89,7 +90,8 @@ import { WithdrawAssignmentResubmissionOptionFieldComponent } from './components
         SpendForLabDataTokenOptionFieldComponent,
         SpendForAssignmentResubmissionTokenOptionFieldComponent,
         WithdrawLabDataTokenOptionFieldComponent,
-        WithdrawAssignmentResubmissionOptionFieldComponent
+        WithdrawAssignmentResubmissionOptionFieldComponent,
+        CreateConfigurationModalComponent
     ],
     imports: [
         BrowserModule,

--- a/src/app/components/course-info-item/course-info-item.component.ts
+++ b/src/app/components/course-info-item/course-info-item.component.ts
@@ -1,5 +1,4 @@
-import { Component, Inject, Input } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import type { Course } from 'app/data/course';
 
 @Component({
@@ -9,11 +8,10 @@ import type { Course } from 'app/data/course';
 })
 export class CourseInfoItemComponent {
     @Input() course: Course | undefined;
+    @Output() selectCourse = new EventEmitter<Course>();
 
-    constructor(@Inject(Router) private router: Router) {}
-
-    onSelectCourse() {
+    onSelectCourse(): void {
         if (!this.course) return;
-        this.router.navigateByUrl('/dashboard', { state: this.course });
+        this.selectCourse.emit(this.course);
     }
 }

--- a/src/app/components/course-selection/course-selection.component.html
+++ b/src/app/components/course-selection/course-selection.component.html
@@ -23,6 +23,7 @@
                 class="col-auto"
                 *ngFor="let course of coursesAsTeacher"
                 [course]="course"
+                (selectCourse)="onSelectCourse($event)"
             ></app-course-info-item>
         </div>
         <h2 class="my-4">Courses you’re enrolled in as a TA</h2>
@@ -31,6 +32,7 @@
                 class="col-auto"
                 *ngFor="let course of coursesAsTA"
                 [course]="course"
+                (selectCourse)="onSelectCourse($event)"
             ></app-course-info-item>
         </div>
     </div>

--- a/src/app/components/create-configuration-modal/create-configuration-modal.component.html
+++ b/src/app/components/create-configuration-modal/create-configuration-modal.component.html
@@ -1,0 +1,36 @@
+<div class="modal-header">
+    <h4 class="modal-title pull-left">Create Token ATM Configuration</h4>
+    <button
+        type="button"
+        class="btn-close close pull-right"
+        aria-label="Close"
+        [disabled]="isProcessing"
+        (click)="onCancel()"
+    >
+        <span aria-hidden="true" class="visually-hidden">&times;</span>
+    </button>
+</div>
+<div class="modal-body message">
+    <p>
+        The course you selected contains no Token ATM configuration, or the Token ATM configuration for this course is
+        invalid. Do you want to create a new configuration?
+    </p>
+    <p>Note: For now, you cannot change it from Token ATM Dashboard once you created it.</p>
+    <!-- TODO: support modification -->
+    <app-string-input-field
+        #suffixFieldComponent
+        label="The suffix of Assignment Group & Module name"
+    ></app-string-input-field>
+    <app-string-textarea-field
+        #descriptionFieldComponent
+        label="Description of Token ATM Log Assignment"
+    ></app-string-textarea-field>
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-outline-secondary me-4" [disabled]="isProcessing" (click)="onCancel()">
+        Cancel
+    </button>
+    <button type="button" class="btn btn-success" (click)="onCreateConfiguration()" [disabled]="isProcessing">
+        Create
+    </button>
+</div>

--- a/src/app/components/create-configuration-modal/create-configuration-modal.component.spec.ts
+++ b/src/app/components/create-configuration-modal/create-configuration-modal.component.spec.ts
@@ -1,0 +1,22 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { CreateConfigurationModalComponent } from './create-configuration-modal.component';
+
+// describe('CreateConfigurationModalComponent', () => {
+//     let component: CreateConfigurationModalComponent;
+//     let fixture: ComponentFixture<CreateConfigurationModalComponent>;
+
+//     beforeEach(async () => {
+//         await TestBed.configureTestingModule({
+//             declarations: [CreateConfigurationModalComponent]
+//         }).compileComponents();
+
+//         fixture = TestBed.createComponent(CreateConfigurationModalComponent);
+//         component = fixture.componentInstance;
+//         fixture.detectChanges();
+//     });
+
+//     it('should create', () => {
+//         expect(component).toBeTruthy();
+//     });
+// });

--- a/src/app/components/create-configuration-modal/create-configuration-modal.component.ts
+++ b/src/app/components/create-configuration-modal/create-configuration-modal.component.ts
@@ -1,0 +1,40 @@
+import { Component, Inject, Input, ViewChild } from '@angular/core';
+import type { Course } from 'app/data/course';
+import { TokenATMConfigurationManagerService } from 'app/services/token-atm-configuration-manager.service';
+import type { StringInputFieldComponent } from '../form-fields/string-input-field/string-input-field.component';
+import type { StringTextareaFieldComponent } from '../form-fields/string-textarea-field/string-textarea-field.component';
+
+@Component({
+    selector: 'app-create-configuration-modal',
+    templateUrl: './create-configuration-modal.component.html',
+    styleUrls: ['./create-configuration-modal.component.sass']
+})
+export class CreateConfigurationModalComponent {
+    isProcessing = false;
+    @Input() onResolve?: (reuslt: boolean) => void;
+    @Input() course?: Course;
+
+    @ViewChild('suffixFieldComponent', { static: true }) private _suffixFieldComponent?: StringInputFieldComponent;
+    @ViewChild('descriptionFieldComponent', { static: true })
+    private _descriptionFieldComponent?: StringTextareaFieldComponent;
+
+    constructor(
+        @Inject(TokenATMConfigurationManagerService)
+        private configurationManagerService: TokenATMConfigurationManagerService
+    ) {}
+
+    onCancel() {
+        if (this.onResolve) this.onResolve(false);
+    }
+
+    async onCreateConfiguration(): Promise<void> {
+        if (!this.course || !this._suffixFieldComponent || !this._descriptionFieldComponent || !this.onResolve) return;
+        this.isProcessing = true;
+        await this.configurationManagerService.createTokenATMConfiguration(
+            this.course,
+            await this._suffixFieldComponent.getValue(),
+            await this._descriptionFieldComponent.getValue()
+        );
+        this.onResolve(true);
+    }
+}


### PR DESCRIPTION
### User Story

As a teacher, I want Token ATM to be able to create a new configuration for a course that has never been setup for Token ATM before so that I can use Token ATM on new courses.

### Acceptance Criteria

Given that a teacher has provided valid credentials to Token ATM and has selected a course, when the selected course don't have a valid Token ATM configuration, then a modal should be shown to allow the teacher to create a new Token ATM configuration for the selected course.