### PR TITLE
Feature: support reset & migrate Token ATM

### DIFF
--- a/src/app/components/configuration/configuration.component.html
+++ b/src/app/components/configuration/configuration.component.html
@@ -9,6 +9,10 @@
         <button class="btn btn-danger my-3" (click)="onDeleteAll()" [disabled]="isProcessing">
             Delete All Token-ATM related content
         </button>
+        <button class="btn btn-danger my-3" (click)="onResetContent()" [disabled]="isProcessing">
+            Reset Token ATM
+        </button>
+        <button class="btn btn-danger my-3" (click)="onMigrate()" [disabled]="isProcessing">Migrate Token ATM</button>
     </div>
 </ng-template>
 

--- a/src/app/components/configuration/configuration.component.html
+++ b/src/app/components/configuration/configuration.component.html
@@ -12,7 +12,9 @@
         <button class="btn btn-danger my-3" (click)="onResetContent()" [disabled]="isProcessing">
             Reset Token ATM
         </button>
-        <button class="btn btn-danger my-3" (click)="onMigrate()" [disabled]="isProcessing">Migrate Token ATM</button>
+        <button class="btn btn-danger my-3" (click)="onMigrate()" [disabled]="isProcessing">
+            Migrate Token ATM after a Course Copy/Import
+        </button>
     </div>
 </ng-template>
 

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -79,7 +79,8 @@ export class DevTestComponent {
                 configuration.nextFreeTokenOptionId,
                 `Test Token Option ${group.tokenOptions.length}`,
                 `Just a test <b>token option</b> ${group.tokenOptions.length}`,
-                group.tokenOptions.length
+                group.tokenOptions.length,
+                false
             )
         );
         const result = await this.manager.updateTokenOptionGroup(group);
