### PR TITLE
Bugfix: Quiz Without Assignment ID

### DIFF
--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1286,7 +1286,9 @@ export class CanvasService {
                 }
             }),
             async (url: string) => await this.paginatedRequestHandler(url),
-            (data: unknown[]) => data.map((entry) => Quiz.deserialize(entry))
+            (data: unknown[]) =>
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                data.filter((x: any) => x.assignment_id !== null).map((entry) => Quiz.deserialize(entry))
         );
     }
 
@@ -1299,7 +1301,9 @@ export class CanvasService {
                 }
             }),
             async (url: string) => await this.paginatedRequestHandler(url),
-            (data: unknown[]) => data.map((entry) => Quiz.deserialize(entry))
+            (data: unknown[]) =>
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                data.filter((x: any) => x.assignment_id !== null).map((entry) => Quiz.deserialize(entry))
         );
         let result: string | undefined = undefined;
         for await (const quiz of quizzes) {


### PR DESCRIPTION
### Description

Token ATM used to assume that every quiz should have an underlying assignment, hence that `assignment_id` field for a quiz will never be `null`. However, this assumption does not hold, as Canvas does not create an assignment for a quiz upon its creation. Instead, the assignment is created when the quiz is saved for the first time. If a quiz is created but never saved, its `assignment_id` field will be `null`. Such a quiz could be created via Canvas UI by clicking “+Quiz” button in the Quizzes page (which creates the quiz) and then clicking “Cancel”.

This bugfix makes Token ATM ignore all quizzes with a their `assignment_id` being `null`. It should be safe to ignore these quizzes given that they are just placeholders that contain no information.

### Testing Note

Please test if the above bugfix works as expected. Specifically, please test if the searchable selection field for Canvas quizzes loads without any error even a quiz without a valid `assignment_id` exists in the course.