### PR TITLE
Bugfix: assignment override update 

### DIFF
--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1033,7 +1033,7 @@ export class CanvasService {
             }
             if (override.studentIdsAsIndividualLevel.includes(studentId)) return false;
             if (targetOverride != undefined) continue;
-	    if (
+            if (
                 override.studentIdsAsIndividualLevel.length >= CanvasService.ASSIGNMENT_OVERRIDE_MAX_SIZE ||
                 override.lockAt == undefined ||
                 compareAsc(override.lockAt, lockDate) != 0

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1032,13 +1032,14 @@ export class CanvasService {
                 titleCnt = parseInt(data[2] as string) + 1;
             }
             if (override.studentIdsAsIndividualLevel.includes(studentId)) return false;
-            if (
+            if (targetOverride != undefined) continue;
+	    if (
                 override.studentIdsAsIndividualLevel.length >= CanvasService.ASSIGNMENT_OVERRIDE_MAX_SIZE ||
                 override.lockAt == undefined ||
                 compareAsc(override.lockAt, lockDate) != 0
             )
                 continue;
-            if(!targetOverride) targetOverride = override;
+            targetOverride = override;
         }
         if (!targetOverride) {
             await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides`, {

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1038,8 +1038,7 @@ export class CanvasService {
                 compareAsc(override.lockAt, lockDate) != 0
             )
                 continue;
-            targetOverride = override;
-            break;
+            if(!targetOverride) targetOverride = override;
         }
         if (!targetOverride) {
             await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/overrides`, {


### PR DESCRIPTION
### Description

The current implementation of `createAssignmentOverrideForStduent` in `canvas.service.ts` breaks the loop of checking assignment override when a proper assignment override to update is found (exact lockDate & not exceeding size limit). However, this loop is also used for checking whether the student to be added to a new assignment override already belongs to another assignment override or not. Breaking this loop could cause some assignment overrides to skip the check, while the student could just belong to one of these skipped assignment overrides. This bugfix resolves this issue by preventing the break of the loop.

### Error Reproduction

1. Create a Canvas assignment.
2. Create a new token option of spend-for-quiz-revision. Configure the assignment for explanation document submission to be the assignment just created.
3. Create two assignment overrides for two students (A and B) separately in the Canvas assignment created in step 1. The assignment override for student B should be created later than the assignment override for student A. These two assignment overrides should have its until date being configured the same as the new until time configured in the token option created in step 2.
4. Let student B request for the token option created in step 2.
5. The error should occur when handling the request made by student B.

### Testing Note

Please test if the bugfix prevent this error to occur. Also, please test if the error resolves after switching from the main branch to the branch of this pull request.