### PR TITLE
Enhancement: make HTTP request more robust

### DIFF
--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -125,7 +125,7 @@ export class DevTestComponent {
         if (!this.course) return;
         const configuration = await this.manager.getTokenATMConfiguration(this.course);
         for await (const student of await this.canvasService.getCourseStudentEnrollments(this.course.id)) {
-            this.canvasService.gradeSubmission(this.course.id, student.id, configuration.logAssignmentId, 0);
+            await this.canvasService.gradeSubmission(this.course.id, student.id, configuration.logAssignmentId, 0);
             for (const submissionComment of await this.canvasService.getSubmissionComments(
                 this.course.id,
                 student.id,

--- a/src/app/components/request-process/request-process.component.ts
+++ b/src/app/components/request-process/request-process.component.ts
@@ -53,15 +53,15 @@ export class RequestProcessComponent implements CourseConfigurable {
                     this.message = message;
                 }
             },
-            complete: () => {
-                this.onRequestProcessingComplete();
+            complete: async () => {
+                await this.onRequestProcessingComplete();
             },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             error: async ([message, err]: [message: string, err: any]) => {
                 await this.modalManagerService.createNotificationModal(
                     message + `\nError message: ${ErrorSerializer.serailize(err)}`
                 );
-                this.onRequestProcessingComplete(false);
+                await this.onRequestProcessingComplete(false);
             }
         });
     }

--- a/src/app/components/student-list/student-list.component.ts
+++ b/src/app/components/student-list/student-list.component.ts
@@ -122,10 +122,10 @@ export class StudentListComponent implements CourseConfigurable {
         this.isFetchingInfo = false;
     }
     //get the student's information
-    navigateToStudent(student: Student): void {
+    async navigateToStudent(student: Student): Promise<void> {
         if (!this.configuration || !this.individaulStudentRecordDisplay) return;
         this.isShowingIndividualStudent = true;
-        this.individaulStudentRecordDisplay.configureStudent(this.configuration, student);
+        await this.individaulStudentRecordDisplay.configureStudent(this.configuration, student);
     }
 
     async onGoBack() {

--- a/src/app/request-resolvers/request-resolver-registry.ts
+++ b/src/app/request-resolvers/request-resolver-registry.ts
@@ -58,7 +58,7 @@ export class RequestResolverRegistry {
         if (quizSubmissionDetail.answers[0] == '') return undefined;
         for (const tokenOption of tokenOptionGroup.tokenOptions) {
             if (tokenOption.prompt != quizSubmissionDetail.answers[0]) continue;
-            return this.getRequestResolver(tokenOption.type).resolve(tokenOption, quizSubmissionDetail);
+            return await this.getRequestResolver(tokenOption.type).resolve(tokenOption, quizSubmissionDetail);
         }
         return undefined;
     }

--- a/src/app/services/axios.service.ts
+++ b/src/app/services/axios.service.ts
@@ -1,44 +1,73 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import axios, { Axios, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { Axios, AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 type AxiosServiceHeader = Pick<Axios, 'head' | 'options' | 'put' | 'post' | 'patch' | 'delete' | 'get' | 'request'>;
 const AXIOS_METHODS = ['head', 'options', 'put', 'post', 'patch', 'delete', 'get', 'request'];
 
+export type IPCCompatibleAxiosResponse<T = any, D = any> = Pick<
+    AxiosResponse<T, D>,
+    'data' | 'status' | 'statusText' | 'headers'
+>;
+
+export type IPCCompatibleAxiosErrorWithoutResponse<T = unknown, D = any> = Pick<
+    AxiosError<T, D>,
+    'code' | 'isAxiosError' | 'status'
+>;
+
+export type IPCCompatibleAxiosError<T = unknown, D = any> = IPCCompatibleAxiosErrorWithoutResponse<T, D> & {
+    response?: IPCCompatibleAxiosResponse<T, D>;
+};
+
+export function isNetworkOrServerError(err: any) {
+    if (err == undefined) return false;
+    if (typeof err.isAxiosError == 'boolean' && err.isAxiosError) {
+        const axiosError = err as IPCCompatibleAxiosError;
+        if (!axiosError.response) return true;
+        const status = axiosError.response.status;
+        if (status == undefined || status < 400 || status >= 500) return true;
+        return false;
+    } else {
+        return true;
+    }
+}
+
 // Auto-generated since cannot use Pick to directly create an abstract class.
 // Abstract class is needed since Angular requires it as a value to perform dependency injection.
 export abstract class AxiosService implements AxiosServiceHeader {
-    abstract head<T = any, R = AxiosResponse<T, any>, D = any>(
+    abstract head<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
         url: string,
         config?: AxiosRequestConfig<D> | undefined
     ): Promise<R>;
-    abstract options<T = any, R = AxiosResponse<T, any>, D = any>(
+    abstract options<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
         url: string,
         config?: AxiosRequestConfig<D> | undefined
     ): Promise<R>;
-    abstract put<T = any, R = AxiosResponse<T, any>, D = any>(
-        url: string,
-        data?: D | undefined,
-        config?: AxiosRequestConfig<D> | undefined
-    ): Promise<R>;
-    abstract post<T = any, R = AxiosResponse<T, any>, D = any>(
+    abstract put<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
         url: string,
         data?: D | undefined,
         config?: AxiosRequestConfig<D> | undefined
     ): Promise<R>;
-    abstract patch<T = any, R = AxiosResponse<T, any>, D = any>(
+    abstract post<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
         url: string,
         data?: D | undefined,
         config?: AxiosRequestConfig<D> | undefined
     ): Promise<R>;
-    abstract delete<T = any, R = AxiosResponse<T, any>, D = any>(
+    abstract patch<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
+        url: string,
+        data?: D | undefined,
+        config?: AxiosRequestConfig<D> | undefined
+    ): Promise<R>;
+    abstract delete<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
         url: string,
         config?: AxiosRequestConfig<D> | undefined
     ): Promise<R>;
-    abstract get<T = any, R = AxiosResponse<T, any>, D = any>(
+    abstract get<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
         url: string,
         config?: AxiosRequestConfig<D> | undefined
     ): Promise<R>;
-    abstract request<T = any, R = AxiosResponse<T, any>, D = any>(config: AxiosRequestConfig<D>): Promise<R>;
+    abstract request<T = any, R = IPCCompatibleAxiosResponse<T, any>, D = any>(
+        config: AxiosRequestConfig<D>
+    ): Promise<R>;
 }
 
 export class AxiosServiceFactory {

--- a/src/app/services/qualtrics.service.ts
+++ b/src/app/services/qualtrics.service.ts
@@ -1,7 +1,8 @@
 import { Inject, Injectable } from '@angular/core';
-import type { AxiosRequestConfig, AxiosResponse } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
 import { unzipRaw } from 'unzipit';
-import { AxiosService } from './axios.service';
+import { AxiosService, IPCCompatibleAxiosResponse, isNetworkOrServerError } from './axios.service';
+import { ExponentialBackoffExecutor } from 'app/utils/exponential-backoff-executor';
 
 @Injectable({
     providedIn: 'root'
@@ -31,22 +32,29 @@ export class QualtricsService {
     }
 
     private async refreshQualtricsAccessToken() {
-        if (!this.#qualtricsURL || !this.#clientID || !this.#clientSecret)
-            throw new Error('Credentials for Qualtrics are invalid');
-        const data = (
-            await this.axiosService.request({
-                url: this.#qualtricsURL + '/oauth2/token',
-                method: 'post',
-                auth: {
-                    username: this.#clientID,
-                    password: this.#clientSecret
-                },
-                params: {
-                    grant_type: 'client_credentials',
-                    scope: ['read:survey_responses', 'read:users'].join(' ')
-                }
-            })
-        ).data;
+        const executor = async () => {
+            if (!this.#qualtricsURL || !this.#clientID || !this.#clientSecret)
+                throw new Error('Credentials for Qualtrics are invalid');
+            return (
+                await this.axiosService.request({
+                    url: this.#qualtricsURL + '/oauth2/token',
+                    method: 'post',
+                    auth: {
+                        username: this.#clientID,
+                        password: this.#clientSecret
+                    },
+                    params: {
+                        grant_type: 'client_credentials',
+                        scope: ['read:survey_responses', 'read:users'].join(' ')
+                    }
+                })
+            ).data;
+        };
+        const data = await ExponentialBackoffExecutor.execute(
+            executor,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (_, err: any | undefined) => !isNetworkOrServerError(err)
+        );
         if (typeof data['access_token'] == 'string') {
             this.#qualtricsAccessToken = data['access_token'];
         } else {
@@ -55,7 +63,10 @@ export class QualtricsService {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private async rawAPIRequest<T = any>(endpoint: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+    private async rawAPIRequest<T = any>(
+        endpoint: string,
+        config?: AxiosRequestConfig
+    ): Promise<IPCCompatibleAxiosResponse<T>> {
         let isAccessTokenRefreshed = false;
         if (!this.#qualtricsAccessToken) {
             isAccessTokenRefreshed = true;
@@ -64,15 +75,22 @@ export class QualtricsService {
         // eslint-disable-next-line no-constant-condition
         while (true) {
             try {
-                const result = await this.axiosService.request({
-                    ...config,
-                    url: this.#qualtricsURL + endpoint,
-                    headers: {
-                        ...config?.headers,
-                        Authorization: 'Bearer ' + this.#qualtricsAccessToken
-                    }
-                });
-                return result;
+                const executor = async () => {
+                    const result = await this.axiosService.request<T>({
+                        ...config,
+                        url: this.#qualtricsURL + endpoint,
+                        headers: {
+                            ...config?.headers,
+                            Authorization: 'Bearer ' + this.#qualtricsAccessToken
+                        }
+                    });
+                    return result;
+                };
+                return await ExponentialBackoffExecutor.execute(
+                    executor,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    async (_, err: any | undefined) => !isNetworkOrServerError(err)
+                );
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (err: any) {
                 if (err.response && err.response.status == 401 && !isAccessTokenRefreshed) {

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -35,6 +35,7 @@ export class RequestProcessManagerService {
 
     public startRequestProcessing(configuration: TokenATMConfiguration): Observable<[number, string]> {
         const result = new BehaviorSubject<[number, string]>([0, 'Request processing started']);
+        // Intentionally not await since the BehaviorSubject needs to be return to the component
         this.runRequestProcessing(configuration, result);
         return result;
     }

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -56,7 +56,7 @@ export class TokenATMConfigurationManagerService {
             configuration.course.id,
             TokenATMConfigurationManagerService.TOKEN_ATM_CONFIGURATION_PAGE_NAME
         );
-        this.writeConfigurationToPage(configuration.course, pageId, JSON.stringify(configuration));
+        await this.writeConfigurationToPage(configuration.course, pageId, JSON.stringify(configuration));
     }
 
     private async getAssignmentGroupId(configuration: TokenATMConfiguration): Promise<string> {

--- a/src/app/utils/exponential-backoff-executor.ts
+++ b/src/app/utils/exponential-backoff-executor.ts
@@ -1,0 +1,44 @@
+export class ExponentialBackoffExecutor {
+    public static async execute<T>(
+        executor: () => Promise<T>,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        resultChecker: (result: T | undefined, err: any | undefined) => Promise<boolean> = async (_, err) =>
+            err != undefined ? false : true,
+        retryCnt = 5,
+        startWaitTime = 250,
+        growthRate = 2
+    ): Promise<T> {
+        let curRetryCnt = 0,
+            curWaitTime = startWaitTime;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            let result: T | undefined = undefined,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                error: any | undefined = undefined;
+            try {
+                result = await executor();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (err: any) {
+                error = err;
+            }
+            if (await resultChecker(result, error)) {
+                if (error != undefined) {
+                    throw error;
+                } else {
+                    return result as T;
+                }
+            } else if (curRetryCnt < retryCnt) {
+                curRetryCnt++;
+                console.log(`Retrying... wait for ${curWaitTime} ms`);
+                await new Promise((resolve) => setTimeout(resolve, curWaitTime));
+                curWaitTime *= growthRate;
+            } else {
+                if (error != undefined) {
+                    throw error;
+                } else {
+                    throw new Error(`Result of exponential backoff execution does not pass the checker`);
+                }
+            }
+        }
+    }
+}

--- a/src/app/utils/paginated-result.ts
+++ b/src/app/utils/paginated-result.ts
@@ -1,15 +1,15 @@
-import type { AxiosResponse } from 'axios';
+import type { IPCCompatibleAxiosResponse } from 'app/services/axios.service';
 
 export class PaginatedResult<T> implements AsyncIterable<T> {
     private data: T[];
     private nextURL: string | undefined;
-    private requestHandler: (url: string) => Promise<AxiosResponse>;
+    private requestHandler: (url: string) => Promise<IPCCompatibleAxiosResponse>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private dataProcessor: (data: any) => T[];
 
     constructor(
-        response: AxiosResponse,
-        requestHandler: (url: string) => Promise<AxiosResponse>,
+        response: IPCCompatibleAxiosResponse,
+        requestHandler: (url: string) => Promise<IPCCompatibleAxiosResponse>,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         dataProcessor: (data: any) => T[]
     ) {
@@ -19,7 +19,7 @@ export class PaginatedResult<T> implements AsyncIterable<T> {
         this.dataProcessor = dataProcessor;
     }
 
-    private extractNextURL(response: AxiosResponse): string | undefined {
+    private extractNextURL(response: IPCCompatibleAxiosResponse): string | undefined {
         const linkHeader = response.headers['link'];
         if (!linkHeader) return undefined;
         for (const link of (linkHeader as string).split(',')) {

--- a/src/app/utils/paginated-view.ts
+++ b/src/app/utils/paginated-view.ts
@@ -1,16 +1,16 @@
-import type { AxiosResponse } from 'axios';
+import type { IPCCompatibleAxiosResponse } from 'app/services/axios.service';
 
 export class PaginatedView<T> implements Iterable<T> {
     private data: T[];
     private prevURL?: string;
     private nextURL?: string;
-    private requestHandler: (url: string) => Promise<AxiosResponse>;
+    private requestHandler: (url: string) => Promise<IPCCompatibleAxiosResponse>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private dataProcessor: (data: any) => T[];
 
     constructor(
-        response: AxiosResponse,
-        requestHandler: (url: string) => Promise<AxiosResponse>,
+        response: IPCCompatibleAxiosResponse,
+        requestHandler: (url: string) => Promise<IPCCompatibleAxiosResponse>,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         dataProcessor: (data: any) => T[]
     ) {
@@ -20,7 +20,7 @@ export class PaginatedView<T> implements Iterable<T> {
         this.dataProcessor = dataProcessor;
     }
 
-    private extractURLs(response: AxiosResponse): void {
+    private extractURLs(response: IPCCompatibleAxiosResponse): void {
         const linkHeader = response.headers['link'];
         this.prevURL = undefined;
         this.nextURL = undefined;
@@ -78,7 +78,7 @@ export class PaginatedView<T> implements Iterable<T> {
 //         this.pageSize = pageSize;
 //     }
 
-//     private async requestHandler(url: string): Promise<AxiosResponse> {
+//     private async requestHandler(url: string): Promise<IPCCompatibleAxiosResponse> {
 //         const response = await axios.get(url, {
 //             headers: {
 //                 Authorization: `Bearer ${this.token}`


### PR DESCRIPTION
### Description

Token ATM will now retry a HTTP request if a plain Javascript Error or an Axios Error with a non-4xx response (which means it's a sever-side issue) is thrown. Exponential backoff is used for retrying. When a request is pending for retrying, a message will be printed to the console to indicate the amount of time waited before the retry. In addition to that, several `await` keyword that are missed before are added.

### Testing Note

1. Please test if Token ATM still behave as epxected when communicating with Canvas LMS and Qualtrics when no errors occur.
2. Please test if the exponential backoff retrying works. The following two scenarios should be tested:

    1. When a plain Javascript Error or an Axios Error with a non-4xx response is thrown during an HTTP request, Token ATM should retry the request. You can modify `canvas.service.ts` to manually throw a plain JavaScript error from the `executor` in `CanvasService.rawAPIRequest()`, or you could disable your network connection and reactivate it to emulate a network interruption.
    2. When an Axios Error with a 4xx response is thrown during an HTTP request, the HTTP request should not be retried. You can test it by emulating such an error as described above, or you could simply search for students using a single non-whitespace character in the student list (which should have a 400 response).