### PR TITLE
Update onDelete modal to match onReset & onMigrate

### DIFF
--- a/src/app/components/configuration/configuration.component.ts
+++ b/src/app/components/configuration/configuration.component.ts
@@ -156,11 +156,12 @@ export class ConfigurationComponent implements CourseConfigurable {
             'Confirmation',
             true
         );
-        modalRef.hide();
         if (!result) {
             this.isProcessing = false;
+            modalRef.hide();
             return;
         }
+        if (modalRef.content) modalRef.content.disableButton = true;
         try {
             const configuration = await this.configurationManagerService.getTokenATMConfiguration(this.course);
             await this.configurationManagerService.deleteAll(configuration);
@@ -175,7 +176,9 @@ export class ConfigurationComponent implements CourseConfigurable {
                 )}\n***ACTION NEEDED***: \nYou can use Canvas to delete the Token ATM content by manually deleting: \n1) the two Canvas pages prefixed with 'Token ATM', \n2) the one Canvas assignment group prefixed with 'Token ATM', and \n3) the one Canvas module prefixed with 'Token ATM'. \n***Sorry for the inconvenience!`,
                 'Error'
             );
+        } finally {
             this.isProcessing = false;
+            modalRef.hide();
         }
     }
 


### PR DESCRIPTION
The UI view of the error reporting modal for `onDeleteAll()` doesn't match the new configuration buttons. This PR updates it to match.

**Testing Note**:
1. Use the code `if (window) throw new Error('Forced Testing Error');` as the first line of the try block for `onDeleteAll()`, `onResetContent()`, and `onMigrate()`.
2. The user interactions for the error reporting modal should match for all three buttons (e.g. page in background is dimmed)