### PR TITLE
Bugfix: incorrect message for stopped requests exportation

### DIFF
--- a/src/app/components/export-request-modal/export-request-modal.component.ts
+++ b/src/app/components/export-request-modal/export-request-modal.component.ts
@@ -248,7 +248,7 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
                 this.fileName = exportedFile.name;
                 this.configField.isReadOnly = true;
             } else this.configField.isReadOnly = false;
-            if (exportedFile == null)
+            if (exportedFile === null)
                 this.message =
                     'Export finished, but there are no requests that satisfy the restrictions specified above.';
             this.isProcessing = false;


### PR DESCRIPTION
### Description

When stopping a request exportation before it finishes, the message "Export finished, but there are no requests that satisfy the restrictions specified above." will shows, which is incorrect. This is caused by using `==` to compare a value that is possibly `null` or `undefined` to `null` while expecting the comparsion result between `undefined` and `null` to be `false`. This bugfix resolves this issue by using `===` instead of `==`.

### Error Reproduction

Please start a request export and stop it before it finishes. The message "Export finished, but there are no requests that satisfy the restrictions specified above." will be shown even if the request exportation is not actually finished.

### Testing Note

Please test if the bugfix works as expected.