### PR TITLE
Feature: Spend Token for Assignment / Quiz Grade

### DIFF
--- a/src/app/components/form-fields/number-input-field/number-input-field.component.html
+++ b/src/app/components/form-fields/number-input-field/number-input-field.component.html
@@ -3,10 +3,11 @@
     <input
         type="number"
         class="form-control"
-        id="'input' + fieldId"
+        [id]="'input' + fieldId"
         [(ngModel)]="value"
         [readonly]="isReadOnly"
         [disabled]="isReadOnly"
+        step="any"
     />
     <p *ngIf="errorMessage" class="text-danger">{{ errorMessage }}</p>
 </div>

--- a/src/app/request-handlers/request-handler-registry.ts
+++ b/src/app/request-handlers/request-handler-registry.ts
@@ -17,6 +17,7 @@ import { WithdrawLabDataRequestHandler } from './withdraw-lab-data-request-handl
 import { WithdrawLabSwitchRequestHandler } from './withdraw-lab-switch-request-handler';
 import { SpendForQuizRevisionRequestHandler } from './spend-for-quiz-revision-request-handler';
 import { SpendForAssignmentExtensionRequestHandler } from './spend-for-assignment-extension-request-handler';
+import { SpendForPassingAssignmentRequestHandler } from './spend-for-passing-assignment-request-handler';
 
 type GenericRequestHandler = RequestHandler<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -32,7 +33,8 @@ export const REGISTERED_REQUEST_HANDLERS: Type<GenericRequestHandler>[] = [
     SpendForLabSwitchRequestHandler,
     WithdrawLabSwitchRequestHandler,
     SpendForQuizRevisionRequestHandler,
-    SpendForAssignmentExtensionRequestHandler
+    SpendForAssignmentExtensionRequestHandler,
+    SpendForPassingAssignmentRequestHandler
 ];
 
 export const REQUEST_HANDLER_INJECT_TOKEN = new InjectionToken<GenericRequestHandler[]>('REQUEST_HANDLERS');

--- a/src/app/request-handlers/spend-for-passing-assignment-request-handler.ts
+++ b/src/app/request-handlers/spend-for-passing-assignment-request-handler.ts
@@ -1,0 +1,59 @@
+import type { SpendForPassingAssignmentRequest } from 'app/requests/spend-for-passing-assignment-request';
+import type { SpendForPassingAssignmentTokenOption } from 'app/token-options/spend-for-passing-assignment-token-option';
+import { RequestHandler } from './request-handlers';
+import { Inject, Injectable } from '@angular/core';
+import { CanvasService } from 'app/services/canvas.service';
+import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
+import { ProcessedRequest } from 'app/data/processed-request';
+import { RequestHandlerGuardExecutor } from './guards/request-handler-guard-executor';
+import { RepeatRequestGuard } from './guards/repeat-request-guard';
+import { SufficientTokenBalanceGuard } from './guards/sufficient-token-balance-guard';
+import type { StudentRecord } from 'app/data/student-record';
+import { ExcludeTokenOptionsGuard } from './guards/exclude-token-options-guard';
+
+@Injectable()
+export class SpendForPassingAssignmentRequestHandler extends RequestHandler<
+    SpendForPassingAssignmentTokenOption,
+    SpendForPassingAssignmentRequest
+> {
+    constructor(@Inject(CanvasService) private canvasService: CanvasService) {
+        super();
+    }
+
+    public async handle(
+        configuration: TokenATMConfiguration,
+        studentRecord: StudentRecord,
+        request: SpendForPassingAssignmentRequest
+    ): Promise<ProcessedRequest> {
+        const guardExecutor = new RequestHandlerGuardExecutor([
+            new RepeatRequestGuard(request.tokenOption, studentRecord.processedRequests),
+            new ExcludeTokenOptionsGuard(request.tokenOption.excludeTokenOptionIds, studentRecord.processedRequests),
+            new SufficientTokenBalanceGuard(studentRecord.tokenBalance, request.tokenOption.tokenBalanceChange)
+        ]);
+        await guardExecutor.check();
+        if (!guardExecutor.isRejected) {
+            await this.canvasService.gradeSubmissionWithPercentage(
+                configuration.course.id,
+                studentRecord.student.id,
+                request.tokenOption.assignmentId,
+                request.tokenOption.gradeThreshold
+            );
+        }
+        return new ProcessedRequest(
+            configuration,
+            request.tokenOption.id,
+            request.tokenOption.name,
+            request.student,
+            !guardExecutor.isRejected,
+            request.submittedTime,
+            new Date(),
+            guardExecutor.isRejected ? 0 : request.tokenOption.tokenBalanceChange,
+            guardExecutor.message ?? '',
+            request.tokenOption.group.id
+        );
+    }
+
+    public get type(): string {
+        return 'spend-for-passing-assignment';
+    }
+}