@@ -163,6 +164,7 @@ export class DevTestComponent {
                 `getting tokens by passing module 1`,
                 `Passing Module 1 with a score no less than 70% of the total score`,
                 1,
+                false,
                 'Module 1',
                 '12612114',
                 new Date(),
@@ -177,6 +179,7 @@ export class DevTestComponent {
                 `getting tokens by passing module 2`,
                 `Passing Module 1 with a score no less than 80% of the total score`,
                 2,
+                false,
                 'Module 2',
                 '12612167',
                 new Date(),
@@ -201,7 +204,8 @@ export class DevTestComponent {
                 configuration.nextFreeTokenOptionId,
                 `basic token option 1`,
                 `Just a test <b>token option</b>`,
-                100
+                100,
+                false
             )
         );
         basicGroup.addTokenOption(
@@ -211,7 +215,8 @@ export class DevTestComponent {
                 configuration.nextFreeTokenOptionId,
                 `basic token option 2`,
                 `Just a test <b>token option</b>`,
-                0.5
+                0.5,
+                false
             )
         );
         basicGroup.addTokenOption(
@@ -221,7 +226,8 @@ export class DevTestComponent {
                 configuration.nextFreeTokenOptionId,
                 `basic token option 3`,
                 `Just a test <b>token option</b>`,
-                -100
+                -100,
+                false
             )
         );
         await this.manager.updateTokenOptionGroup(basicGroup);
@@ -249,6 +255,7 @@ export class DevTestComponent {
                 'Earn by Quiz Testing',
                 'Just a description',
                 10,
+                false,
                 'Argument Driven Inquiry (ADI) Quiz',
                 '14478031',
                 new Date(),
@@ -263,6 +270,7 @@ export class DevTestComponent {
                 'Spend for Assignment Resubmission Testing',
                 'Just a description',
                 -1,
+                false,
                 'Test Locked Assignment',
                 '38096634',
                 new Date(),
@@ -278,6 +286,7 @@ export class DevTestComponent {
                 'Spend for Lab Data Testing',
                 'Just a description',
                 -2,
+                false,
                 'Test Lab Data Quiz',
                 '14544887',
                 new Date(),
@@ -294,6 +303,7 @@ export class DevTestComponent {
                 'Expire Test',
                 'Just make it expired',
                 -2,
+                false,
                 'Test Lab Data Quiz',
                 '14544887',
                 new Date(),
@@ -310,6 +320,7 @@ export class DevTestComponent {
                 'Earn by Taking Qualtrics Survey Testing',
                 'Just a description',
                 10,
+                false,
                 'SV_aVQu2sEgpSgSkBw',
                 'Email',
                 new Date(),

--- a/src/app/components/form-fields/token-option-fields/basic-token-option-field/basic-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/basic-token-option-field/basic-token-option-field.component.ts
@@ -68,7 +68,8 @@ export class BasicTokenOptionFieldComponent extends TokenOptionField<BasicTokenO
                 await this._idField.getValue(),
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
-                await this._tokenBalanceChangeField.getValue()
+                await this._tokenBalanceChangeField.getValue(),
+                false
             );
         } else {
             this._value.name = await this._nameField.getValue();

--- a/src/app/components/form-fields/token-option-fields/earn-by-module-token-option-field/earn-by-module-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/earn-by-module-token-option-field/earn-by-module-token-option-field.component.ts
@@ -58,6 +58,7 @@ export class EarnByModuleTokenOptionFieldComponent extends TokenOptionField<Earn
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._moduleNameField.getValue(),
                 await this.canvasService.getModuleIdByName(courseId, await this._moduleNameField.getValue()),
                 await this._startTimeField.getValue(),

--- a/src/app/components/form-fields/token-option-fields/earn-by-quiz-token-option-field/earn-by-quiz-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/earn-by-quiz-token-option-field/earn-by-quiz-token-option-field.component.ts
@@ -58,6 +58,7 @@ export class EarnByQuizTokenOptionFieldComponent extends TokenOptionField<EarnBy
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._quizNameField.getValue(),
                 await this.canvasService.getQuizIdByName(courseId, await this._quizNameField.getValue()),
                 await this._startTimeField.getValue(),

--- a/src/app/components/form-fields/token-option-fields/earn-by-survey-token-option-field/earn-by-survey-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/earn-by-survey-token-option-field/earn-by-survey-token-option-field.component.ts
@@ -56,6 +56,7 @@ export class EarnBySurveyTokenOptionFieldComponent extends TokenOptionField<Earn
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._surveyIdField.getValue(),
                 await this._fieldNameField.getValue(),
                 await this._startTimeField.getValue(),

--- a/src/app/components/form-fields/token-option-fields/spend-for-assignment-resubmission-token-option-field/spend-for-assignment-resubmission-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/spend-for-assignment-resubmission-token-option-field/spend-for-assignment-resubmission-token-option-field.component.ts
@@ -64,6 +64,7 @@ export class SpendForAssignmentResubmissionTokenOptionFieldComponent
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._assignmentNameField.getValue(),
                 await this.canvasService.getAssignmentIdByName(courseId, await this._assignmentNameField.getValue()),
                 await this._startTimeField.getValue(),

--- a/src/app/components/form-fields/token-option-fields/spend-for-lab-data-token-option-field/spend-for-lab-data-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/spend-for-lab-data-token-option-field/spend-for-lab-data-token-option-field.component.ts
@@ -66,6 +66,7 @@ export class SpendForLabDataTokenOptionFieldComponent
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._quizNameField.getValue(),
                 await this.canvasService.getQuizIdByName(courseId, await this._quizNameField.getValue()),
                 await this._startTimeField.getValue(),

--- a/src/app/components/form-fields/token-option-fields/spend-for-lab-switch-token-option-field/spend-for-lab-switch-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/spend-for-lab-switch-token-option-field/spend-for-lab-switch-token-option-field.component.ts
@@ -88,6 +88,7 @@ export class SpendForLabSwitchTokenOptionFieldComponent
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 (await this._excludeTokenOptionIdsField.getValue())
                     .split(',')
                     .filter((value: string) => value.trim().length != 0)

--- a/src/app/components/form-fields/token-option-fields/withdraw-assignment-resubmission-option-field/withdraw-assignment-resubmission-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/withdraw-assignment-resubmission-option-field/withdraw-assignment-resubmission-option-field.component.ts
@@ -89,6 +89,7 @@ export class WithdrawAssignmentResubmissionOptionFieldComponent
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._withdrawTokenOptionIdField.getValue()
             );
         } else {

--- a/src/app/components/form-fields/token-option-fields/withdraw-lab-data-token-option-field/withdraw-lab-data-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/withdraw-lab-data-token-option-field/withdraw-lab-data-token-option-field.component.ts
@@ -89,6 +89,7 @@ export class WithdrawLabDataTokenOptionFieldComponent
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._withdrawTokenOptionIdField.getValue()
             );
         } else {

--- a/src/app/components/form-fields/token-option-fields/withdraw-lab-switch-token-option-field/withdraw-lab-switch-token-option-field.component.ts
+++ b/src/app/components/form-fields/token-option-fields/withdraw-lab-switch-token-option-field/withdraw-lab-switch-token-option-field.component.ts
@@ -89,6 +89,7 @@ export class WithdrawLabSwitchTokenOptionFieldComponent
                 await this._nameField.getValue(),
                 await this._descriptionField.getValue(),
                 await this._tokenBalanceChangeField.getValue(),
+                false,
                 await this._withdrawTokenOptionIdField.getValue()
             );
         } else {

--- a/src/app/components/token-option-display/token-option-display.component.html
+++ b/src/app/components/token-option-display/token-option-display.component.html
@@ -10,8 +10,12 @@
                         getAbsValue(option.tokenBalanceChange).toString() +
                         ' token' +
                         (getAbsValue(option.tokenBalanceChange) === 1 ? '' : 's')
-                }}</span
-            >
+                }}
+                <ng-container *ngIf="option.isMigrating">
+                    <span class="bi bi-dot"></span>
+                    Migrating <span class="bi bi-exclamation-triangle-fill text-warning"></span> Save It to Complete
+                </ng-container>
+            </span>
         </div>
         <div *ngIf="hoverFocus">
             <div class="btn-group" dropdown>

