### PR TITLE
Refactor pluralize

### DIFF
--- a/src/app/components/batch-token-balance-adjustment-modal/batch-token-balance-adjustment-modal.component.ts
+++ b/src/app/components/batch-token-balance-adjustment-modal/batch-token-balance-adjustment-modal.component.ts
@@ -3,6 +3,7 @@ import { ProcessedRequest } from 'app/data/processed-request';
 import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
 import { CanvasService } from 'app/services/canvas.service';
 import { StudentRecordManagerService } from 'app/services/student-record-manager.service';
+import { countAndNoun } from 'app/utils/pluralize';
 import type { BsModalRef } from 'ngx-bootstrap/modal';
 import * as CSVParse from 'papaparse';
 
@@ -47,7 +48,7 @@ export class BatchTokenBalanceAdjustmentModalComponent {
         for (const data of result) {
             cnt++;
             this.progress = (((cnt - 1) / result.length) * 100).toFixed(2);
-            this.progressMessage = `${cnt - 1} out of ${result.length} record(s) processed`;
+            this.progressMessage = `${cnt - 1} out of ${countAndNoun(result.length, 'record')} processed`;
             if (!Array.isArray(data) || (data.length != 2 && data.length != 3)) continue;
             const email = data[0];
             if (typeof email != 'string') continue;

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -15,6 +15,7 @@ import { CanvasService } from './canvas.service';
 import { QualtricsService } from './qualtrics.service';
 import { RawRequestFetcherService } from './raw-request-fetcher.service';
 import { StudentRecordManagerService } from './student-record-manager.service';
+import { countAndNoun } from 'app/utils/pluralize';
 
 @Injectable({
     providedIn: 'root'
@@ -166,10 +167,10 @@ export class RequestProcessManagerService {
                     ]);
                     progressUpdate.next([
                         -1 - individualProcessedRequestCnt / requests.length,
-                        `Processed ${this.countAndNoun(
+                        `Processed ${countAndNoun(
                             individualProcessedRequestCnt,
                             'request'
-                        )} for the current student, ${this.countAndNoun(
+                        )} for the current student, ${countAndNoun(
                             requests.length - individualProcessedRequestCnt,
                             'request'
                         )} remaining`
@@ -211,7 +212,7 @@ export class RequestProcessManagerService {
                 submissionCnt++;
                 progressUpdate.next([
                     0,
-                    `Gathering submissions: Gathered ${this.countAndNoun(submissionCnt, 'submission')}`
+                    `Gathering submissions: Gathered ${countAndNoun(submissionCnt, 'submission')}`
                 ]);
                 if (this._isStopTriggered) {
                     return [quizSubmissionMap, assignmentIdMap];
@@ -272,7 +273,7 @@ export class RequestProcessManagerService {
                 requestCnt++;
                 progressUpdate.next([
                     -1,
-                    `Resolving Requests: Resolved ${this.countAndNoun(requestCnt, 'request')} for the current student`
+                    `Resolving Requests: Resolved ${countAndNoun(requestCnt, 'request')} for the current student`
                 ]);
                 if (this._isStopTriggered) return [studentRecord, requests];
             }
@@ -288,15 +289,7 @@ export class RequestProcessManagerService {
         }
     }
 
-    private countAndNoun(count: number, noun: string) {
-        const pluralize = (word: string, count: number): string => {
-            return word + (count == 1 ? '' : 's');
-        };
-        return `${count} ${pluralize(noun, count)}`;
-    }
-
     private progressString(studentCnt: number, processedRequestCnt: number, processedStudentCnt: number): string {
-        const countAndNoun = this.countAndNoun;
         const template = (sC: number, pRC: number, pSC: number): string => {
             return (
                 `Processing Requests: Processed ${countAndNoun(pRC, 'request')}` +

--- a/src/app/utils/pluralize.spec.ts
+++ b/src/app/utils/pluralize.spec.ts
@@ -1,0 +1,30 @@
+import { countAndNoun } from './pluralize';
+
+type CountAndNounTestingParameters = { input: [number, string]; result: string };
+
+describe('Basic Pluralization', () => {
+    const parameters: CountAndNounTestingParameters[] = [
+        { input: [1, 'request'], result: '1 request' },
+        { input: [0, 'request'], result: '0 requests' },
+        { input: [2, 'request'], result: '2 requests' },
+        { input: [1, 'submission'], result: '1 submission' },
+        { input: [0, 'submission'], result: '0 submissions' },
+        { input: [2, 'submission'], result: '2 submissions' },
+        { input: [1, 'student'], result: '1 student' },
+        { input: [0, 'student'], result: '0 students' },
+        { input: [2, 'student'], result: '2 students' },
+        { input: [1, 'record'], result: '1 record' },
+        { input: [0, 'record'], result: '0 records' },
+        { input: [2, 'record'], result: '2 records' },
+        { input: [1, 'token option group'], result: '1 token option group' },
+        { input: [0, 'token option group'], result: '0 token option groups' },
+        { input: [2, 'token option group'], result: '2 token option groups' }
+    ];
+
+    parameters.forEach((parameter) => {
+        const [count, noun] = parameter.input;
+        it(`${count} & '${noun}' should be '${parameter.result}'`, () => {
+            expect(countAndNoun(count, noun)).toBe(parameter.result);
+        });
+    });
+});

--- a/src/app/utils/pluralize.ts
+++ b/src/app/utils/pluralize.ts
@@ -1,0 +1,6 @@
+export function countAndNoun(count: number, noun: string) {
+    const pluralize = (word: string, count: number): string => {
+        return word + (count == 1 ? '' : 's');
+    };
+    return `${count} ${pluralize(noun, count)}`;
+}


### PR DESCRIPTION
**Refactoring**:

- Take the `countAndNoun` function out of `request-process-manager.service.ts` and start a `pluralize` utility.
- Add unit tests for `countAndNoun`.
- Update code that has `'(s)'` in strings to use `countAndNoun` instead.

**Testing Note**:

1. Token ATM Functionality shouldn't have changed.
2. The `onMove()` method in the `move-token-option-modal` component should be checked thoroughly for any functionality changes. Significant changes were required for `onMove()` to use `countAndNoun`.