--- a/src/app/request-resolvers/request-resolver-registry.ts
+++ b/src/app/request-resolvers/request-resolver-registry.ts
@@ -16,6 +16,7 @@ import { WithdrawLabDataRequestResolver } from './withdraw-lab-data-request-reso
 import { WithdrawLabSwitchRequestResolver } from './withdraw-lab-switch-request-resolver';
 import { SpendForQuizRevisionRequestResolver } from './spend-for-quiz-revision-request-resolver';
 import { SpendForAssignmentExtensionRequestResolver } from './spend-for-assignment-extension-request-resolver';
+import { SpendForPassingAssignmentRequestResolver } from './spend-for-passing-assignment-request-resolver';
 
 type GenericRequestResolver = RequestResolver<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -31,7 +32,8 @@ export const REGISTERED_REQUEST_RESOLVERS: Type<GenericRequestResolver>[] = [
     SpendForLabSwitchRequestResolver,
     WithdrawLabSwitchRequestResolver,
     SpendForQuizRevisionRequestResolver,
-    SpendForAssignmentExtensionRequestResolver
+    SpendForAssignmentExtensionRequestResolver,
+    SpendForPassingAssignmentRequestResolver
 ];
 
 export const REQUEST_RESOLVER_INJECT_TOKEN = new InjectionToken<GenericRequestResolver[]>('REQUEST_RESOLVERS');

--- a/src/app/request-resolvers/spend-for-passing-assignment-request-resolver.ts
+++ b/src/app/request-resolvers/spend-for-passing-assignment-request-resolver.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import type { QuizSubmissionDetail } from 'app/data/quiz-submission-detail';
+import { RequestResolver } from './request-resolver';
+import type { SpendForPassingAssignmentTokenOption } from 'app/token-options/spend-for-passing-assignment-token-option';
+import { SpendForPassingAssignmentRequest } from 'app/requests/spend-for-passing-assignment-request';
+
+@Injectable()
+export class SpendForPassingAssignmentRequestResolver extends RequestResolver<
+    SpendForPassingAssignmentTokenOption,
+    SpendForPassingAssignmentRequest
+> {
+    public async resolve(
+        tokenOption: SpendForPassingAssignmentTokenOption,
+        quizSubmissionDetail: QuizSubmissionDetail
+    ): Promise<SpendForPassingAssignmentRequest> {
+        return new SpendForPassingAssignmentRequest(
+            tokenOption,
+            quizSubmissionDetail.student,
+            quizSubmissionDetail.submittedTime,
+            quizSubmissionDetail
+        );
+    }
+
+    public get type(): string {
+        return 'spend-for-passing-assignment';
+    }
+}

--- a/src/app/requests/spend-for-passing-assignment-request.ts
+++ b/src/app/requests/spend-for-passing-assignment-request.ts
@@ -1,0 +1,4 @@
+import type { SpendForPassingAssignmentTokenOption } from 'app/token-options/spend-for-passing-assignment-token-option';
+import { TokenATMRequest } from './token-atm-request';
+
+export class SpendForPassingAssignmentRequest extends TokenATMRequest<SpendForPassingAssignmentTokenOption> {}

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -420,6 +420,22 @@ export class CanvasService {
         });
     }
 
