### PR TITLE
Feature: Validate Qualtrics Survey Fields

### DIFF
--- a/src/app/services/qualtrics.service.ts
+++ b/src/app/services/qualtrics.service.ts
@@ -218,7 +218,9 @@ export class QualtricsService {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             if (error?.isAxiosError && error?.response?.status == 404) {
-                throw new Error(`Survey '${surveyId}' not Found on Qualtrics.`);
+                throw new Error(
+                    `Survey '${surveyId}' not found on Qualtrics. Check if this survey is associated with your account.`
+                );
             } else {
                 throw error;
             }

--- a/src/app/token-option-field-component-factories/earn-by-survey-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/earn-by-survey-token-option-field-component-factory.ts
@@ -29,26 +29,25 @@ export class EarnBySurveyTokenOptionFieldComponentFactory extends TokenOptionFie
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         FormField<EarnBySurveyTokenOption | TokenOptionGroup, EarnBySurveyTokenOptionData, any>
     ] {
-        const surveyFieldNameComp = createFieldComponentWithLabel(
-            StringInputFieldComponent,
-            'Survey Field Name for Respondent’s Email (from SSO)',
-            environmentInjector
-        );
-
         const surveyDetailsCombinedComp = createFieldComponentWithLabel(
             StringInputFieldComponent,
             'Qualtrics Survey ID',
             environmentInjector
         )
-            .appendBuilder(surveyFieldNameComp)
+            .appendBuilder(
+                createFieldComponentWithLabel(
+                    StringInputFieldComponent,
+                    'Survey Field Name for Respondent’s Email (from SSO)',
+                    environmentInjector
+                )
+            )
             .editField((field) => {
                 field.validator = async (value: typeof field) => {
+                    const [surveyId, fieldName] = await value.destValue;
                     const idInput = value.fieldA;
                     const nameInput = value.fieldB;
                     idInput.errorMessage = undefined;
                     nameInput.errorMessage = undefined;
-                    const surveyId = await idInput.destValue;
-                    const fieldName = await nameInput.destValue;
                     const nameErrorForIdError = 'A valid Survey ID must be supplied above.';
                     if (surveyId.trim() === '') {
                         idInput.errorMessage = 'A Survey ID must be supplied.';


### PR DESCRIPTION
### Description

Add validators to the `Earn By Taking Qualtrics Survey` token option's Survey ID & Survey Field Name user input fields.

A valid Survey ID must be provided for both inputs to be validated. And the Survey Field Name only works for embeddedData fields on Qualtrics (e.g. the data collected from SSO authentication).

### Testing Note

Please test if this feature works as expected. And that the reported validation error messages are understandable.