### PR TITLE
Bugfix: Unable to authenticate Qualtrics when using token-atm-app

### DIFF
--- a/src/app/services/qualtrics.service.ts
+++ b/src/app/services/qualtrics.service.ts
@@ -33,9 +33,6 @@ export class QualtricsService {
     private async refreshQualtricsAccessToken() {
         if (!this.#qualtricsURL || !this.#clientID || !this.#clientSecret)
             throw new Error('Credentials for Qualtrics are invalid');
-        const formData = new FormData();
-        formData.append('grant_type', 'client_credentials');
-        formData.append('scope', ['read:survey_responses', 'read:users'].join(' '));
         const data = (
             await this.axiosService.request({
                 url: this.#qualtricsURL + '/oauth2/token',
@@ -44,9 +41,9 @@ export class QualtricsService {
                     username: this.#clientID,
                     password: this.#clientSecret
                 },
-                data: formData,
-                headers: {
-                    'Content-Type': 'multipart/form-data'
+                params: {
+                    grant_type: 'client_credentials',
+                    scope: ['read:survey_responses', 'read:users'].join(' ')
                 }
             })
         ).data;


### PR DESCRIPTION
### Probelm Description

This issue is caused by [FormData not supporting structured clone](https://github.com/whatwg/xhr/issues/55). To avoid SOP restriction, requests to Canvas are proxied using Electron IPC, which [sends data between different processes using structured clone](https://www.electronjs.org/docs/latest/tutorial/ipc#object-serialization). As a result, FormData are not properly sent to Electron main process, so the request to Qualtrics OAuth endpoint lacks of parameters.

### Solution

Fix is applied by using URL parameters to make the request rather than FormData.

### Testing Note

1. Please use token-atm-app for testing and set `window.location.href` in the developer console to use the local build of token-atm-spa.
2. Please test whether a request to a token option of earning tokens by completing Qualtrics surveys could be properly processed using the Testing Note 5 from #32.