+    public async gradeSubmissionWithPercentage(
+        courseId: string,
+        studentId: string,
+        assignmentId: string,
+        scorePercentage: number
+    ): Promise<void> {
+        await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`, {
+            method: 'put',
+            data: {
+                submission: {
+                    posted_grade: (scorePercentage * 100).toFixed(2) + '%'
+                }
+            }
+        });
+    }
+
     public async gradeSubmissionWithPostingComment(
         courseId: string,
         studentId: string,

--- a/src/app/token-option-field-component-factories/spend-for-passing-assignment-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-passing-assignment-token-option-field-component-factory.ts
@@ -1,0 +1,87 @@
+import {
+    TokenOptionFieldComponentFactory,
+    createAssignmentFieldComponentBuilder,
+    createExcludeTokenOptionsComponentBuilder,
+    createGradeThresholdComponentBuilder,
+    tokenOptionFieldComponentBuilder,
+    tokenOptionValidationWrapper
+} from './token-option-field-component-factory';
+import { TokenOptionGroup } from 'app/data/token-option-group';
+import { Injectable, type EnvironmentInjector, type ViewContainerRef, Inject } from '@angular/core';
+import type { FormField } from 'app/utils/form-field/form-field';
+import {
+    SpendForPassingAssignmentTokenOptionDataDef,
+    type SpendForPassingAssignmentTokenOption,
+    type SpendForPassingAssignmentTokenOptionData
+} from 'app/token-options/spend-for-passing-assignment-token-option';
+import { CanvasService } from 'app/services/canvas.service';
+
+@Injectable()
+export class SpendForPassingAssignmentTokenOptionFieldComponentFactory extends TokenOptionFieldComponentFactory<SpendForPassingAssignmentTokenOption> {
+    constructor(@Inject(CanvasService) private canvasService: CanvasService) {
+        super();
+    }
+
+    public create(environmentInjector: EnvironmentInjector): [
+        (viewContainerRef: ViewContainerRef) => void,
+        FormField<
+            SpendForPassingAssignmentTokenOption | TokenOptionGroup,
+            SpendForPassingAssignmentTokenOptionData,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            any
+        >
+    ] {
+        return tokenOptionValidationWrapper(
+            environmentInjector,
+            tokenOptionFieldComponentBuilder(environmentInjector)
+                .appendBuilder(
+                    createAssignmentFieldComponentBuilder(
+                        this.canvasService,
+                        environmentInjector,
+                        'Canvas Assignment / Quiz'
+                    )
+                )
+                .appendBuilder(createGradeThresholdComponentBuilder(environmentInjector))
+                .appendBuilder(createExcludeTokenOptionsComponentBuilder(environmentInjector))
+                .transformSrc((value: SpendForPassingAssignmentTokenOption | TokenOptionGroup) => {
+                    if (value instanceof TokenOptionGroup)
+                        return [value, [value.configuration.course.id, undefined], 1, ['', value.configuration]];
+                    else
+                        return [
+                            value,
+                            [
+                                value.group.configuration.course.id,
+                                {
+                                    id: value.assignmentId,
+                                    name: value.assignmentName
+                                }
+                            ],
+                            value.gradeThreshold,
+                            [value.excludeTokenOptionIds.join(','), value.group.configuration]
+                        ];
+                })
+                .transformDest(
+                    async ([
+                        tokenOptionData,
+                        { id: assignmentId, name: assignmentName },
+                        gradeThreshold,
+                        excludeTokenOptionIds
+                    ]) => {
+                        return {
+                            ...tokenOptionData,
+                            type: 'spend-for-passing-assignment',
+                            assignmentName,
+                            assignmentId,
+                            gradeThreshold,
+                            excludeTokenOptionIds
+                        };
+                    }
+                ),
+            SpendForPassingAssignmentTokenOptionDataDef.is
+        ).build();
+    }
+
+    public get type(): string {
+        return 'spend-for-passing-assignment';
+    }
+}

--- a/src/app/token-option-field-component-factories/spend-for-passing-assignment-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-passing-assignment-token-option-field-component-factory.ts
@@ -41,7 +41,7 @@ export class SpendForPassingAssignmentTokenOptionFieldComponentFactory extends T
                         'Canvas Assignment / Quiz'
                     )
                 )
-                .appendBuilder(createGradeThresholdComponentBuilder(environmentInjector))
+                .appendBuilder(createGradeThresholdComponentBuilder(environmentInjector, 'Grade Threshold'))
                 .appendBuilder(createExcludeTokenOptionsComponentBuilder(environmentInjector))
                 .transformSrc((value: SpendForPassingAssignmentTokenOption | TokenOptionGroup) => {
                     if (value instanceof TokenOptionGroup)

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
@@ -23,6 +23,7 @@ import { WithdrawLabDataTokenOptionFieldComponentFactory } from './withdraw-lab-
 import { WithdrawLabSwitchTokenOptionFieldComponentFactory } from './withdraw-lab-switch-token-option-field-component-factory';
 import { SpendForQuizRevisionTokenOptionFieldComponentFactory } from './spend-for-quiz-revision-token-option-field-component-factory';
 import { SpendForAssignmentExtensionTokenOptionFieldComponentFactory } from './spend-for-assignment-extension-token-option-field-component-factory';
+import { SpendForPassingAssignmentTokenOptionFieldComponentFactory } from './spend-for-passing-assignment-token-option-field-component-factory';
 
 export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOptionFieldComponentFactory<TokenOption>>[] =
     [
@@ -37,7 +38,8 @@ export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOption
         WithdrawLabDataTokenOptionFieldComponentFactory,
         WithdrawLabSwitchTokenOptionFieldComponentFactory,
         SpendForQuizRevisionTokenOptionFieldComponentFactory,
-        SpendForAssignmentExtensionTokenOptionFieldComponentFactory
+        SpendForAssignmentExtensionTokenOptionFieldComponentFactory,
+        SpendForPassingAssignmentTokenOptionFieldComponentFactory
     ];
 
 export const TOKEN_OPTION_FIELD_COMPONENT_FACTORY_INJECTION_TOKEN = new InjectionToken<

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
@@ -264,12 +264,14 @@ export function createMultipleSectionDateComponentBuilder(
 }
 
 export function createGradeThresholdComponentBuilder(
-    environmentInjector: EnvironmentInjector
+    environmentInjector: EnvironmentInjector,
+    label = 'Passing Grade Threshold',
+    shortLabel = 'Grade threshold'
 ): FormFieldComponentBuilder<NumberInputFieldComponent> {
     return new FormFieldComponentBuilder()
         .setComp(createComponent(NumberInputFieldComponent, { environmentInjector: environmentInjector }))
         .editField((field) => {
-            field.label = 'Passing Grade Threshold';
+            field.label = label;
             field.validator = async ([field, value]: [NumberInputFieldComponent, number]) => {
                 field.errorMessage = undefined;
                 if (typeof value != 'number') {
@@ -277,7 +279,7 @@ export function createGradeThresholdComponentBuilder(
                     return false;
                 }
                 if (value < 0 || value > 1) {
-                    field.errorMessage = 'Grade threshold needs to be a number between 0 and 1 (inclusive). E.g, 0.7';
+                    field.errorMessage = `${shortLabel} needs to be a number between 0 and 1 (inclusive). E.g, 0.7`;
                     return false;
                 }
                 return true;

--- a/src/app/token-option-resolvers/token-option-resolver-registry.ts
+++ b/src/app/token-option-resolvers/token-option-resolver-registry.ts
@@ -16,6 +16,7 @@ import type { TokenOptionResolver } from './token-option-resolver';
 import camelcaseKeys from 'camelcase-keys';
 import { SpendForQuizRevisionTokenOption } from 'app/token-options/spend-for-quiz-revision-token-option';
 import { SpendForAssignmentExtensionTokenOption } from 'app/token-options/spend-for-assignment-extension-token-option';
+import { SpendForPassingAssignmentTokenOption } from 'app/token-options/spend-for-passing-assignment-token-option';
 
 export const REGISTERED_TOKEN_OPTION_RESOLVERS: Type<TokenOptionResolver<TokenOption>>[] = [];
 
@@ -38,7 +39,8 @@ export const DEFAULT_TOKEN_OPTION_RESOLVERS: {
     'withdraw-lab-data': WithdrawLabDataTokenOption,
     'withdraw-lab-switch': WithdrawLabSwitchTokenOption,
     'spend-for-quiz-revision': SpendForQuizRevisionTokenOption,
-    'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption
+    'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption,
+    'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption
 };
 
 interface ITokenOptionType {

--- a/src/app/token-options/spend-for-passing-assignment-token-option.ts
+++ b/src/app/token-options/spend-for-passing-assignment-token-option.ts
@@ -1,0 +1,26 @@
+import * as t from 'io-ts';
+import { AssignmentMixin, AssignmentMixinDataDef } from './mixins/assignment-mixin';
+import { ATokenOption, TokenOptionDataDef } from './token-option';
+import { FromDataMixin } from './mixins/from-data-mixin';
+import { unwrapValidationFunc } from 'app/utils/validation-unwrapper';
+import { ToJSONMixin } from './mixins/to-json-mixin';
+import { GradeThresholdMixin, GradeThresholdMixinDataDef } from './mixins/grade-threshold-mixin';
+import { ExcludeTokenOptionIdsMixin, ExcludeTokenOptionIdsMixinDataDef } from './mixins/exclude-token-option-ids-mixin';
+
+export const SpendForPassingAssignmentTokenOptionDataDef = t.intersection([
+    TokenOptionDataDef,
+    AssignmentMixinDataDef,
+    GradeThresholdMixinDataDef,
+    ExcludeTokenOptionIdsMixinDataDef
+]);
+
+export type SpendForPassingAssignmentTokenOptionData = t.TypeOf<typeof SpendForPassingAssignmentTokenOptionDataDef>;
+
+export class SpendForPassingAssignmentTokenOption extends FromDataMixin(
+    ToJSONMixin(
+        ExcludeTokenOptionIdsMixin(GradeThresholdMixin(AssignmentMixin(ATokenOption))),
+        SpendForPassingAssignmentTokenOptionDataDef.encode
+    ),
+    unwrapValidationFunc(SpendForPassingAssignmentTokenOptionDataDef.decode),
+    SpendForPassingAssignmentTokenOptionDataDef.is
+) {}

--- a/src/app/token-options/token-option-registry.ts
+++ b/src/app/token-options/token-option-registry.ts
@@ -20,7 +20,8 @@ export class TokenOptionRegistry {
         'spend-for-lab-switch': 'Spend Tokens for Switching Lab',
         'withdraw-lab-switch': 'Withdraw Lab Switch Request (For Teacher Only)',
         'spend-for-quiz-revision': 'Spend Tokens for Revision Assignment on Canvas after not passing Canvas Quiz',
-        'spend-for-assignment-extension': 'Spend Tokens for Canvas Assignment Extension (No Longer Marked Late)'
+        'spend-for-assignment-extension': 'Spend Tokens for Canvas Assignment Extension (No Longer Marked Late)',
+        'spend-for-passing-assignment': 'Spend Tokens for Assignment / Quiz Grade'
     };
 
     public getDescriptiveName(tokenOptionType: string): string | undefined {


### PR DESCRIPTION
### Description

A new type of token option (spend tokens for assignment / quiz grade) is implemented in this pull request. This token option type allows a student to spend token for getting a grade for an assignment or quiz. A student's request will be approved only if all following conditions met:

1.  The student does not have an approved request for this token option.
2.  The student does not have any approved request on token options that this token option is mutually excluded with.
3.  The student has sufficient token.

When approved, Token ATM will assign the specified grade (configured in the form of percentage, shown to student in the configured display method for that assignment / quiz) to the specified assignment or quiz for that student.

### Testing Note

Please test if the new type of token option works as described.