--- a/src/app/components/token-option-management/token-option-management.component.ts
+++ b/src/app/components/token-option-management/token-option-management.component.ts
@@ -49,9 +49,13 @@ export class TokenOptionManagementComponent {
         if (!this._tokenOptionContainer || !this._optionComponentType || !this._value) return;
         if (!this.componentRef)
             this.componentRef = this._tokenOptionContainer.createComponent(this._optionComponentType);
-        this.isReadOnly = this.isEditing;
+        if (this.isEditing) {
+            this.isReadOnly = !(this._value as TokenOption).isMigrating;
+        } else {
+            this.isReadOnly = false;
+        }
         const instance = this.componentRef.instance;
-        instance.isReadOnly = this.isEditing;
+        instance.isReadOnly = this.isReadOnly;
         instance.initValue = this._value;
     }
 
@@ -85,6 +89,7 @@ export class TokenOptionManagementComponent {
             return;
         }
         const tokenOption = await this.componentRef.instance.getValue();
+        if (tokenOption.isMigrating) tokenOption.isMigrating = false;
         const result = await this.configurationManagerService.updateTokenOptionGroup(tokenOption.group);
         if (!result) await this.notifyUpdateFailure();
         this.isProcessing = false;

--- a/src/app/data/token-atm-configuration.ts
+++ b/src/app/data/token-atm-configuration.ts
@@ -6,6 +6,7 @@ import { CryptoHelper } from 'app/utils/crypto-helper';
 import { Base64 } from 'js-base64';
 import { TypedArrayHelper } from 'app/utils/typed-array-helper';
 import { compress, decompress } from 'compress-json';
