### PR TITLE
Feature: Sanitize and Parse user supplied Canvas URL

### DIFF
--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -171,7 +171,18 @@ export class LoginComponent implements AfterViewInit {
         this.isProcessing = false;
     }
 
+    private parseURL(url: string) {
+        const parsedURL = new URL(url);
+        // Force HTTPS protocol
+        parsedURL.protocol = 'https:';
+        return parsedURL.origin;
+    }
+
     async onSubmitCredential(): Promise<void> {
+        // TODO: Check that Canvas is only hosted at a URL origin. If
+        //       Canvas is hosted on a sub-directory, Token ATM won't
+        //       send requests properly.
+        this.credentials.canvasURL = this.parseURL(this.credentials.canvasURL);
         const canvasCredentialValidation = await this.canvasService.configureCredential(
             this.credentials.canvasURL,
             this.credentials.canvasAccessToken

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -176,12 +176,13 @@ export class LoginComponent implements AfterViewInit {
         // Force HTTPS protocol
         parsedURL.protocol = 'https:';
         return parsedURL.origin;
+        // Based on: https://community.canvaslms.com/t5/Canvas-Basics-Guide/Where-do-I-find-my-institution-s-URL-to-access-Canvas/ta-p/82
+        // It looks like Canvas is only hosted at a URL origin.
+        // If a Canvas is hosted on a sub-directory, Token ATM won't
+        // send requests properly.
     }
 
     async onSubmitCredential(): Promise<void> {
-        // TODO: Check that Canvas is only hosted at a URL origin. If
-        //       Canvas is hosted on a sub-directory, Token ATM won't
-        //       send requests properly.
         this.credentials.canvasURL = this.parseURL(this.credentials.canvasURL);
         const canvasCredentialValidation = await this.canvasService.configureCredential(
             this.credentials.canvasURL,

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Inject, isDevMode, TemplateRef, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Inject, isDevMode, SecurityContext, TemplateRef, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormItemInfo } from 'app/data/form-item-info';
 import { TokenATMCredentials } from 'app/data/token-atm-credentials';
@@ -8,6 +8,7 @@ import { ModalManagerService } from 'app/services/modal-manager.service';
 import { QualtricsService } from 'app/services/qualtrics.service';
 import { ErrorSerializer } from 'app/utils/error-serailizer';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
+import { DomSanitizer } from '@angular/platform-browser';
 
 type TokenATMCredentialsAttributes = Exclude<keyof TokenATMCredentials, 'toJSON'>;
 
@@ -37,7 +38,8 @@ export class LoginComponent implements AfterViewInit {
         @Inject(CredentialManagerService) private credentialManagerService: CredentialManagerService,
         @Inject(Router) private router: Router,
         @Inject(BsModalService) private modalService: BsModalService,
-        @Inject(ModalManagerService) private modalManagerService: ModalManagerService
+        @Inject(ModalManagerService) private modalManagerService: ModalManagerService,
+        @Inject(DomSanitizer) private sanitizer: DomSanitizer
     ) {}
 
     static CREDENTIALS_FORM_ITEM_INFO_MAP: CredentialsFormItemInfoMap = {
@@ -171,8 +173,14 @@ export class LoginComponent implements AfterViewInit {
         this.isProcessing = false;
     }
 
-    private parseURL(url: string) {
-        const parsedURL = new URL(url);
+    private sanitizeAndParseURL(url: string) {
+        const sanitized = this.sanitizer.sanitize(SecurityContext.URL, url);
+        if (sanitized == null || sanitized.startsWith('unsafe:')) {
+            throw new Error(`Provided Canvas URL (${url}) can't be sanitized.`);
+        }
+        // TODO: handle protocol-less inputs.
+        //       i.e., 'localhost:23457' or 'canvas.instructure.com'
+        const parsedURL = new URL(sanitized);
         // Force HTTPS protocol
         parsedURL.protocol = 'https:';
         return parsedURL.origin;
@@ -183,7 +191,16 @@ export class LoginComponent implements AfterViewInit {
     }
 
     async onSubmitCredential(): Promise<void> {
-        this.credentials.canvasURL = this.parseURL(this.credentials.canvasURL);
+        try {
+            this.credentials.canvasURL = this.sanitizeAndParseURL(this.credentials.canvasURL);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            await this.modalManagerService.createNotificationModal(
+                ErrorSerializer.serailize(error),
+                'Canvas URL Error'
+            );
+            return;
+        }
         const canvasCredentialValidation = await this.canvasService.configureCredential(
             this.credentials.canvasURL,
             this.credentials.canvasAccessToken


### PR DESCRIPTION
### Description
Sanitizes and parses Canvas URLs provided by the user.

The parsing functionality forces the URL protocol scheme to be HTTPS, and returns only the origin URL (discards all directories and parameters).

Unsafe URLs and strings that aren't valid URLs result in a `Canvas URL Error` notification modal.

### Testing notes

1. Sanitization is done using this angular code: https://github.com/angular/angular/blob/main/packages/core/src/sanitization/url_sanitizer.ts#L39
1.1. A `javascript:` protocol is treated as unsafe. See the [`SAFE_URL_PATTERN` regex](https://github.com/angular/angular/blob/main/packages/core/src/sanitization/url_sanitizer.ts#L38) for more specific examples.
2. Parsing changes the URL's protocol scheme (i.e., `ftp:`, `http:`, etc.) to `https:`.
3. The Canvas URL input field is overwritten with the new sanitized and parsed URL.
4. If a URL is unsafe or not a valid URL, the error modal should appear. And network connections to Canvas and Qualtrics should not occur.
5. A user should be able to copy the entirety of a Canvas URL from their browser, paste it directly into Token ATM, and have Token ATM automatically update it to a proper origin URL.