### PR TITLE
Feature: Placeholder Token Option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8457,9 +8457,9 @@
             "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "funding": [
                 {
                     "type": "individual",

--- a/src/app/components/form-fields/list-field/list-field.component.ts
+++ b/src/app/components/form-fields/list-field/list-field.component.ts
@@ -13,6 +13,7 @@ export class ListFieldComponent<F extends FormField<any, any, any>>
     implements OnInit, FormField<ExtractSrc<F>[], ExtractDest<F>[], F[]>
 {
     @Input() fieldFactory?: () => [(viewContainerRef: ViewContainerRef) => void, F];
+    @Input() defaultFieldSrcValueProvider?: () => ExtractSrc<F>;
     @ViewChild('container', { read: ViewContainerRef, static: true }) viewContainerRef?: ViewContainerRef;
     private delayedInitValue?: ExtractSrc<F>[];
     private isInitialized = false;
@@ -27,6 +28,7 @@ export class ListFieldComponent<F extends FormField<any, any, any>>
             item = this.viewContainerRef.createComponent(ListFieldItemWrapperComponent);
         item.instance.renderer = renderer;
         if (value != undefined) field.srcValue = value;
+        else if (this.defaultFieldSrcValueProvider) field.srcValue = this.defaultFieldSrcValueProvider();
         firstValueFrom(item.instance.remove).then(() => {
             const itemInd = this.itemRefs.indexOf(item);
             if (itemInd != -1) {

--- a/src/app/components/form-fields/multiple-section-date-field/multiple-section-date-field.component.ts
+++ b/src/app/components/form-fields/multiple-section-date-field/multiple-section-date-field.component.ts
@@ -35,6 +35,8 @@ export class MultipleSectionDateFieldComponent
         FormField<Date, Date, any>
     >;
 
+    @Input() defaultDateValueProvider?: () => Date;
+
     @ViewChild('defaultDateContainer', { read: ViewContainerRef, static: true })
     defaultDateContainerRef?: ViewContainerRef;
     @ViewChild(ListFieldComponent, { static: true }) listFieldComponent?: ListFieldComponent<
@@ -76,6 +78,14 @@ export class MultipleSectionDateFieldComponent
         }
         if (!this._defaultDateField || !this.listFieldComponent) return;
         const [courseId, value] = srcValue;
+        this.listFieldComponent.defaultFieldSrcValueProvider = () => [
+            {
+                sections: [],
+                name: '',
+                date: this.defaultDateValueProvider ? this.defaultDateValueProvider() : new Date()
+            },
+            courseId
+        ];
         this.listFieldComponent.fieldFactory = () => {
             if (!this.dateFieldBuilderFactory)
                 throw new Error('Failed to initialize list item for MultipleSectionDateFieldComponent');
@@ -167,16 +177,6 @@ export class MultipleSectionDateFieldComponent
                         name: displayName,
                         date: date
                     };
-                })
-                .editField((field) => {
-                    field.srcValue = [
-                        {
-                            sections: [],
-                            name: '',
-                            date: new Date()
-                        },
-                        courseId
-                    ];
                 })
                 .build();
         };

--- a/src/app/components/request-process/request-process.component.html
+++ b/src/app/components/request-process/request-process.component.html
@@ -4,7 +4,7 @@
         <div class="d-flex flex-column align-items-center">
             <button
                 class="btn btn-primary btn-lg mx-auto"
-                [disabled]="isRunning"
+                [disabled]="isProcessing"
                 (click)="isProcessingRequest ? onStopRequestProcessing() : onStartRequestProcessing()"
                 [class.btn-danger]="isProcessingRequest"
             >

--- a/src/app/components/request-process/request-process.component.ts
+++ b/src/app/components/request-process/request-process.component.ts
@@ -86,13 +86,13 @@ export class RequestProcessComponent implements CourseConfigurable {
         this.isProcessing = false;
     }
 
-    public async onRequestProcessingComplete(recogfiure = true): Promise<void> {
+    public async onRequestProcessingComplete(reconfigure = true): Promise<void> {
         this.progress = undefined;
         this.message = undefined;
         this.individualProgress = undefined;
         this.individualMessage = undefined;
         this.isProcessing = true;
-        if (this.course && recogfiure) await this.configureCourse(this.course);
+        if (this.course && reconfigure) await this.configureCourse(this.course);
         this.isProcessing = false;
     }
 

--- a/src/app/components/student-record-display/student-record-display.component.ts
+++ b/src/app/components/student-record-display/student-record-display.component.ts
@@ -41,7 +41,7 @@ export class StudentRecordDisplayComponent {
     }
 
     formatDate(date: Date): string {
-        return format(date, 'MMM dd, yyyy kk:mm:ss');
+        return format(date, 'MMM dd, yyyy HH:mm:ss');
     }
 
     async onAddManualChange(): Promise<void> {

--- a/src/app/instruction-generators/end-time-transformer.ts
+++ b/src/app/instruction-generators/end-time-transformer.ts
@@ -18,7 +18,7 @@ export class EndTimeTransformer extends TokenOptionInstructionTransformer<HasEnd
             if (convertedObject == undefined) return '';
             const endTime = convertedObject.endTime;
             if (endTime instanceof Date) {
-                return format(endTime, 'MMM dd, yyyy kk:mm:ss');
+                return format(endTime, 'MMM dd, yyyy HH:mm:ss');
             } else {
                 return endTime.toHTML();
             }

--- a/src/app/instruction-generators/new-due-time-transformer.ts
+++ b/src/app/instruction-generators/new-due-time-transformer.ts
@@ -18,7 +18,7 @@ export class NewDueTimeTransformer extends TokenOptionInstructionTransformer<Has
             if (convertedObject == undefined) return '';
             const newDueTime = convertedObject.newDueTime;
             if (newDueTime instanceof Date) {
-                return format(newDueTime, 'MMM dd, yyyy kk:mm:ss');
+                return format(newDueTime, 'MMM dd, yyyy HH:mm:ss');
             } else {
                 return newDueTime.toHTML();
             }

--- a/src/app/instruction-generators/start-time-transformer.ts
+++ b/src/app/instruction-generators/start-time-transformer.ts
@@ -18,7 +18,7 @@ export class StartTimeTransformer extends TokenOptionInstructionTransformer<HasS
             if (convertedObject == undefined) return '';
             const startTime = convertedObject.startTime;
             if (startTime instanceof Date) {
-                return format(startTime, 'MMM dd, yyyy kk:mm:ss');
+                return format(startTime, 'MMM dd, yyyy HH:mm:ss');
             } else {
                 return startTime.toHTML();
             }

--- a/src/app/request-handlers/guards/multiple-requests-guard.ts
+++ b/src/app/request-handlers/guards/multiple-requests-guard.ts
@@ -1,0 +1,27 @@
+import { RequestHandlerGuard } from './request-handler-guard';
+import type { ProcessedRequest } from 'app/data/processed-request';
+import type { IMultipleReqeusts } from 'app/token-options/mixins/multiple-requests-mixin';
+import type { TokenOption } from 'app/token-options/token-option';
+
+export class MultipleRequestsGuard extends RequestHandlerGuard {
+    constructor(private tokenOption: TokenOption & IMultipleReqeusts, private processedRequests: ProcessedRequest[]) {
+        super();
+    }
+
+    public async check(onReject: (message: string) => Promise<void>): Promise<void> {
+        let count = 0;
+        for (const request of this.processedRequests) {
+            if (!request.tokenOption) continue;
+            if (!request.isApproved) continue;
+            if (this.tokenOption.id == request.tokenOption.id) {
+                count++;
+            }
+        }
+        if (this.tokenOption.allowedReqeustCnt != -1 && count >= this.tokenOption.allowedReqeustCnt)
+            onReject(
+                this.tokenOption.allowedReqeustCnt != 1
+                    ? `Your already have ${count} approved requests for this token option and cannot have more.`
+                    : 'There is already an approved request for this token option.'
+            );
+    }
+}

--- a/src/app/request-handlers/guards/multiple-requests-guard.ts
+++ b/src/app/request-handlers/guards/multiple-requests-guard.ts
@@ -1,10 +1,10 @@
 import { RequestHandlerGuard } from './request-handler-guard';
 import type { ProcessedRequest } from 'app/data/processed-request';
-import type { IMultipleReqeusts } from 'app/token-options/mixins/multiple-requests-mixin';
+import type { IMultipleRequests } from 'app/token-options/mixins/multiple-requests-mixin';
 import type { TokenOption } from 'app/token-options/token-option';
 
 export class MultipleRequestsGuard extends RequestHandlerGuard {
-    constructor(private tokenOption: TokenOption & IMultipleReqeusts, private processedRequests: ProcessedRequest[]) {
+    constructor(private tokenOption: TokenOption & IMultipleRequests, private processedRequests: ProcessedRequest[]) {
         super();
     }
 
@@ -17,10 +17,10 @@ export class MultipleRequestsGuard extends RequestHandlerGuard {
                 count++;
             }
         }
-        if (this.tokenOption.allowedReqeustCnt != -1 && count >= this.tokenOption.allowedReqeustCnt)
+        if (this.tokenOption.allowedRequestCnt != -1 && count >= this.tokenOption.allowedRequestCnt)
             onReject(
-                this.tokenOption.allowedReqeustCnt != 1
-                    ? `Your already have ${count} approved requests for this token option and cannot have more.`
+                this.tokenOption.allowedRequestCnt != 1
+                    ? `You already have ${count} approved requests for this token option and cannot have more.`
                     : 'There is already an approved request for this token option.'
             );
     }

--- a/src/app/request-handlers/guards/multiple-section-start-date-guard.ts
+++ b/src/app/request-handlers/guards/multiple-section-start-date-guard.ts
@@ -1,0 +1,26 @@
+import { RequestHandlerGuard } from './request-handler-guard';
+import type { MultipleSectionDateMatcher } from 'app/utils/multiple-section-date-matcher';
+import type { CanvasService } from 'app/services/canvas.service';
+import { DataConversionHelper } from 'app/utils/data-conversion-helper';
+import { compareAsc } from 'date-fns';
+
+export class MultipleSectionStartDateGuard extends RequestHandlerGuard {
+    constructor(
+        private courseId: string,
+        private studentId: string,
+        private submittedDate: Date,
+        private startDate: MultipleSectionDateMatcher,
+        private canvasService: CanvasService
+    ) {
+        super();
+    }
+
+    public async check(onReject: (message: string) => Promise<void>): Promise<void> {
+        const matchedStartDate = this.startDate.match(
+            await DataConversionHelper.convertAsyncIterableToList(
+                await this.canvasService.getStudentSectionEnrollments(this.courseId, this.studentId)
+            )
+        );
+        if (compareAsc(this.submittedDate, matchedStartDate) == -1) onReject('Request was submitted too early');
+    }
+}

--- a/src/app/request-handlers/placeholder-request-handler.ts
+++ b/src/app/request-handlers/placeholder-request-handler.ts
@@ -1,0 +1,82 @@
+import { Inject, Injectable } from '@angular/core';
+import { ProcessedRequest } from 'app/data/processed-request';
+import type { StudentRecord } from 'app/data/student-record';
+import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
+import { CanvasService } from 'app/services/canvas.service';
+import { EndDateGuard } from './guards/end-date-guard';
+import { RequestHandlerGuardExecutor } from './guards/request-handler-guard-executor';
+import { StartDateGuard } from './guards/start-date-guard';
+import { SufficientTokenBalanceGuard } from './guards/sufficient-token-balance-guard';
+import { RequestHandler } from './request-handlers';
+import { MultipleSectionEndDateGuard } from './guards/multiple-section-end-date-guard';
+import type { PlaceholderTokenOption } from 'app/token-options/placeholder-token-option';
+import type { PlaceholderRequest } from 'app/requests/placeholder-request';
+import { MultipleSectionStartDateGuard } from './guards/multiple-section-start-date-guard';
+import type { RequestHandlerGuard } from './guards/request-handler-guard';
+import { MultipleRequestsGuard } from './guards/multiple-requests-guard';
+import { ExcludeTokenOptionsGuard } from './guards/exclude-token-options-guard';
+
+@Injectable()
+export class PlaceholderRequestHandler extends RequestHandler<PlaceholderTokenOption, PlaceholderRequest> {
+    constructor(@Inject(CanvasService) private canvasService: CanvasService) {
+        super();
+    }
+
+    public async handle(
+        configuration: TokenATMConfiguration,
+        studentRecord: StudentRecord,
+        request: PlaceholderRequest
+    ): Promise<ProcessedRequest> {
+        const tokenOption = request.tokenOption;
+        const guards: RequestHandlerGuard[] = [
+            new MultipleRequestsGuard(tokenOption, studentRecord.processedRequests),
+            new ExcludeTokenOptionsGuard(tokenOption.excludeTokenOptionIds, studentRecord.processedRequests)
+        ];
+        if (tokenOption.tokenBalanceChange < 0)
+            guards.push(new SufficientTokenBalanceGuard(studentRecord.tokenBalance, tokenOption.tokenBalanceChange));
+        if (tokenOption.startTime !== null)
+            guards.push(
+                tokenOption.startTime instanceof Date
+                    ? new StartDateGuard(request.submittedTime, tokenOption.startTime)
+                    : new MultipleSectionStartDateGuard(
+                          configuration.course.id,
+                          studentRecord.student.id,
+                          request.submittedTime,
+                          tokenOption.startTime,
+                          this.canvasService
+                      )
+            );
+
+        if (tokenOption.endTime !== null)
+            guards.push(
+                tokenOption.endTime instanceof Date
+                    ? new EndDateGuard(request.submittedTime, tokenOption.endTime)
+                    : new MultipleSectionEndDateGuard(
+                          configuration.course.id,
+                          studentRecord.student.id,
+                          request.submittedTime,
+                          tokenOption.endTime,
+                          this.canvasService
+                      )
+            );
+
+        const guardExecutor = new RequestHandlerGuardExecutor(guards);
+        await guardExecutor.check();
+        return new ProcessedRequest(
+            configuration,
+            request.tokenOption.id,
+            request.tokenOption.name,
+            request.student,
+            !guardExecutor.isRejected,
+            request.submittedTime,
+            new Date(),
+            guardExecutor.isRejected ? 0 : request.tokenOption.tokenBalanceChange,
+            guardExecutor.message ?? '',
+            request.tokenOption.group.id
+        );
+    }
+
+    public get type(): string {
+        return 'placeholder-token-option';
+    }
+}

--- a/src/app/request-handlers/request-handler-registry.ts
+++ b/src/app/request-handlers/request-handler-registry.ts
@@ -18,6 +18,7 @@ import { WithdrawLabSwitchRequestHandler } from './withdraw-lab-switch-request-h
 import { SpendForQuizRevisionRequestHandler } from './spend-for-quiz-revision-request-handler';
 import { SpendForAssignmentExtensionRequestHandler } from './spend-for-assignment-extension-request-handler';
 import { SpendForPassingAssignmentRequestHandler } from './spend-for-passing-assignment-request-handler';
+import { PlaceholderRequestHandler } from './placeholder-request-handler';
 
 type GenericRequestHandler = RequestHandler<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -34,7 +35,8 @@ export const REGISTERED_REQUEST_HANDLERS: Type<GenericRequestHandler>[] = [
     WithdrawLabSwitchRequestHandler,
     SpendForQuizRevisionRequestHandler,
     SpendForAssignmentExtensionRequestHandler,
-    SpendForPassingAssignmentRequestHandler
+    SpendForPassingAssignmentRequestHandler,
+    PlaceholderRequestHandler
 ];
 
 export const REQUEST_HANDLER_INJECT_TOKEN = new InjectionToken<GenericRequestHandler[]>('REQUEST_HANDLERS');

--- a/src/app/request-resolvers/placeholder-request-resolver.ts
+++ b/src/app/request-resolvers/placeholder-request-resolver.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { RequestResolver } from './request-resolver';
+import type { PlaceholderTokenOption } from 'app/token-options/placeholder-token-option';
+import { PlaceholderRequest } from 'app/requests/placeholder-request';
+import type { QuizSubmissionDetail } from 'app/data/quiz-submission-detail';
+
+@Injectable()
+export class PlaceholderRequestResolver extends RequestResolver<PlaceholderTokenOption, PlaceholderRequest> {
+    public async resolve(
+        tokenOption: PlaceholderTokenOption,
+        quizSubmissionDetail: QuizSubmissionDetail
+    ): Promise<PlaceholderRequest> {
+        return new PlaceholderRequest(
+            tokenOption,
+            quizSubmissionDetail.student,
+            quizSubmissionDetail.submittedTime,
+            quizSubmissionDetail
+        );
+    }
+    public get type(): string {
+        return 'placeholder-token-option';
+    }
+}

--- a/src/app/request-resolvers/request-resolver-registry.ts
+++ b/src/app/request-resolvers/request-resolver-registry.ts
@@ -17,6 +17,7 @@ import { WithdrawLabSwitchRequestResolver } from './withdraw-lab-switch-request-
 import { SpendForQuizRevisionRequestResolver } from './spend-for-quiz-revision-request-resolver';
 import { SpendForAssignmentExtensionRequestResolver } from './spend-for-assignment-extension-request-resolver';
 import { SpendForPassingAssignmentRequestResolver } from './spend-for-passing-assignment-request-resolver';
+import { PlaceholderRequestResolver } from './placeholder-request-resolver';
 
 type GenericRequestResolver = RequestResolver<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -33,7 +34,8 @@ export const REGISTERED_REQUEST_RESOLVERS: Type<GenericRequestResolver>[] = [
     WithdrawLabSwitchRequestResolver,
     SpendForQuizRevisionRequestResolver,
     SpendForAssignmentExtensionRequestResolver,
-    SpendForPassingAssignmentRequestResolver
+    SpendForPassingAssignmentRequestResolver,
+    PlaceholderRequestResolver
 ];
 
 export const REQUEST_RESOLVER_INJECT_TOKEN = new InjectionToken<GenericRequestResolver[]>('REQUEST_RESOLVERS');

--- a/src/app/requests/placeholder-request.ts
+++ b/src/app/requests/placeholder-request.ts
@@ -1,0 +1,4 @@
+import { TokenATMRequest } from './token-atm-request';
+import type { PlaceholderTokenOption } from 'app/token-options/placeholder-token-option';
+
+export class PlaceholderRequest extends TokenATMRequest<PlaceholderTokenOption> {}

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -130,7 +130,7 @@ export class RequestProcessManagerService {
                             progressUpdate.error([
                                 `Encountered an error while handling request to ${
                                     processedRequest ? processedRequest.tokenOptionName : request.tokenOption.name
-                                } submitted at ${format(request.submittedTime, 'MMM dd, yyyy kk:mm:ss')} by student ${
+                                } submitted at ${format(request.submittedTime, 'MMM dd, yyyy HH:mm:ss')} by student ${
                                     student.name + (student.email == '' ? '' : `(${student.email})`)
                                 }`,
                                 err
@@ -152,7 +152,7 @@ export class RequestProcessManagerService {
                                 processedRequest.tokenOptionName
                             } submitted at ${format(
                                 processedRequest.submittedTime,
-                                'MMM dd, yyyy kk:mm:ss'
+                                'MMM dd, yyyy HH:mm:ss'
                             )} by student ${student.name + (student.email == '' ? '' : `(${student.email})`)}`,
                             err
                         ]);

--- a/src/app/services/student-record-manager.service.ts
+++ b/src/app/services/student-record-manager.service.ts
@@ -123,9 +123,9 @@ export class StudentRecordManagerService {
             configuration.logAssignmentId,
             `Your request to ${processedRequest.tokenOptionName} has been processed.\nResult: ${
                 processedRequest.isApproved ? 'Approved' : '*REJECTED*'
-            }\nSubmitted at: ${format(processedRequest.submittedTime, 'MMM dd, yyyy kk:mm:ss')}\nProcessed at: ${format(
+            }\nSubmitted at: ${format(processedRequest.submittedTime, 'MMM dd, yyyy HH:mm:ss')}\nProcessed at: ${format(
                 processedRequest.processedTime,
-                'MMM dd, yyyy kk:mm:ss'
+                'MMM dd, yyyy HH:mm:ss'
             )}\nToken Balance Change: ${oldTokenBalance} -> ${studentRecord.tokenBalance}${
                 processedRequest.message != '' ? `\nMessage: ${processedRequest.message}` : ''
             }`

--- a/src/app/token-option-field-component-factories/placeholder-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/placeholder-token-option-field-component-factory.ts
@@ -173,19 +173,19 @@ export class PlaceholderTokenOptionFieldComponentFactory extends TokenOptionFiel
                                         })
                                 ]
                             ],
-                            [value.allowedReqeustCnt != 1, value.allowedReqeustCnt],
+                            [value.allowedRequestCnt != 1, value.allowedRequestCnt],
                             [value.excludeTokenOptionIds.join(','), value.group.configuration]
                         ];
                     }
                 })
                 .transformDest(
-                    async ([tokenOptionData, startTime, endTime, allowedReqeustCnt, excludeTokenOptionIds]) => {
+                    async ([tokenOptionData, startTime, endTime, allowedRequestCnt, excludeTokenOptionIds]) => {
                         return {
                             ...tokenOptionData,
                             type: 'placeholder-token-option',
                             startTime: startTime ?? null,
                             endTime: endTime ?? null,
-                            allowedReqeustCnt: allowedReqeustCnt ?? 1,
+                            allowedRequestCnt: allowedRequestCnt ?? 1,
                             excludeTokenOptionIds
                         };
                     }

--- a/src/app/token-option-field-component-factories/placeholder-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/placeholder-token-option-field-component-factory.ts
@@ -1,0 +1,199 @@
+import {
+    PlaceholderTokenOption,
+    PlaceholderTokenOptionData,
+    PlaceholderTokenOptionDataDef
+} from 'app/token-options/placeholder-token-option';
+import {
+    TokenOptionFieldComponentFactory,
+    createExcludeTokenOptionsComponentBuilder,
+    createFieldComponentWithLabel,
+    createMultipleSectionDateComponentBuilder,
+    tokenOptionFieldComponentBuilder,
+    tokenOptionValidationWrapper
+} from './token-option-field-component-factory';
+import { type EnvironmentInjector, type ViewContainerRef, Injectable } from '@angular/core';
+import { TokenOptionGroup } from 'app/data/token-option-group';
+import type { FormField } from 'app/utils/form-field/form-field';
+import { set } from 'date-fns';
+import { DateTimeFieldComponent } from 'app/components/form-fields/date-time-field/date-time-field.component';
+import { OptionalFieldComponent } from 'app/components/form-fields/optional-field/optional-field.component';
+import type { MultipleSectionDateFieldComponent } from 'app/components/form-fields/multiple-section-date-field/multiple-section-date-field.component';
+import { NumberInputFieldComponent } from 'app/components/form-fields/number-input-field/number-input-field.component';
+
+@Injectable()
+export class PlaceholderTokenOptionFieldComponentFactory extends TokenOptionFieldComponentFactory<PlaceholderTokenOption> {
+    public override create(environmentInjector: EnvironmentInjector): [
+        (viewContainerRef: ViewContainerRef) => void,
+        FormField<
+            PlaceholderTokenOption | TokenOptionGroup,
+            PlaceholderTokenOptionData,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            any
+        >
+    ] {
+        return tokenOptionValidationWrapper(
+            environmentInjector,
+            tokenOptionFieldComponentBuilder(environmentInjector)
+                .appendBuilder(
+                    createFieldComponentWithLabel(
+                        OptionalFieldComponent<MultipleSectionDateFieldComponent>,
+                        'Specify when students can start submitting requests',
+                        environmentInjector
+                    ).editField((field) => {
+                        field.fieldBuilder = createMultipleSectionDateComponentBuilder(
+                            () => {
+                                return createFieldComponentWithLabel(
+                                    DateTimeFieldComponent,
+                                    'Date/Time',
+                                    environmentInjector
+                                );
+                            },
+                            'Students Can Request From',
+                            environmentInjector,
+                            () =>
+                                set(new Date(), {
+                                    hours: 0,
+                                    minutes: 0,
+                                    seconds: 0,
+                                    milliseconds: 0
+                                })
+                        );
+                    })
+                )
+                .appendBuilder(
+                    createFieldComponentWithLabel(
+                        OptionalFieldComponent<MultipleSectionDateFieldComponent>,
+                        'Specify when students can no longer submit requests',
+                        environmentInjector
+                    ).editField((field) => {
+                        field.fieldBuilder = createMultipleSectionDateComponentBuilder(
+                            () => {
+                                return createFieldComponentWithLabel(
+                                    DateTimeFieldComponent,
+                                    'Date/Time',
+                                    environmentInjector
+                                );
+                            },
+                            'Students Can Request Until',
+                            environmentInjector,
+                            () =>
+                                set(new Date(), {
+                                    hours: 23,
+                                    minutes: 59,
+                                    seconds: 59,
+                                    milliseconds: 999
+                                })
+                        );
+                    })
+                )
+                .appendBuilder(
+                    createFieldComponentWithLabel(
+                        OptionalFieldComponent<NumberInputFieldComponent>,
+                        'Allow multiple approved requests',
+                        environmentInjector
+                    ).editField((field) => {
+                        field.fieldBuilder = createFieldComponentWithLabel(
+                            NumberInputFieldComponent,
+                            'Allowed maximum number of approved requests (-1 for unlimited)',
+                            environmentInjector
+                        ).editField((field) => {
+                            field.validator = async ([x, v]: [NumberInputFieldComponent, number]) => {
+                                x.errorMessage = undefined;
+                                if (!Number.isInteger(v)) {
+                                    x.errorMessage = 'Should be an integer (floating number is not allowed)';
+                                    return false;
+                                }
+                                if (v != -1 && v < 0) {
+                                    x.errorMessage = 'Negative number is not allowed (except for -1)';
+                                    return false;
+                                }
+                                return true;
+                            };
+                        });
+                    })
+                )
+                .appendBuilder(createExcludeTokenOptionsComponentBuilder(environmentInjector))
+                .transformSrc((value: PlaceholderTokenOption | TokenOptionGroup) => {
+                    if (value instanceof TokenOptionGroup) {
+                        return [
+                            value,
+                            [
+                                false,
+                                [
+                                    value.configuration.course.id,
+                                    set(new Date(), {
+                                        hours: 0,
+                                        minutes: 0,
+                                        seconds: 0,
+                                        milliseconds: 0
+                                    })
+                                ]
+                            ],
+                            [
+                                false,
+                                [
+                                    value.configuration.course.id,
+                                    set(new Date(), {
+                                        hours: 23,
+                                        minutes: 59,
+                                        seconds: 59,
+                                        milliseconds: 999
+                                    })
+                                ]
+                            ],
+                            [false, 1],
+                            ['', value.configuration]
+                        ];
+                    } else {
+                        return [
+                            value,
+                            [
+                                value.startTime !== null,
+                                [
+                                    value.group.configuration.course.id,
+                                    value.startTime ??
+                                        set(new Date(), {
+                                            hours: 0,
+                                            minutes: 0,
+                                            seconds: 0,
+                                            milliseconds: 0
+                                        })
+                                ]
+                            ],
+                            [
+                                value.endTime !== null,
+                                [
+                                    value.group.configuration.course.id,
+                                    value.endTime ??
+                                        set(new Date(), {
+                                            hours: 23,
+                                            minutes: 59,
+                                            seconds: 59,
+                                            milliseconds: 999
+                                        })
+                                ]
+                            ],
+                            [value.allowedReqeustCnt != 1, value.allowedReqeustCnt],
+                            [value.excludeTokenOptionIds.join(','), value.group.configuration]
+                        ];
+                    }
+                })
+                .transformDest(
+                    async ([tokenOptionData, startTime, endTime, allowedReqeustCnt, excludeTokenOptionIds]) => {
+                        return {
+                            ...tokenOptionData,
+                            type: 'placeholder-token-option',
+                            startTime: startTime ?? null,
+                            endTime: endTime ?? null,
+                            allowedReqeustCnt: allowedReqeustCnt ?? 1,
+                            excludeTokenOptionIds
+                        };
+                    }
+                ),
+            PlaceholderTokenOptionDataDef.is
+        ).build();
+    }
+    public override get type(): string {
+        return 'placeholder-token-option';
+    }
+}

--- a/src/app/token-option-field-component-factories/spend-for-assignment-resubmission-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-assignment-resubmission-token-option-field-component-factory.ts
@@ -50,7 +50,14 @@ export class SpendForAssignmentResubmissionTokenOptionFieldComponentFactory exte
                             );
                         },
                         'Students Can Request Until',
-                        environmentInjector
+                        environmentInjector,
+                        () =>
+                            set(new Date(), {
+                                hours: 23,
+                                minutes: 59,
+                                seconds: 59,
+                                milliseconds: 999
+                            })
                     )
                 )
                 .appendBuilder(
@@ -59,7 +66,14 @@ export class SpendForAssignmentResubmissionTokenOptionFieldComponentFactory exte
                             return createNewDueTimeComponentBuilder(environmentInjector, 'Date/Time');
                         },
                         'Change the Canvas Assignment’s “Available Until” to', // TODO: Phrasing may need more work
-                        environmentInjector
+                        environmentInjector,
+                        () =>
+                            set(new Date(), {
+                                hours: 23,
+                                minutes: 59,
+                                seconds: 59,
+                                milliseconds: 999
+                            })
                     )
                 )
                 .transformSrc((value: SpendForAssignmentResubmissionTokenOption | TokenOptionGroup) => {

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
@@ -24,6 +24,7 @@ import { WithdrawLabSwitchTokenOptionFieldComponentFactory } from './withdraw-la
 import { SpendForQuizRevisionTokenOptionFieldComponentFactory } from './spend-for-quiz-revision-token-option-field-component-factory';
 import { SpendForAssignmentExtensionTokenOptionFieldComponentFactory } from './spend-for-assignment-extension-token-option-field-component-factory';
 import { SpendForPassingAssignmentTokenOptionFieldComponentFactory } from './spend-for-passing-assignment-token-option-field-component-factory';
+import { PlaceholderTokenOptionFieldComponentFactory } from './placeholder-token-option-field-component-factory';
 
 export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOptionFieldComponentFactory<TokenOption>>[] =
     [
@@ -39,7 +40,8 @@ export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOption
         WithdrawLabSwitchTokenOptionFieldComponentFactory,
         SpendForQuizRevisionTokenOptionFieldComponentFactory,
         SpendForAssignmentExtensionTokenOptionFieldComponentFactory,
-        SpendForPassingAssignmentTokenOptionFieldComponentFactory
+        SpendForPassingAssignmentTokenOptionFieldComponentFactory,
+        PlaceholderTokenOptionFieldComponentFactory
     ];
 
 export const TOKEN_OPTION_FIELD_COMPONENT_FACTORY_INJECTION_TOKEN = new InjectionToken<

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
@@ -254,11 +254,13 @@ export function createMultipleSectionDateComponentBuilder(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     dateFieldBuilderFactory: () => FormFieldComponentBuilder<FormField<Date, Date, any>>,
     label: string,
-    environmentInjector: EnvironmentInjector
+    environmentInjector: EnvironmentInjector,
+    defaultDateProvider?: () => Date
 ): FormFieldComponentBuilder<MultipleSectionDateFieldComponent> {
     return createFieldComponentWithLabel(MultipleSectionDateFieldComponent, label, environmentInjector).editField(
         (field) => {
             field.dateFieldBuilderFactory = dateFieldBuilderFactory;
+            if (defaultDateProvider) field.defaultDateValueProvider = defaultDateProvider;
         }
     );
 }

--- a/src/app/token-option-resolvers/token-option-resolver-registry.ts
+++ b/src/app/token-option-resolvers/token-option-resolver-registry.ts
@@ -17,6 +17,7 @@ import camelcaseKeys from 'camelcase-keys';
 import { SpendForQuizRevisionTokenOption } from 'app/token-options/spend-for-quiz-revision-token-option';
 import { SpendForAssignmentExtensionTokenOption } from 'app/token-options/spend-for-assignment-extension-token-option';
 import { SpendForPassingAssignmentTokenOption } from 'app/token-options/spend-for-passing-assignment-token-option';
+import { PlaceholderTokenOption } from 'app/token-options/placeholder-token-option';
 
 export const REGISTERED_TOKEN_OPTION_RESOLVERS: Type<TokenOptionResolver<TokenOption>>[] = [];
 
@@ -40,7 +41,8 @@ export const DEFAULT_TOKEN_OPTION_RESOLVERS: {
     'withdraw-lab-switch': WithdrawLabSwitchTokenOption,
     'spend-for-quiz-revision': SpendForQuizRevisionTokenOption,
     'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption,
-    'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption
+    'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption,
+    'placeholder-token-option': PlaceholderTokenOption
 };
 
 interface ITokenOptionType {

--- a/src/app/token-options/mixins/multiple-requests-mixin.ts
+++ b/src/app/token-options/mixins/multiple-requests-mixin.ts
@@ -1,0 +1,27 @@
+import * as t from 'io-ts';
+import type { IGridViewDataSource } from './grid-view-data-source-mixin';
+import type { Constructor } from 'app/utils/mixin-helper';
+
+export const MultipleReqeustsMixinDataDef = t.strict({
+    allowedReqeustCnt: t.number
+});
+
+export type MultipleReqeustsMixinData = t.TypeOf<typeof MultipleReqeustsMixinDataDef>;
+
+export type IMultipleReqeusts = MultipleReqeustsMixinData & IGridViewDataSource;
+
+export function MultipleReqeustsMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IMultipleReqeusts {
+        allowedReqeustCnt = 1;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+            this.registerDataPointSource(() => ({
+                colName: 'Allowed Reqeusts Count',
+                type: 'number',
+                value: this.allowedReqeustCnt
+            }));
+        }
+    };
+}

--- a/src/app/token-options/mixins/multiple-requests-mixin.ts
+++ b/src/app/token-options/mixins/multiple-requests-mixin.ts
@@ -2,25 +2,25 @@ import * as t from 'io-ts';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 import type { Constructor } from 'app/utils/mixin-helper';
 
-export const MultipleReqeustsMixinDataDef = t.strict({
-    allowedReqeustCnt: t.number
+export const MultipleRequestsMixinDataDef = t.strict({
+    allowedRequestCnt: t.number
 });
 
-export type MultipleReqeustsMixinData = t.TypeOf<typeof MultipleReqeustsMixinDataDef>;
+export type MultipleRequestsMixinData = t.TypeOf<typeof MultipleRequestsMixinDataDef>;
 
-export type IMultipleReqeusts = MultipleReqeustsMixinData & IGridViewDataSource;
+export type IMultipleRequests = MultipleRequestsMixinData & IGridViewDataSource;
 
-export function MultipleReqeustsMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
-    return class extends Base implements IMultipleReqeusts {
-        allowedReqeustCnt = 1;
+export function MultipleRequestsMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IMultipleRequests {
+        allowedRequestCnt = 1;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         constructor(...args: any[]) {
             super(...args);
             this.registerDataPointSource(() => ({
-                colName: 'Allowed Reqeusts Count',
+                colName: 'Allowed Requests Count',
                 type: 'number',
-                value: this.allowedReqeustCnt
+                value: this.allowedRequestCnt
             }));
         }
     };

--- a/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
@@ -1,0 +1,39 @@
+import * as t from 'io-ts';
+import { Constructor, DateDef } from 'app/utils/mixin-helper';
+import type { IGridViewDataSource } from './grid-view-data-source-mixin';
+import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
+
+export const OptionalMultipleSectionEndTimeMixinDataDef = t.strict({
+    endTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
+});
+
+export type OptionalMultipleSectionEndTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;
+export type RawOptionalMultipleSectionEndTimeMixinData = t.OutputOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;
+
+export type IOptionalMultipleSectionEndTime = OptionalMultipleSectionEndTimeMixinData & IGridViewDataSource;
+
+export function OptionalMultipleSectionEndTimeMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IOptionalMultipleSectionEndTime {
+        endTime: Date | MultipleSectionDateMatcher | null = null;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+            this.registerDataPointSource(() =>
+                this.endTime !== null
+                    ? this.endTime instanceof MultipleSectionDateMatcher
+                        ? {
+                              colName: 'Can Request Until (with exceptions)',
+                              type: 'html',
+                              value: this.endTime.toHTML()
+                          }
+                        : {
+                              colName: 'Can Request Until',
+                              type: 'date',
+                              value: this.endTime
+                          }
+                    : undefined
+            );
+        }
+    };
+}

--- a/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
@@ -1,0 +1,41 @@
+import * as t from 'io-ts';
+import { Constructor, DateDef } from 'app/utils/mixin-helper';
+import type { IGridViewDataSource } from './grid-view-data-source-mixin';
+import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
+
+export const OptionalMultipleSectionStartTimeMixinDataDef = t.strict({
+    startTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
+});
+
+export type OptionalMultipleSectionStartTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionStartTimeMixinDataDef>;
+export type RawOptionalMultipleSectionStartTimeMixinData = t.OutputOf<
+    typeof OptionalMultipleSectionStartTimeMixinDataDef
+>;
+
+export type IOptionalMultipleSectionStartTime = OptionalMultipleSectionStartTimeMixinData & IGridViewDataSource;
+
+export function OptionalMultipleSectionStartTimeMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IOptionalMultipleSectionStartTime {
+        startTime: Date | MultipleSectionDateMatcher | null = null;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+            this.registerDataPointSource(() =>
+                this.startTime !== null
+                    ? this.startTime instanceof MultipleSectionDateMatcher
+                        ? {
+                              colName: 'Can Request From (with exceptions)',
+                              type: 'html',
+                              value: this.startTime.toHTML()
+                          }
+                        : {
+                              colName: 'Can Request From',
+                              type: 'date',
+                              value: this.startTime
+                          }
+                    : undefined
+            );
+        }
+    };
+}

--- a/src/app/token-options/placeholder-token-option.ts
+++ b/src/app/token-options/placeholder-token-option.ts
@@ -1,0 +1,38 @@
+import * as t from 'io-ts';
+import { ATokenOption, TokenOptionDataDef } from './token-option';
+import { FromDataMixin } from './mixins/from-data-mixin';
+import { unwrapValidationFunc } from 'app/utils/validation-unwrapper';
+import { ToJSONMixin } from './mixins/to-json-mixin';
+import {
+    OptionalMultipleSectionStartTimeMixin,
+    OptionalMultipleSectionStartTimeMixinDataDef
+} from './mixins/optional-multiple-section-start-time-mixin';
+import {
+    OptionalMultipleSectionEndTimeMixin,
+    OptionalMultipleSectionEndTimeMixinDataDef
+} from './mixins/optional-multiple-section-end-time-mixin';
+import { MultipleReqeustsMixin, MultipleReqeustsMixinDataDef } from './mixins/multiple-requests-mixin';
+import { ExcludeTokenOptionIdsMixin, ExcludeTokenOptionIdsMixinDataDef } from './mixins/exclude-token-option-ids-mixin';
+
+export const PlaceholderTokenOptionDataDef = t.intersection([
+    TokenOptionDataDef,
+    OptionalMultipleSectionStartTimeMixinDataDef,
+    OptionalMultipleSectionEndTimeMixinDataDef,
+    MultipleReqeustsMixinDataDef,
+    ExcludeTokenOptionIdsMixinDataDef
+]);
+
+export type PlaceholderTokenOptionData = t.TypeOf<typeof PlaceholderTokenOptionDataDef>;
+
+export class PlaceholderTokenOption extends FromDataMixin(
+    ToJSONMixin(
+        ExcludeTokenOptionIdsMixin(
+            MultipleReqeustsMixin(
+                OptionalMultipleSectionEndTimeMixin(OptionalMultipleSectionStartTimeMixin(ATokenOption))
+            )
+        ),
+        PlaceholderTokenOptionDataDef.encode
+    ),
+    unwrapValidationFunc(PlaceholderTokenOptionDataDef.decode),
+    PlaceholderTokenOptionDataDef.is
+) {}

--- a/src/app/token-options/placeholder-token-option.ts
+++ b/src/app/token-options/placeholder-token-option.ts
@@ -11,14 +11,14 @@ import {
     OptionalMultipleSectionEndTimeMixin,
     OptionalMultipleSectionEndTimeMixinDataDef
 } from './mixins/optional-multiple-section-end-time-mixin';
-import { MultipleReqeustsMixin, MultipleReqeustsMixinDataDef } from './mixins/multiple-requests-mixin';
+import { MultipleRequestsMixin, MultipleRequestsMixinDataDef } from './mixins/multiple-requests-mixin';
 import { ExcludeTokenOptionIdsMixin, ExcludeTokenOptionIdsMixinDataDef } from './mixins/exclude-token-option-ids-mixin';
 
 export const PlaceholderTokenOptionDataDef = t.intersection([
     TokenOptionDataDef,
     OptionalMultipleSectionStartTimeMixinDataDef,
     OptionalMultipleSectionEndTimeMixinDataDef,
-    MultipleReqeustsMixinDataDef,
+    MultipleRequestsMixinDataDef,
     ExcludeTokenOptionIdsMixinDataDef
 ]);
 
@@ -27,7 +27,7 @@ export type PlaceholderTokenOptionData = t.TypeOf<typeof PlaceholderTokenOptionD
 export class PlaceholderTokenOption extends FromDataMixin(
     ToJSONMixin(
         ExcludeTokenOptionIdsMixin(
-            MultipleReqeustsMixin(
+            MultipleRequestsMixin(
                 OptionalMultipleSectionEndTimeMixin(OptionalMultipleSectionStartTimeMixin(ATokenOption))
             )
         ),

--- a/src/app/token-options/token-option-registry.ts
+++ b/src/app/token-options/token-option-registry.ts
@@ -14,6 +14,7 @@ import { SpendForQuizRevisionTokenOption } from './spend-for-quiz-revision-token
 import { SpendForAssignmentExtensionTokenOption } from './spend-for-assignment-extension-token-option';
 import { SpendForPassingAssignmentTokenOption } from './spend-for-passing-assignment-token-option';
 import type { Constructor } from 'app/utils/mixin-helper';
+import { PlaceholderTokenOption } from './placeholder-token-option';
 
 @Injectable({
     providedIn: 'root'
@@ -34,7 +35,8 @@ export class TokenOptionRegistry {
         'withdraw-lab-switch': 'Withdraw Lab Switch Request (For Teacher Only)',
         'spend-for-quiz-revision': 'Spend Tokens for Revision Assignment on Canvas after not passing Canvas Quiz',
         'spend-for-assignment-extension': 'Spend Tokens for Canvas Assignment Extension (No Longer Marked Late)',
-        'spend-for-passing-assignment': 'Spend Tokens for Assignment / Quiz Grade'
+        'spend-for-passing-assignment': 'Spend Tokens for Assignment / Quiz Grade',
+        'placeholder-token-option': 'Placeholder Token Option'
     };
 
     private static TOKEN_OPTION_CLASS_REGISTRY: {
@@ -53,7 +55,8 @@ export class TokenOptionRegistry {
         'withdraw-lab-switch': WithdrawLabSwitchTokenOption,
         'spend-for-quiz-revision': SpendForQuizRevisionTokenOption,
         'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption,
-        'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption
+        'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption,
+        'placeholder-token-option': PlaceholderTokenOption
     };
 
     public getDescriptiveName(tokenOptionType: string): string | undefined {

--- a/src/app/utils/multiple-section-date-matcher.ts
+++ b/src/app/utils/multiple-section-date-matcher.ts
@@ -45,7 +45,7 @@ export class MultipleSectionDateMatcher implements MultipleSectionDateMatcherDat
 
     public toHTML(): string {
         if (this._overrides.length == 0) {
-            return format(this.defaultDate, 'MMM dd, yyyy kk:mm:ss');
+            return format(this.defaultDate, 'MMM dd, yyyy HH:mm:ss');
         }
         return [
             '<table style="border-collapse: collapse; width: 100%;">',
@@ -56,7 +56,7 @@ export class MultipleSectionDateMatcher implements MultipleSectionDateMatcherDat
                     `<td style="text-align: end; text-wrap: nowrap">${override.name}:</td>`,
                     `<td style="text-align: start; text-wrap: nowrap">${format(
                         override.date,
-                        'MMM dd, yyyy kk:mm:ss'
+                        'MMM dd, yyyy HH:mm:ss'
                     )}</td>`,
                     `</tr>`
                 ].join('');
@@ -65,7 +65,7 @@ export class MultipleSectionDateMatcher implements MultipleSectionDateMatcherDat
             '<td style="text-align: end; text-wrap: nowrap">Default:</td>',
             `<td style="text-align: start; text-wrap: nowrap">${format(
                 this.defaultDate,
-                'MMM dd, yyyy kk:mm:ss'
+                'MMM dd, yyyy HH:mm:ss'
             )}</td>`,
             '</tr>',
             '</tbody>',


### PR DESCRIPTION
### Description

A new type of token option (placeholder token option) is implemented in this pull request. This token option type serves as a placeholder to allow the user to integrate Token ATM with other third-party services. In addition to general configurations for all token options, the following configurations  are available for this type of token option:

1.  Optionally configure a start time (with exceptions for sections)
2.  Optionally configure an end time (with exceptions for sections)
3.  Optionally allow multiple approved requests (-1 for unlimited)
4.  Exclude other token options

 A student's request will be approved only if all following conditions met:

1.  The student does not reach the maximum allowed amount of approved requests for this token option. If the amount of multiple requests is unlimited (-1), this condition will always met.
2.  The student does not have any approved request for token options that this token option is excluded with.
3.  If the token balance change for this token option is negative, the student should have sufficient token (i.e., have a non-negative balance after spending for this token option)
4.  If start time is configured, the request should be made no earlier than the start time.
5.  If end time is configured, the request should be made no later than the end time.

When approved, Token ATM will record the request and made corresponding token balance change. The user could then export requests for this token option as csv.

In addition to the new token option type, this pull request also includes an enhancement and a bugfix:

*   Enhancement: When configuring exceptions for sections on start time, end time, and new due date, the time for the exception is set to the current time upon creation. It could be frustrating for the user to manually adjust the date to 00:00:00 or 23:59:59. Therefore, a change is made to make the default time behavior for exceptions the same as the default time for start time/end time/new due time (i.e., 00:00:00 for start time; 23:59:59 for end time and new due time).
*   Bugfix: Now at the start of the request processing, several asynchronous checks such as the publish state of Token ATM Log and whether there are missing credentials are performed. However, the button to start request processing is not disabled during these checks. The user could accidentally clicks the “Start Request Processing” twice, which then causes two request processing instance run simultaneously. This will breaks student's Token ATM record. A change is made to disable the “Start Request Processing” button during these checks.

### Testing Note

1.  Please test if the new type of token option works as described.
2.  Please test if the enhancement and the bugfix mentioned above works as described.