+import { generateRandomString } from 'app/utils/random-string-generator';
 
 export class TokenATMConfiguration {
     private _course: Course;
@@ -145,10 +146,9 @@ export class TokenATMConfiguration {
     }
 
     // Warning: This function will override previous secure config!
-    public regenrateSecureConfig(): void {
+    public regenerateSecureConfig(): void {
         this.#encryptionKey = undefined;
-        // https://stackoverflow.com/a/47496558
-        this.#encryptionPassword = [...Array(32)].map(() => Math.random().toString(36)[2]).join('');
+        this.#encryptionPassword = generateRandomString(32);
         this.#encryptionSalt = window.crypto.getRandomValues(new Uint8Array(32));
     }
 

--- a/src/app/data/token-atm-configuration.ts
+++ b/src/app/data/token-atm-configuration.ts
@@ -65,6 +65,10 @@ export class TokenATMConfiguration {
         return this._uid;
     }
 
+    public set uid(uid: string) {
+        this._uid = uid;
+    }
+
     public get suffix(): string {
         return this._suffix;
     }
@@ -138,6 +142,14 @@ export class TokenATMConfiguration {
             password: this.#encryptionPassword,
             salt: Base64.fromUint8Array(this.#encryptionSalt)
         };
+    }
+
+    // Warning: This function will override previous secure config!
+    public regenrateSecureConfig(): void {
+        this.#encryptionKey = undefined;
+        // https://stackoverflow.com/a/47496558
+        this.#encryptionPassword = [...Array(32)].map(() => Math.random().toString(36)[2]).join('');
+        this.#encryptionSalt = window.crypto.getRandomValues(new Uint8Array(32));
     }
 
     async #generateKey(): Promise<void> {

--- a/src/app/data/token-option-group.ts
+++ b/src/app/data/token-option-group.ts
@@ -77,6 +77,10 @@ export class TokenOptionGroup {
         this._tokenOptions = tokenOptions;
     }
 
+    public get availableTokenOptions(): TokenOption[] {
+        return this.tokenOptions.filter((tokenOption) => !tokenOption.isMigrating);
+    }
+
     public addTokenOption(tokenOption: TokenOption, position?: number): void {
         this.configuration.updateNextFreeTokenOptionId(tokenOption.id);
         if (position == undefined) this._tokenOptions.push(tokenOption);

--- a/src/app/request-resolvers/request-resolver-registry.ts
+++ b/src/app/request-resolvers/request-resolver-registry.ts
@@ -56,7 +56,7 @@ export class RequestResolverRegistry {
         quizSubmissionDetail: QuizSubmissionDetail
     ): Promise<TokenATMRequest<TokenOption> | undefined> {
         if (quizSubmissionDetail.answers[0] == '') return undefined;
-        for (const tokenOption of tokenOptionGroup.tokenOptions) {
+        for (const tokenOption of tokenOptionGroup.availableTokenOptions) {
             if (tokenOption.prompt != quizSubmissionDetail.answers[0]) continue;
             return this.getRequestResolver(tokenOption.type).resolve(tokenOption, quizSubmissionDetail);
         }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -905,6 +905,46 @@ export class CanvasService {
         }
     }
 
+    public async replaceQuizQuestions(courseId: string, quizId: string, quizQuestions: QuizQuestion[]): Promise<void> {
+        await this.safeGuardForQuiz(courseId, quizId);
+        const quizQuestionIds = await DataConversionHelper.convertAsyncIterableToList(
+            new PaginatedResult<string>(
+                await this.rawAPIRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions`, {
+                    params: {
+                        per_page: 100
+                    }
+                }),
+                async (url: string) => await this.paginatedRequestHandler(url),
+                (data: unknown[]) => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    return data.map((entry: any) => entry.id);
+                }
+            )
+        );
+        const minLen = Math.min(quizQuestionIds.length, quizQuestions.length);
+        for (let i = 0; i < minLen; i++) {
+            await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions/${quizQuestionIds[i]}`, {
+                method: 'put',
+                data: {
+                    question: quizQuestions[i]?.toJSON()
+                }
+            });
+        }
+        for (let i = minLen; i < quizQuestionIds.length; i++) {
+            await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions/${quizQuestionIds[i]}`, {
+                method: 'delete'
+            });
+        }
+        for (let i = minLen; i < quizQuestions.length; i++) {
+            await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}/questions`, {
+                method: 'post',
+                data: {
+                    question: quizQuestions[i]?.toJSON()
+                }
+            });
+        }
+    }
+
     public async getQuiz(courseId: string, quizId: string): Promise<Quiz> {
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/quizzes/${quizId}`);
         return Quiz.deserialize(data);

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -263,7 +263,7 @@ export class RequestProcessManagerService {
                             quizSubmissionDetail.submittedTime,
                             new Date(),
                             0,
-                            'The token option you made a request to cannot be recognized. That token option might be deleted or moved, or you might have submitted the quiz without selecting an option in Question 1',
+                            'The token option you made a request for cannot be recognized. You might have submitted the quiz without selecting an option from Question 1, or the token option you requested for is deleted, moved, or not configured properly yet.',
                             group.id
                         )
                     );

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -13,6 +13,7 @@ import { TokenOptionResolverRegistry } from 'app/token-option-resolvers/token-op
 import { CanvasService } from './canvas.service';
 import HTMLParse from 'html-dom-parser';
 import { NewDueTimeTransformer } from 'app/instruction-generators/new-due-time-transformer';
+import { generateRandomString } from 'app/utils/random-string-generator';
 
 @Injectable({
     providedIn: 'root'
@@ -277,11 +278,7 @@ export class TokenATMConfigurationManagerService {
         const configuration = new TokenATMConfiguration(
             course,
             '',
-            // https://stackoverflow.com/a/47496558
-            [...Array(8)]
-                .map(() => Math.random().toString(36)[2])
-                .join('')
-                .toUpperCase(),
+            generateRandomString(8).toUpperCase(),
             suffix,
             description,
             1,
@@ -290,7 +287,7 @@ export class TokenATMConfigurationManagerService {
             (group, data) => {
                 return this.tokenOptionResolverRegistry.resolveTokenOption(group, data);
             },
-            [...Array(32)].map(() => Math.random().toString(36)[2]).join(''),
+            generateRandomString(32),
             window.crypto.getRandomValues(new Uint8Array(32))
         );
         await this.canvasService.createPage(
@@ -304,11 +301,8 @@ export class TokenATMConfigurationManagerService {
 
     public async regenerateContent(configuration: TokenATMConfiguration, isMigrating = false): Promise<void> {
         await this.deleteGeneratedContent(configuration);
-        configuration.uid = [...Array(8)]
-            .map(() => Math.random().toString(36)[2])
-            .join('')
-            .toUpperCase();
-        configuration.regenrateSecureConfig();
+        configuration.uid = generateRandomString(8).toUpperCase();
+        configuration.regenerateSecureConfig();
         if (isMigrating)
             for (const tokenOptionGroup of configuration.tokenOptionGroups) {
                 tokenOptionGroup.isPublished = false;

--- a/src/app/token-options/earn-by-module-token-option.ts
+++ b/src/app/token-options/earn-by-module-token-option.ts
@@ -15,12 +15,13 @@ export class EarnByModuleTokenOption extends TokenOption {
         name: string,
         description: string,
         tokenBalanceChange: number,
+        isMigrating: boolean,
         moduleName: string,
         moduleId: string,
         startTime: Date,
         gradeThreshold: number
     ) {
-        super(group, type, id, name, description, tokenBalanceChange);
+        super(group, type, id, name, description, tokenBalanceChange, isMigrating);
         this._moduleName = moduleName;
         this._moduleId = moduleId;
         this._startTime = startTime;

--- a/src/app/token-options/earn-by-quiz-token-option.ts
+++ b/src/app/token-options/earn-by-quiz-token-option.ts
@@ -15,12 +15,13 @@ export class EarnByQuizTokenOption extends TokenOption {
         name: string,
         description: string,
         tokenBalanceChange: number,
+        isMigrating: boolean,
         quizName: string,
         quizId: string,
         startTime: Date,
         gradeThreshold: number
     ) {
-        super(group, type, id, name, description, tokenBalanceChange);
+        super(group, type, id, name, description, tokenBalanceChange, isMigrating);
         this._quizName = quizName;
         this._quizId = quizId;
         this._startTime = startTime;

--- a/src/app/token-options/earn-by-survey-token-option.ts
+++ b/src/app/token-options/earn-by-survey-token-option.ts
@@ -15,12 +15,13 @@ export class EarnBySurveyTokenOption extends TokenOption {
         name: string,
         description: string,
         tokenBalanceChange: number,
+        isMigrating: boolean,
         surveyId: string,
         fieldName: string,
         startTime: Date,
         endTime: Date
     ) {
-        super(group, type, id, name, description, tokenBalanceChange);
+        super(group, type, id, name, description, tokenBalanceChange, isMigrating);
         this._surveyId = surveyId;
         this._fieldName = fieldName;
         this._startTime = startTime;

--- a/src/app/token-options/spend-for-assignment-resubmission-token-option.ts
+++ b/src/app/token-options/spend-for-assignment-resubmission-token-option.ts
@@ -16,13 +16,14 @@ export class SpendForAssignmentResubmissionTokenOption extends TokenOption {
         name: string,
         description: string,
         tokenBalanceChange: number,
+        isMigrating: boolean,
         assignmentName: string,
         assignmentId: string,
         startTime: Date,
         endTime: Date,
         newDueTime: Date
     ) {
-        super(group, type, id, name, description, tokenBalanceChange);
+        super(group, type, id, name, description, tokenBalanceChange, isMigrating);
         this._assignmentName = assignmentName;
         this._assignmentId = assignmentId;
         this._startTime = startTime;

--- a/src/app/token-options/spend-for-lab-data-token-option.ts
+++ b/src/app/token-options/spend-for-lab-data-token-option.ts
@@ -17,6 +17,7 @@ export class SpendForLabDataTokenOption extends TokenOption {
         name: string,
         description: string,
         tokenBalanceChange: number,
+        isMigrating: boolean,
         quizName: string,
         quizId: string,
         startTime: Date,
@@ -24,7 +25,7 @@ export class SpendForLabDataTokenOption extends TokenOption {
         newDueTime: Date,
         excludeTokenOptionIds: number[]
     ) {
-        super(group, type, id, name, description, tokenBalanceChange);
+        super(group, type, id, name, description, tokenBalanceChange, isMigrating);
         this._quizName = quizName;
         this._quizId = quizId;
         this._startTime = startTime;

--- a/src/app/token-options/spend-for-lab-switch-token-option.ts
+++ b/src/app/token-options/spend-for-lab-switch-token-option.ts
@@ -11,9 +11,10 @@ export class SpendForLabSwitchTokenOption extends TokenOption {
         name: string,
         description: string,
         tokenBalanceChange: number,
+        isMigrating: boolean,
         excludeTokenOptionIds: number[]
     ) {
-        super(group, type, id, name, description, tokenBalanceChange);
+        super(group, type, id, name, description, tokenBalanceChange, isMigrating);
         this._excludeTokenOptionIds = excludeTokenOptionIds;
     }
 

--- a/src/app/token-options/token-option.ts
+++ b/src/app/token-options/token-option.ts
@@ -8,6 +8,7 @@ export abstract class TokenOption {
     private _name: string;
     private _description: string;
     private _tokenBalanceChange: number;
+    private _isMigrating: boolean;
 
     constructor(
         group: TokenOptionGroup,
@@ -15,7 +16,8 @@ export abstract class TokenOption {
         id: number,
         name: string,
         description: string,
-        tokenBalanceChange: number
+        tokenBalanceChange: number,
+        isMigrating: boolean
     ) {
         this._group = group;
         this._type = type;
@@ -23,6 +25,7 @@ export abstract class TokenOption {
         this._name = name;
         this._description = description;
         this._tokenBalanceChange = tokenBalanceChange;
+        this._isMigrating = isMigrating;
     }
 
     public get group(): TokenOptionGroup {
@@ -73,6 +76,14 @@ export abstract class TokenOption {
         this._tokenBalanceChange = tokenBalanceChange;
     }
 
+    public set isMigrating(isMigrating: boolean) {
+        this._isMigrating = isMigrating;
+    }
+
+    public get isMigrating(): boolean {
+        return this._isMigrating;
+    }
+
     public get prompt(): string {
         return 'Request for ' + this.name;
     }
@@ -83,7 +94,8 @@ export abstract class TokenOption {
             id: this.id,
             name: this.name,
             description: Base64.encode(this.description),
-            token_balance_change: this.tokenBalanceChange
+            token_balance_change: this.tokenBalanceChange,
+            is_migrating: this.isMigrating ? true : undefined
         };
     }
 
@@ -98,7 +110,8 @@ export abstract class TokenOption {
             typeof data['id'] != 'number' ||
             typeof data['name'] != 'string' ||
             (typeof data['description'] != 'undefined' && typeof data['description'] != 'string') ||
-            typeof data['token_balance_change'] != 'number'
+            typeof data['token_balance_change'] != 'number' ||
+            (typeof data['is_migrating'] != 'undefined' && typeof data['is_migrating'] != 'boolean')
         )
             throw new Error('Invalid data');
         return [
@@ -107,7 +120,8 @@ export abstract class TokenOption {
             data['id'],
             data['name'],
             data['description'] ? Base64.decode(data['description']) : '',
-            data['token_balance_change']
+            data['token_balance_change'],
+            data['is_migrating'] ?? false
         ];
     }
 }

--- a/src/app/token-options/withdraw-token-option.ts
+++ b/src/app/token-options/withdraw-token-option.ts
@@ -13,9 +13,10 @@ export abstract class WithdrawTokenOption<T> extends TokenOption {
         name: string,
         description: string,
         tokenBalanceChange: number,
+        isMigrating: boolean,
         withdrawTokenOptionId: number
     ) {
-        super(group, type, id, name, description, tokenBalanceChange);
+        super(group, type, id, name, description, tokenBalanceChange, isMigrating);
         this._withdrawTokenOptionId = withdrawTokenOptionId;
     }
 

--- a/src/app/utils/random-string-generator.ts
+++ b/src/app/utils/random-string-generator.ts
@@ -1,0 +1,4 @@
+// Ref: https://stackoverflow.com/a/47496558
+export function generateRandomString(size: number): string {
+    return [...Array(size)].map(() => Math.random().toString(36)[2] ?? '0').join('');
+}


### PR DESCRIPTION
### Description

1. A new button "Reset Token ATM" in the Configuration page is available to reset Token ATM content. Resetting Token ATM content will cause all previous Token ATM content being deleted and generated again, which clears all existing token balances & requests. The original publish state of token option groups will remain the same.
2. A new button "Migrate Token ATM" in the Configuration page is available to migrate Token ATM content. Migrating Token ATM content will cause all previous Token ATM content being deleted and generated again, which clears all existing token balances & requests. All token option groups will be unpublished, while every token option needs to be saved to complete its migration and become available for students to request for. Token options whose migrations are not completed won't be shown in the request submission quiz, while warning signs and notices will be shown for them in the Token Options page.

### Testing Note

1. Please test if these two functionalities work as described above. 
2. There is a mechanism change on the generation of request submsision quiz: in the previous implementation, all quiz questions of a request submission quiz are deleted first, and then new quiz question(s) are generated. This pull request change the implementation to replacing existing quiz questions as much as possible. Please test if creating/modifying/deleting/moving token options still generates correct quiz questions.