### PR TITLE
Handle possible whitespace in local workspace path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,8 +34,8 @@
     // Use 'postCreateCommand' to run commands after the container is created.
     "initializeCommand": "git config -l > \"${localWorkspaceFolder}\"/.devcontainer/.gitconfig.all && git config --local -l > \"${localWorkspaceFolder}\"/.devcontainer/.gitconfig.local",
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "cd ${containerWorkspaceFolder}/.devcontainer && /bin/bash ./setup.sh",
-    "postAttachCommand": "cd ${containerWorkspaceFolder}/.devcontainer && /bin/bash ./attach.sh",
+    "postCreateCommand": "cd \"${containerWorkspaceFolder}\"/.devcontainer && /bin/bash ./setup.sh",
+    "postAttachCommand": "cd \"${containerWorkspaceFolder}\"/.devcontainer && /bin/bash ./attach.sh",
 
     // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "node"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
     "forwardPorts": [4200, 9876],
 
     // Use 'postCreateCommand' to run commands after the container is created.
-    "initializeCommand": "git config -l > ${localWorkspaceFolder}/.devcontainer/.gitconfig.all && git config --local -l > ${localWorkspaceFolder}/.devcontainer/.gitconfig.local",
+    "initializeCommand": "git config -l > \"${localWorkspaceFolder}\"/.devcontainer/.gitconfig.all && git config --local -l > \"${localWorkspaceFolder}\"/.devcontainer/.gitconfig.local",
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "cd ${containerWorkspaceFolder}/.devcontainer && /bin/bash ./setup.sh",
     "postAttachCommand": "cd ${containerWorkspaceFolder}/.devcontainer && /bin/bash ./attach.sh",


### PR DESCRIPTION
White space characters in paths are not automatically escaped by VS code and bash commands.

This pull request adds quotes to uses of the local workspace folder path so that the initialize command works without error for developers with white space characters in their local dev path.