### PR TITLE
Bugfix: maximum token option count per group

### DIFF
--- a/src/app/components/move-token-option-modal/move-token-option-modal.component.html
+++ b/src/app/components/move-token-option-modal/move-token-option-modal.component.html
@@ -22,7 +22,7 @@
                 *ngFor="let group of configuration.tokenOptionGroups"
                 [ngValue]="group"
                 [disabled]="group !== srcOption?.group && group.isFull"
-                [title]="
+                [attr.title]="
                     group !== srcOption?.group && group.isFull
                         ? 'This token option group is full (cannot have more than 17 token options in one group)'
                         : undefined

--- a/src/app/components/move-token-option-modal/move-token-option-modal.component.html
+++ b/src/app/components/move-token-option-modal/move-token-option-modal.component.html
@@ -18,7 +18,18 @@
             </option>
         </select>
         <select class="form-select m-2" [ngModel]="selectedGroup" (ngModelChange)="onSelectTokenOptionGroup($event)">
-            <option *ngFor="let group of configuration.tokenOptionGroups" [ngValue]="group">{{ group.name }}</option>
+            <option
+                *ngFor="let group of configuration.tokenOptionGroups"
+                [ngValue]="group"
+                [disabled]="group !== srcOption?.group && group.isFull"
+                [title]="
+                    group !== srcOption?.group && group.isFull
+                        ? 'This token option group is full (cannot have more than 17 token options in one group)'
+                        : undefined
+                "
+            >
+                {{ group.name }}
+            </option>
         </select>
         <ng-container *ngIf="validTokenOptions">
             <select

--- a/src/app/components/move-token-option-modal/move-token-option-modal.component.html
+++ b/src/app/components/move-token-option-modal/move-token-option-modal.component.html
@@ -24,7 +24,9 @@
                 [disabled]="group !== srcOption?.group && group.isFull"
                 [attr.title]="
                     group !== srcOption?.group && group.isFull
-                        ? 'This token option group is full (cannot have more than 17 token options in one group)'
+                        ? 'This token option group is full (there cannot be more than ' +
+                          tokenOptionGroupMaxSize.toString() +
+                          ' token options in a group)'
                         : undefined
                 "
             >

--- a/src/app/components/move-token-option-modal/move-token-option-modal.component.ts
+++ b/src/app/components/move-token-option-modal/move-token-option-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, Input } from '@angular/core';
 import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
-import type { TokenOptionGroup } from 'app/data/token-option-group';
+import { TokenOptionGroup } from 'app/data/token-option-group';
 import { ModalManagerService } from 'app/services/modal-manager.service';
 import { TokenATMConfigurationManagerService } from 'app/services/token-atm-configuration-manager.service';
 import type { TokenOption } from 'app/token-options/token-option';
