### PR TITLE
Bugfix: Invalid Quiz Attempt

### DIFF
--- a/src/app/services/raw-request-fetcher.service.ts
+++ b/src/app/services/raw-request-fetcher.service.ts
@@ -18,8 +18,8 @@ export class RawRequestFetcherService {
         quizSubmissionId: string,
         curAttempt: number,
         assignmentId?: string
-    ): Promise<QuizSubmissionDetail> {
-        const [submittedAt, answers] = await this.canvasService.getQuizSubmissionAttempt(
+    ): Promise<QuizSubmissionDetail | undefined> {
+        const quizAttemptResult = await this.canvasService.getQuizSubmissionAttempt(
             configuration.course.id,
             tokenOptionGroup.quizId,
             quizSubmissionId,
@@ -27,6 +27,8 @@ export class RawRequestFetcherService {
             curAttempt,
             { assignmentId: assignmentId }
         );
+        if (!quizAttemptResult) return undefined;
+        const [submittedAt, answers] = quizAttemptResult;
         return new QuizSubmissionDetail(student, submittedAt, curAttempt, answers);
     }
 }

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -253,6 +253,7 @@ export class RequestProcessManagerService {
                     assignmentIdMap.get(group.quizId)
                 );
                 if (this._isStopTriggered) return [studentRecord, requests];
+                if (!quizSubmissionDetail) continue;
                 const request = await this.requestResolverRegistry.resolveRequest(group, quizSubmissionDetail);
                 if (!request) {
                     requests.push(


### PR DESCRIPTION
### Description

It seems that Canvas might create an invalid quiz attempt that does not exist in the submission history. Token ATM used to assume every quiz attempt to be valid. This pull request fix this bug by recognizing invalid quiz attempt during the request processing and ignore it.

### Testing Note

Testing is delayed since the error cannot be reproduced on the development environment. Potential testing could be conducted on the production environment after the quarter ends.