### PR TITLE
Bugfix: Assignment Override Decode

### DIFF
--- a/src/app/data/assignment-override.ts
+++ b/src/app/data/assignment-override.ts
@@ -3,14 +3,15 @@ import { ISODateDef } from '../utils/mixin-helper';
 import { chain } from 'fp-ts/Either';
 import camelcaseKeys from 'camelcase-keys';
 import decamelizeKeys from 'decamelize-keys';
+import { NullOrUndefinedAsNull } from 'app/utils/io-ts-type-definitions';
 
 export const AssignmentOverrideDataDef = t.intersection([
     t.strict({
         id: t.string,
         title: t.string,
-        lockAt: t.union([ISODateDef, t.null]),
-        unlockAt: t.union([ISODateDef, t.null]),
-        dueAt: t.union([ISODateDef, t.null])
+        lockAt: t.union([ISODateDef, NullOrUndefinedAsNull]),
+        unlockAt: t.union([ISODateDef, NullOrUndefinedAsNull]),
+        dueAt: t.union([ISODateDef, NullOrUndefinedAsNull])
     }),
     t.union([
         t.strict({

--- a/src/app/request-handlers/spend-for-quiz-revision-request-handler.ts
+++ b/src/app/request-handlers/spend-for-quiz-revision-request-handler.ts
@@ -51,7 +51,7 @@ export class SpendForQuizRevisionRequestHandler extends RequestHandler<
                 configuration.course.id,
                 request.tokenOption.assignmentId,
                 studentRecord.student.id,
-                '',
+                `Token ATM - ${configuration.uid}`,
                 request.tokenOption.newDueTime
             );
         }

--- a/src/app/utils/io-ts-type-definitions.ts
+++ b/src/app/utils/io-ts-type-definitions.ts
@@ -3,6 +3,6 @@ import * as t from 'io-ts';
 export const NullOrUndefinedAsNull = new t.Type<null, unknown, unknown>(
     'NullOrUndefinedAsNull',
     (v): v is null => v == null,
-    (v, ctx) => (v == null || v == undefined ? t.success(null) : t.failure(v, ctx)),
+    (v, ctx) => (v === null || v === undefined ? t.success(null) : t.failure(v, ctx)),
     () => null
 );

--- a/src/app/utils/io-ts-type-definitions.ts
+++ b/src/app/utils/io-ts-type-definitions.ts
@@ -1,0 +1,8 @@
+import * as t from 'io-ts';
+
+export const NullOrUndefinedAsNull = new t.Type<null, unknown, unknown>(
+    'NullOrUndefinedAsNull',
+    (v): v is null => v == null,
+    (v, ctx) => (v == null || v == undefined ? t.success(null) : t.failure(v, ctx)),
+    () => null
+);


### PR DESCRIPTION
### Description

Canvas treats assignment override created from the user interface and via API differently. For all assignment overrides created from the user interface, its date attributes will be `null` unless specified. However, for assignment override created via API, its date attributes will be `undefined` unless specified. Token ATM currently cannot properly decode assignment overrides created via API as expected since it assume all dates attributes will be either a ISO Date string or `null`. This pull request fix this issue by accepting `undefined` as a possible value of the date attribute.

In addition, this pull request includes a fix for the issue of the quiz revision request handler using incorrect assignment override prefix.

### Testing Note

Please test if the fix works as expected by testing if token options that involves manipulation of assignment overrides work as expected. `spend-for-quiz-revision` should be the main focus. Since this is a urgent bugfix, we can test other token options adequately for comprehensiveness after this pull request is merged.