### PR TITLE
Enhancement: Move CSV handling (parsing, unparsing, and bundling) into a Service

### DIFF
--- a/src/app/components/batch-token-balance-adjustment-modal/batch-token-balance-adjustment-modal.component.ts
+++ b/src/app/components/batch-token-balance-adjustment-modal/batch-token-balance-adjustment-modal.component.ts
@@ -260,14 +260,14 @@ export class BatchTokenBalanceAdjustmentModalComponent implements OnDestroy {
         if (this.errorCollection == null) {
             throw new Error('Error collector has not been initialized');
         }
-        const error_noLinebreaks = errorMessage.replaceAll(/[\n\r]/g, '  ');
+        const errorNoLinebreaks = errorMessage.replaceAll(/[\n\r]/g, '  ');
         if (Array.isArray(record)) {
-            this.errorCollection.push([...record, `line ${line}`, error_noLinebreaks]);
+            this.errorCollection.push([...record, `line ${line}`, errorNoLinebreaks]);
         } else {
             this.errorCollection.push({
                 ...record,
                 Line: `${line}`,
-                Error: error_noLinebreaks
+                Error: errorNoLinebreaks
             });
         }
     }

--- a/src/app/components/batch-token-balance-adjustment-modal/batch-token-balance-adjustment-modal.component.ts
+++ b/src/app/components/batch-token-balance-adjustment-modal/batch-token-balance-adjustment-modal.component.ts
@@ -275,7 +275,7 @@ export class BatchTokenBalanceAdjustmentModalComponent implements OnDestroy {
     async makeErrorCSV() {
         if (this.errorCollection == null || this.errorCollection.length == 0) return;
 
-        const importedFileName = this.selectedFile?.name == null ? 'Batch-CSV' : this.selectedFile?.name;
+        const importedFileName = this.selectedFile?.name ?? 'Batch-CSV';
         this.errorsCSVFile = await this.csvService.makeFile(new Map([[importedFileName, this.errorCollection]]), {
             prefix: '',
             suffix: 'Import-Errors'

--- a/src/app/components/export-request-modal/export-request-modal.component.ts
+++ b/src/app/components/export-request-modal/export-request-modal.component.ts
@@ -225,7 +225,7 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
             this.exportInstance = this.requestExporterService.createRequestExportInstance(
                 this.configuration,
                 students,
-                undefined,
+                this.titleSuffix,
                 async (request: ProcessedRequest) => {
                     if (this.filter && !(await this.filter(request))) return false;
                     if (

--- a/src/app/services/csvs.service.spec.ts
+++ b/src/app/services/csvs.service.spec.ts
@@ -1,0 +1,16 @@
+// import { TestBed } from '@angular/core/testing';
+
+// import { CSVsService } from './csvs.service';
+
+// describe('CSVsService', () => {
+//   let service: CSVsService;
+
+//   beforeEach(() => {
+//     TestBed.configureTestingModule({});
+//     service = TestBed.inject(CSVsService);
+//   });
+
+//   it('should be created', () => {
+//     expect(service).toBeTruthy();
+//   });
+// });

--- a/src/app/services/csvs.service.ts
+++ b/src/app/services/csvs.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class CSVsService {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor() {}
+}

--- a/src/app/services/csvs.service.ts
+++ b/src/app/services/csvs.service.ts
@@ -79,7 +79,7 @@ export class CSVsService {
             [await this.zipObject.generateAsync({ type: 'blob' })],
             sanitizeFileName(
                 this.filenameTemplate(
-                    typeof zipName === 'string' ? zipName : '',
+                    zipName ?? '',
                     zipFixes
                         ? zipFixes
                         : {

--- a/src/app/services/csvs.service.ts
+++ b/src/app/services/csvs.service.ts
@@ -4,7 +4,7 @@ import ZipFile from 'jszip';
 import sanitizeFileName from 'sanitize-filename';
 import { formatISO } from 'date-fns';
 
-type Fixes = { prefix: string; suffix: string };
+type Affixes = { prefix: string; suffix: string };
 
 @Injectable({
     providedIn: 'root'
@@ -39,9 +39,9 @@ export class CSVsService {
 
     public async makeFile(
         namesAndContent: Map<string, Record<string, string>[]>,
-        fixes?: Fixes,
+        fixes?: Affixes,
         zipName?: string,
-        zipFixes?: Fixes
+        zipFixes?: Affixes
     ): Promise<File> {
         if (namesAndContent.size === 0) {
             throw new Error('No filename or data provided to make a file');
@@ -52,7 +52,7 @@ export class CSVsService {
         }
     }
 
-    private makeCSVFile(nameAndContent: [string, Record<string, string>[]], fixes?: Fixes) {
+    private makeCSVFile(nameAndContent: [string, Record<string, string>[]], fixes?: Affixes) {
         const [filename, data] = nameAndContent;
         return new File(
             [CSVParse.unparse(data)],
@@ -65,9 +65,9 @@ export class CSVsService {
 
     private async makeZipFile(
         namesAndContent: Map<string, Record<string, string>[]>,
-        fixes?: Fixes,
+        fixes?: Affixes,
         zipName?: string,
-        zipFixes?: Fixes
+        zipFixes?: Affixes
     ) {
         const zipFile = new ZipFile();
         const generationDate = new Date();
@@ -98,7 +98,7 @@ export class CSVsService {
         );
     }
 
-    private filenameTemplate(filename: string, date?: Date, fixes?: Fixes): string {
+    private filenameTemplate(filename: string, date?: Date, fixes?: Affixes): string {
         const taggedDate = date ?? new Date();
         return [fixes?.prefix, filename, fixes?.suffix, formatISO(taggedDate, { format: 'basic' })]
             .filter((x) => x)

--- a/src/app/services/csvs.service.ts
+++ b/src/app/services/csvs.service.ts
@@ -1,9 +1,103 @@
 import { Injectable } from '@angular/core';
+import * as CSVParse from 'papaparse';
+import ZipFile from 'jszip';
+import sanitizeFileName from 'sanitize-filename';
+import { formatISO } from 'date-fns';
+
+type Fixes = { prefix: string; suffix: string };
 
 @Injectable({
     providedIn: 'root'
 })
 export class CSVsService {
+    private zipObject = new ZipFile();
+    private currentDate: Date | undefined;
+
+    private baselineParseConfig = {
+        skipEmptyLines: true,
+        dynamicTyping: false
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     constructor() {}
+
+    // TODO: - Parsing from & Unparsing to Excel formatted CSVs (https://www.papaparse.com/faq#encoding)
+    //       - Expose Parser Errors & Meta info (`results.errors` & `results.meta`)
+    //       - Update parser to use a stream to parse row by row (makes progress indeterminate)
+
+    async parseCSV(file: File, options?: object) {
+        let promiseResolve: (results: CSVParse.ParseResult<unknown>) => void;
+        const promise = new Promise<CSVParse.ParseResult<unknown>>((resolve) => {
+            promiseResolve = resolve;
+        });
+        CSVParse.parse(file, {
+            ...this.baselineParseConfig,
+            ...options,
+            complete: async (results) => {
+                promiseResolve(results);
+            }
+        });
+        return promise;
+    }
+
+    public async makeFile(
+        namesAndContent: Map<string, Record<string, string>[]>,
+        fixes?: Fixes,
+        zipName?: string,
+        zipFixes?: Fixes
+    ): Promise<File> {
+        this.currentDate = undefined;
+        if (namesAndContent.size === 0) {
+            throw new Error('No filename or data provided to make a file');
+        } else if (namesAndContent.size === 1 && zipName === undefined && zipFixes === undefined) {
+            return this.makeCSVFile(namesAndContent.entries().next().value, fixes);
+        } else {
+            return await this.makeZipFile(namesAndContent, fixes, zipName, zipFixes);
+        }
+    }
+
+    private makeCSVFile(nameAndContent: [string, Record<string, string>[]], fixes?: Fixes) {
+        const [filename, data] = nameAndContent;
+        return new File([CSVParse.unparse(data)], sanitizeFileName(this.filenameTemplate(filename, fixes) + '.csv'), {
+            type: 'text/csv;charset=utf-8;'
+        });
+    }
+
+    private async makeZipFile(
+        namesAndContent: Map<string, Record<string, string>[]>,
+        fixes?: Fixes,
+        zipName?: string,
+        zipFixes?: Fixes
+    ) {
+        const zipFile = new ZipFile();
+        this.zipObject = zipFile;
+        for (const [filename, data] of namesAndContent.entries()) {
+            zipFile.file(sanitizeFileName(this.filenameTemplate(filename, fixes) + '.csv'), CSVParse.unparse(data));
+        }
+        // TODO: Call any functions to add more files here. E.g., Readme or Data Dictionary generator
+        return new File(
+            [await this.zipObject.generateAsync({ type: 'blob' })],
+            sanitizeFileName(
+                this.filenameTemplate(
+                    typeof zipName === 'string' ? zipName : '',
+                    zipFixes
+                        ? zipFixes
+                        : {
+                              prefix: 'Token-ATM-Export',
+                              suffix: ''
+                          }
+                ) + '.zip'
+            ),
+            {
+                type: 'application/zip'
+            }
+        );
+    }
+
+    private filenameTemplate(filename: string, fixes?: Fixes): string {
+        if (this.currentDate == null) this.currentDate = new Date();
+        return [fixes?.prefix, filename, fixes?.suffix, formatISO(this.currentDate, { format: 'basic' })]
+            .filter((x) => x)
+            .join('_');
+    }
 }

--- a/src/app/services/request-exporter.service.ts
+++ b/src/app/services/request-exporter.service.ts
@@ -76,7 +76,7 @@ export class RequestExportInstance {
             this.curProgress++;
         }
         const fixes = { prefix: 'Token-ATM-Requests-Export', suffix: '' };
-        const fName = this.fileName ? this.fileName : '';
+        const fName = this.fileName ?? '';
         if (!this.classifier) {
             if (requestDataArray.length == 0) return null;
             return this.csvService.makeFile(new Map([[fName, requestDataArray]]), fixes);


### PR DESCRIPTION
### Description

Updated "Import CSV for Batched Manual Adjustments", "Download CSV with Import Errors" and "Export Processed Requests as CSV" to use a single angular service.

The new service`CSVsService` can make individual CSV files, or bundle multiple into a Zip. The service supports adding prefixes and suffixes to the files, and always adds a timestamp to each filename (for both CSVs and Zips). The timestamp is shared for all files bundled together.

A desired name can also be included in the filename. For example, 
- an import errors CSV filename includes the name of the imported file that was processed. And
- the highest level (either single CSV or else Zip) of an Export Processed Requests bundle now includes some context for the export (i.e., All Token Options, a specific Token Option Group, or a specific Token Option) in the filename.

### Testing Note

Please check if enhancement works as expected. Focus should be placed on the generated files, since the actual parsing should remain unchanged. A code review and generation of a file or two should be sufficient to show that (un)parsing continues to work.