@@ -93,6 +93,10 @@ export class MoveTokenOptionModalComponent {
     onSelectTokenOptionGroup(group: TokenOptionGroup) {
         this.selectedGroup = group;
         this.selectedOption = undefined;
+    }
+
+    get tokenOptionGroupMaxSize() {
+        return TokenOptionGroup.TOKEN_OPTION_GROUP_MAX_SIZE;
     }
 
     get validTokenOptions(): TokenOption[] | undefined {

--- a/src/app/components/token-option-group-display/token-option-group-display.component.html
+++ b/src/app/components/token-option-group-display/token-option-group-display.component.html
@@ -15,7 +15,22 @@
                 [class.bi-slash-circle]="!group.isPublished"
                 (click)="group.isPublished ? onUnpublishGroup() : onPublishGroup()"
             ></span>
-            <span class="bi bi-plus-circle text-success fs-5 mx-3 is-link" (click)="onCreateTokenOption()"></span>
+            <div
+                [title]="
+                    group.isFull
+                        ? 'Group is full (cannot have more than 17 token options in one group)'
+                        : 'Add a new token option to this group'
+                "
+            >
+                <button
+                    type="button"
+                    class="btn btn-outline-success mx-3 border-0"
+                    (click)="onCreateTokenOption()"
+                    [disabled]="group.isFull ? 'disabled' : undefined"
+                >
+                    <span class="bi bi-plus-circle fs-5"></span>
+                </button>
+            </div>
             <div class="btn-group" dropdown>
                 <span class="bi bi-three-dots-vertical fs-5 mx-3 is-link" dropdownToggle></span>
                 <ul class="dropdown-menu dropdown-menu-right border-dark text-center" *dropdownMenu>

--- a/src/app/components/token-option-group-display/token-option-group-display.component.html
+++ b/src/app/components/token-option-group-display/token-option-group-display.component.html
@@ -18,7 +18,9 @@
             <div
                 [title]="
                     group.isFull
-                        ? 'Group is full (cannot have more than 17 token options in one group)'
+                        ? 'Group is full (there cannot be more than ' +
+                          tokenOptionGroupMaxSize.toString() +
+                          ' token options in a group)'
                         : 'Add a new token option to this group'
                 "
             >

--- a/src/app/components/token-option-group-display/token-option-group-display.component.ts
+++ b/src/app/components/token-option-group-display/token-option-group-display.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, Input } from '@angular/core';
-import type { TokenOptionGroup } from 'app/data/token-option-group';
+import { TokenOptionGroup } from 'app/data/token-option-group';
 import { ModalManagerService } from 'app/services/modal-manager.service';
 import { TokenATMConfigurationManagerService } from 'app/services/token-atm-configuration-manager.service';
 import { BsModalService } from 'ngx-bootstrap/modal';
@@ -91,5 +91,9 @@ export class TokenOptionGroupDisplayComponent {
         if (modalRef.content) modalRef.content.disableButton = true;
         await this.configurationManagerService.deleteTokenOptionGroup(this.group);
         modalRef.hide();
+    }
+
+    get tokenOptionGroupMaxSize() {
+        return TokenOptionGroup.TOKEN_OPTION_GROUP_MAX_SIZE;
     }
 }

--- a/src/app/data/token-option-group.ts
+++ b/src/app/data/token-option-group.ts
@@ -11,6 +11,7 @@ export class TokenOptionGroup {
     private _description: string;
     private _isPublished: boolean;
     private _tokenOptions: TokenOption[];
+    public static TOKEN_OPTION_GROUP_MAX_SIZE = 17;
 
     constructor(
         configuration: TokenATMConfiguration,
@@ -80,6 +81,10 @@ export class TokenOptionGroup {
 
     public get availableTokenOptions(): TokenOption[] {
         return this.tokenOptions.filter((tokenOption) => !tokenOption.isMigrating);
+    }
+
+    public get isFull(): boolean {
+        return this.tokenOptions.length >= TokenOptionGroup.TOKEN_OPTION_GROUP_MAX_SIZE;
     }
 
     public addTokenOption(tokenOption: TokenOption, position?: number): void {


### PR DESCRIPTION
### Description

As discovered in [the testing for a pull request](https://github.com/UCI-IN4MATX-191-Token-ATM/token-atm-spa/pull/65#issuecomment-1682937688), a token option group cannot contain more than 17 token options. This is because of the limitation on the number of options of a multiple-choice question in Canvas.

This pull request prevents the user from attempting to create a token option group with the following change of behaviors:

1.  If a token option group has 17 token options, the “+” button at the right of the group name on the “Token Options” page will be disabled. In that case, a tooltip on it (shown when hovering over it) will explain why it is disabled.
2.  When moving a token option group, if a token option group is not the same as the source token option group and already contains 17 token options, that token option group will be disabled in the select element. A tooltip on it (shown when hovering over it) will explain why it is disabled.

### Testing Note

Please test if the above behavior changes work as expected. Also, please test if the protection is comprehensive by attempting to break this protection. For testing purpose, you can change `TokenOptionGroup.TOKEN_OPTION_GROUP_MAX_SIZE` to change the token option count limitation.