### PR TITLE
Bugfix: Canvas Pagination Change

### DIFF
--- a/src/app/utils/paginated-result.ts
+++ b/src/app/utils/paginated-result.ts
@@ -46,8 +46,9 @@ export class PaginatedResult<T> implements AsyncIterable<T> {
         let index = 0;
         while (this.hasNextPage() || index != this.data.length) {
             if (index == this.data.length) await this.fetchNextPage();
+            if (index == this.data.length) return;
             const result = this.data[index++];
-            if (!result) throw new Error('Index out of bounds');
+            if (result === undefined) throw new Error('Index out of bounds');
             yield result;
         }
     }


### PR DESCRIPTION
### Description

Canvas changes the pagination implementation from opaque token back to the old version of page number. Under the current implementation, for some endpoints, Canvas will return an empty page as the last page when the total number of records is divisible by the number of records per page. Previously Token ATM assumes each page except for the first page will have some data. This bugfix checks whether a returned page is empty or not.

### Testing Note

Please test if the bugfix works as expected. A known endpoint that has this behavior is [“List user in course”](https://canvas.instructure.com/doc/api/courses.html#method.courses.users). Since this bugfix is urgent, while the change theoretically should not cause any issue, testing will be performed after this pull request get merged.