### PR TITLE
Feature: Prompt to Publish Token ATM Log if not already published

### DIFF
--- a/src/app/components/request-process/request-process.component.ts
+++ b/src/app/components/request-process/request-process.component.ts
@@ -42,18 +42,7 @@ export class RequestProcessComponent implements CourseConfigurable {
     public async onStartRequestProcessing(): Promise<void> {
         if (!this.configuration) return;
         if (!(await this.configurationManager.isTokenATMLogPublished(this.configuration))) {
-            const confirmPublish = await this.modalManagerService.createConfirmationModalWithoutRef(
-                'The Token ATM Log assignment on Canvas must be published to process student requests.\n\nWould you like Token ATM to publish this assignment for you?',
-                'Publish Token ATM Log?',
-                false,
-                'I’ll publish it myself.',
-                'Yes, publish it for me.'
-            );
-            if (confirmPublish) {
-                await this.configurationManager.publishTokenATMLog(this.configuration);
-            } else {
-                return;
-            }
+            if (!(await this.onPublishLog())) return;
         }
         this.isReconfigureFinished = false;
         this.isStopRequested = false;
@@ -99,5 +88,24 @@ export class RequestProcessComponent implements CourseConfigurable {
             (this.requestProcessManagerService.isRunning && this.isStopRequested) ||
             (!this.requestProcessManagerService.isRunning && !this.isReconfigureFinished)
         );
+    }
+
+    public async onPublishLog(): Promise<boolean> {
+        if (!this.configuration) return false;
+        const [confirmationRef, result] = await this.modalManagerService.createConfirmationModal(
+            'The Token ATM Log assignment on Canvas must be published to process student requests.\n\nWould you like Token ATM to publish this assignment for you?',
+            'Publish Token ATM Log?',
+            false,
+            'I’ll publish it myself.',
+            'Yes, publish it for me.'
+        );
+        if (result) {
+            await this.configurationManager.publishTokenATMLog(this.configuration);
+            confirmationRef.hide();
+            return true;
+        } else {
+            confirmationRef.hide();
+            return false;
+        }
     }
 }

--- a/src/app/components/request-process/request-process.component.ts
+++ b/src/app/components/request-process/request-process.component.ts
@@ -41,6 +41,20 @@ export class RequestProcessComponent implements CourseConfigurable {
 
     public async onStartRequestProcessing(): Promise<void> {
         if (!this.configuration) return;
+        if (!(await this.configurationManager.isTokenATMLogPublished(this.configuration))) {
+            const confirmPublish = await this.modalManagerService.createConfirmationModalWithoutRef(
+                'The Token ATM Log assignment on Canvas must be published to process student requests.\n\nWould you like Token ATM to publish this assignment for you?',
+                'Publish Token ATM Log?',
+                false,
+                'I’ll publish it myself.',
+                'Yes, publish it for me.'
+            );
+            if (confirmPublish) {
+                await this.configurationManager.publishTokenATMLog(this.configuration);
+            } else {
+                return;
+            }
+        }
         this.isReconfigureFinished = false;
         this.isStopRequested = false;
         this.requestProcessManagerService.startRequestProcessing(this.configuration).subscribe({

--- a/src/app/services/modal-manager.service.ts
+++ b/src/app/services/modal-manager.service.ts
@@ -9,6 +9,15 @@ import { BsModalRef, BsModalService, ModalOptions } from 'ngx-bootstrap/modal';
 export class ModalManagerService {
     constructor(@Inject(BsModalService) private modalService: BsModalService) {}
 
+    /**
+     * Create a modal to collect user confirmation
+     * @param message Message in modal body
+     * @param heading Header text of modal
+     * @param isDanger Flag for marking if confirmation may have an irreversible result
+     * @param noText Declination text
+     * @param yesText Affirmation text
+     * @returns Reference to the modal, and the user's choice
+     */
     public async createConfirmationModal(
         message: string,
         heading = 'Confirmation',
@@ -39,6 +48,15 @@ export class ModalManagerService {
         return [modalRef, result];
     }
 
+    /**
+     * Create a modal to collect user confirmation (Should not be used with asynchronous functionality)
+     * @param message Message in modal body
+     * @param heading Header text of modal
+     * @param isDanger Flag for marking if confirmation may have an irreversible result
+     * @param noText Declination text
+     * @param yesText Affirmation text
+     * @returns User's choice
+     */
     public async createConfirmationModalWithoutRef(
         message: string,
         heading = 'Confirmation',
@@ -51,6 +69,12 @@ export class ModalManagerService {
         return result;
     }
 
+    /**
+     * Create a modal to notify the user
+     * @param message Message in modal body
+     * @param heading Header text of modal
+     * @returns Nothing once the modal is dismissed
+     */
     public async createNotificationModal(message: string, heading = 'Notification'): Promise<void> {
         let modalResolve: () => void;
         const promise = new Promise<void>((resolve) => {

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -404,4 +404,21 @@ export class TokenATMConfigurationManagerService {
     }
 
     // TODO: support reordering of token option groups and token options
+
+    public async isTokenATMLogPublished(configuration: TokenATMConfiguration): Promise<boolean> {
+        const logId = await this.canvasService.getAssignmentIdByName(
+            configuration.course.id,
+            TokenATMConfigurationManagerService.TOKEN_ATM_LOG_ASSIGNMENT_NAME
+        );
+        if (logId !== configuration.logAssignmentId) {
+            throw new Error(
+                'Token ATM Log assignment on Canvas doesn’t match the ID saved by Token ATM.\nThe Token ATM Configuration needs to be updated/checked.'
+            );
+        }
+        return (await this.canvasService.isAssignmentPublished(configuration.course.id, logId)) ?? false;
+    }
+
+    public async publishTokenATMLog(configuration: TokenATMConfiguration): Promise<void> {
+        this.canvasService.modifyAssignmentPublishedState(configuration.course.id, configuration.logAssignmentId, true);
+    }
 }

--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -419,6 +419,10 @@ export class TokenATMConfigurationManagerService {
     }
 
     public async publishTokenATMLog(configuration: TokenATMConfiguration): Promise<void> {
-        this.canvasService.modifyAssignmentPublishedState(configuration.course.id, configuration.logAssignmentId, true);
+        await this.canvasService.modifyAssignmentPublishedState(
+            configuration.course.id,
+            configuration.logAssignmentId,
+            true
+        );
     }
 }


### PR DESCRIPTION
### Description

Token ATM stores the history of each students' processed requests in the comments of the Token ATM Log assignments on Canvas. To make new comments for individual students, Canvas assignments must be published. This feature checks that the Token ATM Log assignment is published before it starts processing requests. And if the assignment isn't published, prompts instructors to publish it from within Token ATM. But if an instructor chooses to not publish the assignment, request processing is skipped.

This feature helps prevent some reading/writing errors during processing, and prevents unnecessary API calls.

Also, the code includes a quick verification that the Canvas Assignment ID and the configuration stored `log_assignment_id` both match. An error is thrown if this is not the case. Future feature(s) will attempt to catch and handle this error.

### Testing Note

Please test if this feature, and the possible error, work as described.