### PR TITLE
Bugfix for unexpected Canvas behaviors

### DIFF
--- a/src/app/components/student-list/student-list.component.ts
+++ b/src/app/components/student-list/student-list.component.ts
@@ -128,7 +128,8 @@ export class StudentListComponent implements CourseConfigurable {
         this.individaulStudentRecordDisplay.configureStudent(this.configuration, student);
     }
 
-    onGoBack() {
+    async onGoBack() {
         this.isShowingIndividualStudent = false;
+        await this.getStudentGrades();
     }
 }

--- a/src/app/components/student-list/student-list.component.ts
+++ b/src/app/components/student-list/student-list.component.ts
@@ -94,10 +94,15 @@ export class StudentListComponent implements CourseConfigurable {
     private async getStudentGrades(): Promise<void> {
         if (!this.course || !this.configuration || !this.students) return;
         this.studentGrades = undefined;
+        const curPageStudents = Array.from(this.students).map((entry: Student) => entry.id);
+        if (curPageStudents.length == 0) {
+            this.studentGrades = new Map<string, number>();
+            return;
+        }
         this.studentGrades = await this.canvasService.getStudentsGrades(
             this.course.id,
             this.configuration.logAssignmentId,
-            Array.from(this.students).map((entry: Student) => entry.id)
+            curPageStudents
         );
     }
     //Go back to the previous students information page

--- a/src/app/data/student-record.ts
+++ b/src/app/data/student-record.ts
@@ -62,6 +62,10 @@ export class StudentRecord {
         return this._processedRequests;
     }
 
+    public get submittedRequestCnt(): number {
+        return Array.from(this._processedAttemptsMap.values()).reduce((a, b) => a + b, 0);
+    }
+
     public logProcessedRequest(processedRequest: ProcessedRequest) {
         this._tokenBalance += processedRequest.tokenBalanceChange;
         if (processedRequest.tokenOptionGroupId != undefined) {

--- a/src/app/request-handlers/guards/no-assignment-submission-guard.ts
+++ b/src/app/request-handlers/guards/no-assignment-submission-guard.ts
@@ -6,7 +6,7 @@ export class NoAssignmentSubmissionGuard extends RequestHandlerGuard {
         private courseId: string,
         private assignmentId: string,
         private studentId: string,
-        private overrideTitle: string,
+        private overrideTitlePrefix: string,
         private lockDate: Date,
         private canvasService: CanvasService
     ) {
@@ -14,24 +14,18 @@ export class NoAssignmentSubmissionGuard extends RequestHandlerGuard {
     }
 
     public async check(onReject: (message: string) => Promise<void>): Promise<void> {
-        await this.canvasService.removeStudentFromAssignmentOverrideByOverrideTitle(
-            this.courseId,
-            this.assignmentId,
-            this.overrideTitle,
-            this.studentId,
-            this.lockDate
-        );
+        await this.canvasService.deleteAssignmentOverrideForStudent(this.courseId, this.assignmentId, this.studentId);
         const submission = await this.canvasService.getAssignmentSubmission(
             this.courseId,
             this.assignmentId,
             this.studentId
         );
         if (submission.workflowState != 'unsubmitted') {
-            await this.canvasService.addStudentToAssignmentOverrideByOverrideTitle(
+            await this.canvasService.createAssignmentOverrideForStudent(
                 this.courseId,
                 this.assignmentId,
-                this.overrideTitle,
                 this.studentId,
+                this.overrideTitlePrefix,
                 this.lockDate
             );
             onReject('You have already made a submission to the assignment.');

--- a/src/app/request-handlers/spend-for-assignment-resubmission-request-handler.ts
+++ b/src/app/request-handlers/spend-for-assignment-resubmission-request-handler.ts
@@ -33,49 +33,25 @@ export class SpendForAssignmentResubmissionRequestHandler extends RequestHandler
             new SufficientTokenBalanceGuard(studentRecord.tokenBalance, request.tokenOption.tokenBalanceChange)
         ]);
         await guardExecutor.check();
-        let message = guardExecutor.message ?? '';
-        let isRejected = guardExecutor.isRejected;
         if (!guardExecutor.isRejected) {
-            const override = await this.canvasService.getAssignmentOverrideByTitle(
+            await this.canvasService.createAssignmentOverrideForStudent(
                 configuration.course.id,
                 request.tokenOption.assignmentId,
-                `Token ATM - ${configuration.uid}`
+                request.student.id,
+                `Token ATM - ${configuration.uid}`,
+                request.tokenOption.newDueTime
             );
-            if (!override) {
-                await this.canvasService.createAssignmentOverride(
-                    configuration.course.id,
-                    request.tokenOption.assignmentId,
-                    `Token ATM - ${configuration.uid}`,
-                    [request.student.id],
-                    request.tokenOption.newDueTime
-                );
-            } else {
-                if (override.studentIds.includes(request.student.id)) {
-                    message =
-                        'There is already an assignment override on this assignment for this student. It could be caused by a network error when processing this request. Your teacher should already have this issue handled by manually adjusting your token balance. Please check your request history.';
-                    isRejected = true;
-                } else
-                    await this.canvasService.updateAssignmentOverride(
-                        configuration.course.id,
-                        request.tokenOption.assignmentId,
-                        override.id,
-                        `Token ATM - ${configuration.uid}`,
-                        override.studentIds.concat(request.student.id),
-                        request.tokenOption.newDueTime
-                    );
-                // TODO: failure to add means leftover?
-            }
         }
         return new ProcessedRequest(
             configuration,
             request.tokenOption.id,
             request.tokenOption.name,
             request.student,
-            !isRejected,
+            !guardExecutor.isRejected,
             request.submittedTime,
             new Date(),
-            isRejected ? 0 : request.tokenOption.tokenBalanceChange,
-            message,
+            guardExecutor.isRejected ? 0 : request.tokenOption.tokenBalanceChange,
+            guardExecutor.message ?? '',
             request.tokenOption.group.id
         );
     }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -7,7 +7,7 @@ import { SubmissionComment } from 'app/data/submission-comment';
 import { PaginatedResult } from 'app/utils/paginated-result';
 import { PaginatedView } from 'app/utils/paginated-view';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
-import { formatISO, parseISO } from 'date-fns';
+import { compareAsc, formatISO, parseISO } from 'date-fns';
 import { AxiosService } from './axios.service';
 import { User } from 'app/data/user';
 import type { QuizQuestion } from 'app/quiz-questions/quiz-question';
@@ -35,6 +35,8 @@ type StudentGradeInfo = {
     providedIn: 'root'
 })
 export class CanvasService {
+    private static ASSIGNMENT_OVERRIDE_MAX_SIZE = 35;
+
     #url?: string;
     #accessToken?: string;
 
@@ -908,126 +910,225 @@ export class CanvasService {
         return Quiz.deserialize(data);
     }
 
-    public async getAssignmentOverrideByTitle(
+    // public async getAssignmentOverrideByTitle(
+    //     courseId: string,
+    //     assignmentId: string,
+    //     overrideTitle: string
+    // ): Promise<AssignmentOverride | undefined> {
+    //     const data = new PaginatedResult<AssignmentOverride>(
+    //         await this.rawAPIRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides`),
+    //         async (url: string) => await this.paginatedRequestHandler(url),
+    //         (data: unknown[]) => data.map((entry) => AssignmentOverride.deserialize(entry))
+    //     );
+    //     for await (const override of data) {
+    //         if (override.title == overrideTitle) {
+    //             return override;
+    //         }
+    //     }
+    //     return undefined;
+    // }
+
+    // public async createAssignmentOverride(
+    //     courseId: string,
+    //     assignmentId: string,
+    //     title: string,
+    //     studentIds: string[],
+    //     lockDate: Date
+    // ): Promise<AssignmentOverride> {
+    //     return AssignmentOverride.deserialize(
+    //         await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides`, {
+    //             method: 'post',
+    //             data: {
+    //                 assignment_override: {
+    //                     student_ids: studentIds,
+    //                     title: title,
+    //                     lock_at: formatISO(lockDate)
+    //                 }
+    //             }
+    //         })
+    //     );
+    // }
+
+    // public async updateAssignmentOverride(
+    //     courseId: string,
+    //     assignmentId: string,
+    //     overrideId: string,
+    //     title: string,
+    //     studentIds: string[],
+    //     lockDate: Date
+    // ): Promise<AssignmentOverride> {
+    //     return AssignmentOverride.deserialize(
+    //         await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides/${overrideId}`, {
+    //             method: 'put',
+    //             data: {
+    //                 assignment_override: {
+    //                     student_ids: studentIds,
+    //                     title: title,
+    //                     lock_at: formatISO(lockDate)
+    //                 }
+    //             }
+    //         })
+    //     );
+    // }
+
+    // public async deleteAssignmentOverride(courseId: string, assignmentId: string, overrideId: string): Promise<void> {
+    //     await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides/${overrideId}`, {
+    //         method: 'delete'
+    //     });
+    // }
+
+    // public async addStudentToAssignmentOverrideByOverrideTitle(
+    //     courseId: string,
+    //     assignmentId: string,
+    //     overrideTitle: string,
+    //     studentId: string,
+    //     lockDate: Date
+    // ): Promise<[AssignmentOverride, boolean]> {
+    //     const override = await this.getAssignmentOverrideByTitle(courseId, assignmentId, overrideTitle);
+    //     if (!override) {
+    //         return [
+    //             await this.createAssignmentOverride(courseId, assignmentId, overrideTitle, [studentId], lockDate),
+    //             true
+    //         ];
+    //     }
+    //     if (override.studentIds.includes(studentId)) return [override, false];
+    //     override.studentIds.push(studentId);
+    //     return [
+    //         await this.updateAssignmentOverride(
+    //             courseId,
+    //             assignmentId,
+    //             override.id,
+    //             overrideTitle,
+    //             override.studentIds,
+    //             lockDate
+    //         ),
+    //         true
+    //     ];
+    // }
+
+    // public async removeStudentFromAssignmentOverrideByOverrideTitle(
+    //     courseId: string,
+    //     assignmentId: string,
+    //     overrideTitle: string,
+    //     studentId: string,
+    //     lockDate: Date
+    // ): Promise<boolean> {
+    //     const override = await this.getAssignmentOverrideByTitle(courseId, assignmentId, overrideTitle);
+    //     if (!override || !override.studentIds.includes(studentId)) {
+    //         return false;
+    //     }
+    //     if (override.studentIds.length == 1) {
+    //         await this.deleteAssignmentOverride(courseId, assignmentId, override.id);
+    //         return true;
+    //     }
+    //     override.studentIds.splice(override.studentIds.indexOf(studentId), 1);
+    //     await this.updateAssignmentOverride(
+    //         courseId,
+    //         assignmentId,
+    //         override.id,
+    //         overrideTitle,
+    //         override.studentIds,
+    //         lockDate
+    //     );
+    //     return true;
+    // }
+
+    public async getAssignmentOverrides(
         courseId: string,
-        assignmentId: string,
-        overrideTitle: string
-    ): Promise<AssignmentOverride | undefined> {
-        const data = new PaginatedResult<AssignmentOverride>(
+        assignmentId: string
+    ): Promise<PaginatedResult<AssignmentOverride>> {
+        return new PaginatedResult<AssignmentOverride>(
             await this.rawAPIRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides`),
             async (url: string) => await this.paginatedRequestHandler(url),
             (data: unknown[]) => data.map((entry) => AssignmentOverride.deserialize(entry))
         );
-        for await (const override of data) {
-            if (override.title == overrideTitle) {
-                return override;
-            }
-        }
-        return undefined;
     }
 
-    public async createAssignmentOverride(
+    public async createAssignmentOverrideForStudent(
         courseId: string,
         assignmentId: string,
-        title: string,
-        studentIds: string[],
+        studentId: string,
+        overrideTitlePrefix: string,
         lockDate: Date
-    ): Promise<AssignmentOverride> {
-        return AssignmentOverride.deserialize(
+    ): Promise<boolean> {
+        let targetOverride: AssignmentOverride | undefined = undefined,
+            titleCnt = 0;
+        for await (const override of await this.getAssignmentOverrides(courseId, assignmentId)) {
+            const data = override.title.split(' - ');
+            if (data.length >= 3) {
+                titleCnt = parseInt(data[2] as string) + 1;
+            }
+            if (override.studentIds.includes(studentId)) return false;
+            if (
+                override.studentIds.length >= CanvasService.ASSIGNMENT_OVERRIDE_MAX_SIZE ||
+                override.lockAt == undefined ||
+                compareAsc(override.lockAt, lockDate) != 0
+            )
+                continue;
+            targetOverride = override;
+        }
+        if (!targetOverride) {
             await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides`, {
                 method: 'post',
                 data: {
                     assignment_override: {
-                        student_ids: studentIds,
-                        title: title,
+                        student_ids: [studentId],
+                        title: `${overrideTitlePrefix} - ${titleCnt}`,
                         lock_at: formatISO(lockDate)
                     }
                 }
-            })
-        );
-    }
-
-    public async updateAssignmentOverride(
-        courseId: string,
-        assignmentId: string,
-        overrideId: string,
-        title: string,
-        studentIds: string[],
-        lockDate: Date
-    ): Promise<AssignmentOverride> {
-        return AssignmentOverride.deserialize(
-            await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides/${overrideId}`, {
-                method: 'put',
-                data: {
-                    assignment_override: {
-                        student_ids: studentIds,
-                        title: title,
-                        lock_at: formatISO(lockDate)
+            });
+        } else {
+            await this.apiRequest(
+                `/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides/${targetOverride.id}`,
+                {
+                    method: 'put',
+                    data: {
+                        assignment_override: {
+                            student_ids: targetOverride.studentIds.concat([studentId]),
+                            title: targetOverride.title,
+                            lock_at: formatISO(lockDate)
+                        }
                     }
                 }
-            })
-        );
-    }
-
-    public async deleteAssignmentOverride(courseId: string, assignmentId: string, overrideId: string): Promise<void> {
-        await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides/${overrideId}`, {
-            method: 'delete'
-        });
-    }
-
-    public async addStudentToAssignmentOverrideByOverrideTitle(
-        courseId: string,
-        assignmentId: string,
-        overrideTitle: string,
-        studentId: string,
-        lockDate: Date
-    ): Promise<[AssignmentOverride, boolean]> {
-        const override = await this.getAssignmentOverrideByTitle(courseId, assignmentId, overrideTitle);
-        if (!override) {
-            return [
-                await this.createAssignmentOverride(courseId, assignmentId, overrideTitle, [studentId], lockDate),
-                true
-            ];
+            );
         }
-        if (override.studentIds.includes(studentId)) return [override, false];
-        override.studentIds.push(studentId);
-        return [
-            await this.updateAssignmentOverride(
-                courseId,
-                assignmentId,
-                override.id,
-                overrideTitle,
-                override.studentIds,
-                lockDate
-            ),
-            true
-        ];
+        return true;
     }
 
-    public async removeStudentFromAssignmentOverrideByOverrideTitle(
+    public async deleteAssignmentOverrideForStudent(
         courseId: string,
         assignmentId: string,
-        overrideTitle: string,
-        studentId: string,
-        lockDate: Date
+        studentId: string
     ): Promise<boolean> {
-        const override = await this.getAssignmentOverrideByTitle(courseId, assignmentId, overrideTitle);
-        if (!override || !override.studentIds.includes(studentId)) {
-            return false;
+        let targetOverride: AssignmentOverride | undefined = undefined;
+        for await (const override of await this.getAssignmentOverrides(courseId, assignmentId)) {
+            if (!override.studentIds.includes(studentId)) continue;
+            targetOverride = override;
+            break;
         }
-        if (override.studentIds.length == 1) {
-            await this.deleteAssignmentOverride(courseId, assignmentId, override.id);
-            return true;
+        if (targetOverride == undefined) return false;
+        if (targetOverride.studentIds.length == 1) {
+            await this.apiRequest(
+                `/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides/${targetOverride.id}`,
+                { method: 'delete' }
+            );
+        } else {
+            targetOverride.studentIds.splice(targetOverride.studentIds.indexOf(studentId), 1);
+            await this.apiRequest(
+                `/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides/${targetOverride.id}`,
+                {
+                    method: 'put',
+                    data: {
+                        assignment_override: {
+                            student_ids: targetOverride.studentIds,
+                            title: targetOverride.title,
+                            lock_at: targetOverride.lockAt ? formatISO(targetOverride.lockAt) : undefined
+                        }
+                    }
+                }
+            );
         }
-        override.studentIds.splice(override.studentIds.indexOf(studentId), 1);
-        await this.updateAssignmentOverride(
-            courseId,
-            assignmentId,
-            override.id,
-            overrideTitle,
-            override.studentIds,
-            lockDate
-        );
         return true;
     }
 

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1066,6 +1066,7 @@ export class CanvasService {
             )
                 continue;
             targetOverride = override;
+            break;
         }
         if (!targetOverride) {
             await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides`, {

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -22,6 +22,7 @@ import { StudentRecordManagerService } from './student-record-manager.service';
 export class RequestProcessManagerService {
     private _isRunning = false;
     private _isStopTriggered = false;
+    private static MAX_SUBMITTED_REQUEST_CNT = 200;
 
     constructor(
         @Inject(CanvasService) private canvasService: CanvasService,
@@ -110,6 +111,8 @@ export class RequestProcessManagerService {
                     return;
                 }
                 for (const request of requests) {
+                    if (studentRecord.submittedRequestCnt >= RequestProcessManagerService.MAX_SUBMITTED_REQUEST_CNT)
+                        break;
                     let processedRequest = undefined;
                     if (request instanceof ProcessedRequest) {
                         processedRequest = request;
@@ -227,6 +230,8 @@ export class RequestProcessManagerService {
     ): Promise<[StudentRecord, (TokenATMRequest<TokenOption> | ProcessedRequest)[]]> {
         const studentRecord = await this.studentRecordManagerService.getStudentRecord(configuration, student);
         const requests: (TokenATMRequest<TokenOption> | ProcessedRequest)[] = [];
+        if (studentRecord.submittedRequestCnt >= RequestProcessManagerService.MAX_SUBMITTED_REQUEST_CNT)
+            return [studentRecord, requests];
         if (this._isStopTriggered) {
             return [studentRecord, requests];
         }

--- a/src/app/utils/assignment-override.ts
+++ b/src/app/utils/assignment-override.ts
@@ -1,12 +1,16 @@
+import { parseISO } from 'date-fns';
+
 export class AssignmentOverride {
     private _id: string;
     private _title: string;
     private _studentIds: string[];
+    private _lockAt?: Date;
 
-    constructor(id: string, title: string, studentIds: string[]) {
+    constructor(id: string, title: string, studentIds: string[], lockAt?: Date) {
         this._id = id;
         this._title = title;
         this._studentIds = studentIds;
+        this._lockAt = lockAt;
     }
 
     public get id(): string {
@@ -21,15 +25,25 @@ export class AssignmentOverride {
         return this._studentIds;
     }
 
+    public get lockAt(): Date | undefined {
+        return this._lockAt;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public static deserialize(data: any): AssignmentOverride {
         if (
             typeof data['id'] != 'string' ||
             typeof data['title'] != 'string' ||
             typeof data['student_ids'] != 'object' ||
+            (typeof data['lock_at'] != 'undefined' && typeof data['lock_at'] != 'string') ||
             !Array.isArray(data['student_ids'])
         )
             throw new Error('Invalid data');
-        return new AssignmentOverride(data['id'], data['title'], data['student_ids']);
+        return new AssignmentOverride(
+            data['id'],
+            data['title'],
+            data['student_ids'],
+            data['lock_at'] ? parseISO(data['lock_at']) : undefined
+        );
     }
 }


### PR DESCRIPTION
### Changelog

1. For each student, only the first 200 requests submitted by them will be processed. This is to prevent the abuse of Token ATM.
2. Assignment overrides are now chunked to avoid severe performance issue.

### Testing Note

1. You can change `RequestProcessManagerService.MAX_SUBMITTED_REQUEST_CNT` to change the maximum number of request each student could submit. Here is the expected behavior: when the threshold is reached for the first time, all requests from the students will still be resolved (but those who exceed the threshold are not handled) since all requests need to be resolved and sorted by the submitted time to determine the order to be processed.
2. You can change `CanvasService.ASSIGNMENT_OVERRIDE_MAX_SIZE` to change the maximum size of the assignment override. Also, Canvas Live API can be used to inspect how many assignment overrides an assignment current have.