### PR TITLE
Feature: Spend for Additional Points Token Option

### DIFF
--- a/src/app/components/dev-test/dev-test.component.html
+++ b/src/app/components/dev-test/dev-test.component.html
@@ -57,4 +57,7 @@
         <button class="btn btn-primary m-1" (click)="isAssignmentPublished()">is Published?</button>
         <button class="btn btn-warning" (click)="switchAssignmentPublishedState()">Switch Published State</button>
     </div>
+    <button class="btn btn-primary my-3" (click)="checkAllAssignmentGroupsTotalPointsPossible()">
+        Check Total Points Possible for all Assignment Groups
+    </button>
 </div>

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -250,4 +250,16 @@ export class DevTestComponent {
         await this.canvasService.modifyAssignmentPublishedState(this.course.id, assignmentId, !bool);
         console.log(`Canvas Assignment '${this.testAssignmentName}' is now ${!bool ? '' : 'NOT '}published.`);
     }
+
+    async checkAllAssignmentGroupsTotalPointsPossible(): Promise<void> {
+        if (!this.course) return;
+        console.log('Total Points Possible');
+        const skipIf = undefined; // { points_possible: [3, 7, 10] };
+        for await (const { id, name } of await this.canvasService.getAssignmentGroups(this.course.id)) {
+            console.log(
+                `  ${name}:`,
+                await this.canvasService.getTotalPointsPossibleInAnAssignmentGroup(this.course.id, id, skipIf)
+            );
+        }
+    }
 }

--- a/src/app/components/form-fields/optional-field/optional-field.component.ts
+++ b/src/app/components/form-fields/optional-field/optional-field.component.ts
@@ -25,7 +25,7 @@ export class OptionalFieldComponent<T extends FormField<any, any, any>>
         const [renderer, field] = this.fieldBuilder.build();
         this._field = field;
         this._field.isReadOnly = this.isReadOnly;
-        if (this.cachedSrcValue) {
+        if (this.cachedSrcValue !== undefined) {
             this._field.srcValue = this.cachedSrcValue;
             this.cachedSrcValue = undefined;
         }

--- a/src/app/data/assignment-group.ts
+++ b/src/app/data/assignment-group.ts
@@ -1,0 +1,27 @@
+import camelcaseKeys from 'camelcase-keys';
+import decamelizeKeys from 'decamelize-keys';
+import { chain } from 'fp-ts/lib/Either';
+import * as t from 'io-ts';
+
+export const AssignmentGroupDataDef = t.strict({
+    id: t.string,
+    name: t.string
+});
+
+export type AssignmentGroupData = t.TypeOf<typeof AssignmentGroupDataDef>;
+
+export class AssignmentGroup implements AssignmentGroupData {
+    public id = '';
+    public name = '';
+}
+
+export const AssignmentGroupDef = new t.Type<AssignmentGroup, unknown, unknown>(
+    'Assignment',
+    (v): v is AssignmentGroup => v instanceof AssignmentGroup,
+    (v, ctx) =>
+        chain((v: AssignmentGroupData) => t.success(Object.assign(new AssignmentGroup(), v)))(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            AssignmentGroupDataDef.validate(camelcaseKeys(v as any, { deep: true }), ctx)
+        ),
+    (v) => decamelizeKeys(AssignmentGroupDataDef.encode(v))
+);

--- a/src/app/request-handlers/request-handler-registry.ts
+++ b/src/app/request-handlers/request-handler-registry.ts
@@ -19,6 +19,7 @@ import { SpendForQuizRevisionRequestHandler } from './spend-for-quiz-revision-re
 import { SpendForAssignmentExtensionRequestHandler } from './spend-for-assignment-extension-request-handler';
 import { SpendForPassingAssignmentRequestHandler } from './spend-for-passing-assignment-request-handler';
 import { PlaceholderRequestHandler } from './placeholder-request-handler';
+import { SpendForAdditionalPointsRequestHandler } from './spend-for-additional-points-request-handler';
 
 type GenericRequestHandler = RequestHandler<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -36,7 +37,8 @@ export const REGISTERED_REQUEST_HANDLERS: Type<GenericRequestHandler>[] = [
     SpendForQuizRevisionRequestHandler,
     SpendForAssignmentExtensionRequestHandler,
     SpendForPassingAssignmentRequestHandler,
-    PlaceholderRequestHandler
+    PlaceholderRequestHandler,
+    SpendForAdditionalPointsRequestHandler
 ];
 
 export const REQUEST_HANDLER_INJECT_TOKEN = new InjectionToken<GenericRequestHandler[]>('REQUEST_HANDLERS');

--- a/src/app/request-handlers/spend-for-additional-points-request-handler.ts
+++ b/src/app/request-handlers/spend-for-additional-points-request-handler.ts
@@ -63,7 +63,7 @@ export class SpendForAdditionalPointsRequestHandler extends RequestHandler<
                 totalPointsPossible
             );
             const assignmentComment = `Request for ${request.tokenOption.name} was approved.\n` + updateMessage;
-            this.canvasService.postSubmissionGradeWithComment(
+            await this.canvasService.postSubmissionGradeWithComment(
                 configuration.course.id,
                 studentRecord.student.id,
                 request.tokenOption.assignmentId,

--- a/src/app/request-handlers/spend-for-additional-points-request-handler.ts
+++ b/src/app/request-handlers/spend-for-additional-points-request-handler.ts
@@ -25,15 +25,6 @@ export class SpendForAdditionalPointsRequestHandler extends RequestHandler<
         studentRecord: StudentRecord,
         request: SpendForAdditionalPointsRequest
     ): Promise<ProcessedRequest> {
-        const { gradingType, pointsPossible } = await this.canvasService.getAssignmentGradingTypeAndPointsPossible(
-            configuration.course.id,
-            request.tokenOption.assignmentId
-        );
-        if (gradingType !== 'points' && gradingType !== 'percent') {
-            throw new Error(
-                `${request.tokenOption.assignmentName} doesn’t display its Grade as Points or as a Percent, and so its score cannot be added to.`
-            );
-        }
         const guardExecutor = new RequestHandlerGuardExecutor([
             new MultipleRequestsGuard(request.tokenOption, studentRecord.processedRequests),
             new ExcludeTokenOptionsGuard(request.tokenOption.excludeTokenOptionIds, studentRecord.processedRequests),
@@ -41,6 +32,15 @@ export class SpendForAdditionalPointsRequestHandler extends RequestHandler<
         ]);
         await guardExecutor.check();
         if (!guardExecutor.isRejected) {
+            const { gradingType, pointsPossible } = await this.canvasService.getAssignmentGradingTypeAndPointsPossible(
+                configuration.course.id,
+                request.tokenOption.assignmentId
+            );
+            if (gradingType !== 'points' && gradingType !== 'percent') {
+                throw new Error(
+                    `${request.tokenOption.assignmentName} doesn’t display its Grade as Points or as a Percent, and so its score cannot be added to.`
+                );
+            }
             const addText = request.tokenOption.additionalScore;
             const { grade, score, gradeMatchesCurrentSubmission } = await this.canvasService.getSubmissionGradeAndScore(
                 configuration.course.id,

--- a/src/app/request-handlers/spend-for-additional-points-request-handler.ts
+++ b/src/app/request-handlers/spend-for-additional-points-request-handler.ts
@@ -41,6 +41,16 @@ export class SpendForAdditionalPointsRequestHandler extends RequestHandler<
                     `${request.tokenOption.assignmentName} doesn’t display its Grade as Points or as a Percent, and so its score cannot be added to.`
                 );
             }
+            if (
+                !(await this.canvasService.isAssignmentPublished(
+                    configuration.course.id,
+                    request.tokenOption.assignmentId
+                ))
+            ) {
+                throw new Error(
+                    `${request.tokenOption.assignmentName} must be published for its score to be added to.`
+                );
+            }
             const addText = request.tokenOption.additionalScore;
             const { grade, score, gradeMatchesCurrentSubmission } = await this.canvasService.getSubmissionGradeAndScore(
                 configuration.course.id,

--- a/src/app/request-handlers/spend-for-additional-points-request-handler.ts
+++ b/src/app/request-handlers/spend-for-additional-points-request-handler.ts
@@ -62,7 +62,7 @@ export class SpendForAdditionalPointsRequestHandler extends RequestHandler<
                 const newPostedGrade = addScoreFunc(toAdd, current, pointsPossible);
                 // Note: `toAddStr` uses score function, because canvas-grading.ts defaults to using only 2 decimal points
                 const toAddStr = addScoreFunc(toAdd, isAddingPercent ? '0%' : '0', pointsPossible); // TODO: use input text
-                const assignmentComment = `Request for ${request.tokenOption.name} was approved.\nChange: ${current} => ${newPostedGrade}\nAdded ${toAddStr} to ${current} of ${pointsPossible} points.`;
+                const assignmentComment = `Request for ${request.tokenOption.name} was approved.\nAdded ${toAddStr} to ${current} of ${pointsPossible} points.\nChange: ${current} => ${newPostedGrade}`;
                 this.canvasService.postSubmissionGradeWithComment(
                     configuration.course.id,
                     studentRecord.student.id,

--- a/src/app/request-handlers/spend-for-additional-points-request-handler.ts
+++ b/src/app/request-handlers/spend-for-additional-points-request-handler.ts
@@ -1,0 +1,93 @@
+import { Inject, Injectable } from '@angular/core';
+import { RequestHandler } from './request-handlers';
+import type { SpendForAdditionalPointsTokenOption } from 'app/token-options/spend-for-additional-points-token-option';
+import type { SpendForAdditionalPointsRequest } from 'app/requests/spend-for-additional-points-request';
+import { CanvasService } from 'app/services/canvas.service';
+import { ProcessedRequest } from 'app/data/processed-request';
+import type { StudentRecord } from 'app/data/student-record';
+import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
+import { RequestHandlerGuardExecutor } from './guards/request-handler-guard-executor';
+import {
+    addPercentToPointsOrPercentType,
+    addPointsToPercentOrPointsType,
+    parseCanvasPercentsAndPoints
+} from 'app/utils/canvas-grading';
+import { MultipleRequestsGuard } from './guards/multiple-requests-guard';
+import { ExcludeTokenOptionsGuard } from './guards/exclude-token-options-guard';
+import { SufficientTokenBalanceGuard } from './guards/sufficient-token-balance-guard';
+
+@Injectable()
+export class SpendForAdditionalPointsRequestHandler extends RequestHandler<
+    SpendForAdditionalPointsTokenOption,
+    SpendForAdditionalPointsRequest
+> {
+    constructor(@Inject(CanvasService) private canvasService: CanvasService) {
+        super();
+    }
+    public async handle(
+        configuration: TokenATMConfiguration,
+        studentRecord: StudentRecord,
+        request: SpendForAdditionalPointsRequest
+    ): Promise<ProcessedRequest> {
+        const { gradingType, pointsPossible } = await this.canvasService.getAssignmentGradingTypeAndPointsPossible(
+            configuration.course.id,
+            request.tokenOption.assignmentId
+        );
+        if (gradingType === 'points' || gradingType === 'percent') {
+            const guardExecutor = new RequestHandlerGuardExecutor([
+                new MultipleRequestsGuard(request.tokenOption, studentRecord.processedRequests),
+                new ExcludeTokenOptionsGuard(
+                    request.tokenOption.excludeTokenOptionIds,
+                    studentRecord.processedRequests
+                ),
+                new SufficientTokenBalanceGuard(studentRecord.tokenBalance, request.tokenOption.tokenBalanceChange)
+            ]);
+            await guardExecutor.check();
+            if (!guardExecutor.isRejected) {
+                const isAddingPercent = true; // TODO: Update to use input form
+                let toAdd = parseCanvasPercentsAndPoints('0'); // TODO: Update to use input form
+                toAdd = request.tokenOption.gradeThreshold;
+                const addScoreFunc = isAddingPercent ? addPercentToPointsOrPercentType : addPointsToPercentOrPointsType;
+                const { grade, score, gradeMatchesCurrentSubmission } =
+                    await this.canvasService.getSubmissionGradeAndScore(
+                        configuration.course.id,
+                        request.tokenOption.assignmentId,
+                        studentRecord.student.id
+                    );
+                if (!gradeMatchesCurrentSubmission) {
+                    throw new Error('Was about to add points to an out-of-date assignment score.');
+                }
+                const current = gradingType === 'points' ? score.toString() : grade;
+                const newPostedGrade = addScoreFunc(toAdd, current, pointsPossible);
+                const toAddStr = addScoreFunc(toAdd, isAddingPercent ? '0%' : '0', pointsPossible); // TODO: use input text
+                const assignmentComment = `Request for ${request.tokenOption.name} was approved.\nChange: ${current} => ${newPostedGrade}\nAdded ${toAddStr} to ${current} of ${pointsPossible} points.`;
+                this.canvasService.postSubmissionGradeWithComment(
+                    configuration.course.id,
+                    studentRecord.student.id,
+                    request.tokenOption.assignmentId,
+                    newPostedGrade,
+                    assignmentComment
+                );
+            }
+            return new ProcessedRequest(
+                configuration,
+                request.tokenOption.id,
+                request.tokenOption.name,
+                request.student,
+                !guardExecutor.isRejected,
+                request.submittedTime,
+                new Date(),
+                guardExecutor.isRejected ? 0 : request.tokenOption.tokenBalanceChange,
+                guardExecutor.message ?? '',
+                request.tokenOption.group.id
+            );
+        } else {
+            throw new Error(
+                `${request.tokenOption.assignmentName} doesn’t display its Grade as Points or a Percent, and so its score cannot be added to.`
+            );
+        }
+    }
+    public get type(): string {
+        return 'spend-for-additional-points';
+    }
+}

--- a/src/app/request-resolvers/request-resolver-registry.ts
+++ b/src/app/request-resolvers/request-resolver-registry.ts
@@ -18,6 +18,7 @@ import { SpendForQuizRevisionRequestResolver } from './spend-for-quiz-revision-r
 import { SpendForAssignmentExtensionRequestResolver } from './spend-for-assignment-extension-request-resolver';
 import { SpendForPassingAssignmentRequestResolver } from './spend-for-passing-assignment-request-resolver';
 import { PlaceholderRequestResolver } from './placeholder-request-resolver';
+import { SpendForAdditionalPointsRequestResolver } from './spend-for-additional-points-request-resolver';
 
 type GenericRequestResolver = RequestResolver<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -35,7 +36,8 @@ export const REGISTERED_REQUEST_RESOLVERS: Type<GenericRequestResolver>[] = [
     SpendForQuizRevisionRequestResolver,
     SpendForAssignmentExtensionRequestResolver,
     SpendForPassingAssignmentRequestResolver,
-    PlaceholderRequestResolver
+    PlaceholderRequestResolver,
+    SpendForAdditionalPointsRequestResolver
 ];
 
 export const REQUEST_RESOLVER_INJECT_TOKEN = new InjectionToken<GenericRequestResolver[]>('REQUEST_RESOLVERS');

--- a/src/app/request-resolvers/spend-for-additional-points-request-resolver.ts
+++ b/src/app/request-resolvers/spend-for-additional-points-request-resolver.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import type { QuizSubmissionDetail } from 'app/data/quiz-submission-detail';
+import { RequestResolver } from './request-resolver';
+import type { SpendForAdditionalPointsTokenOption } from 'app/token-options/spend-for-additional-points-token-option';
+import { SpendForAdditionalPointsRequest } from 'app/requests/spend-for-additional-points-request';
+
+@Injectable()
+export class SpendForAdditionalPointsRequestResolver extends RequestResolver<
+    SpendForAdditionalPointsTokenOption,
+    SpendForAdditionalPointsRequest
+> {
+    public async resolve(
+        tokenOption: SpendForAdditionalPointsTokenOption,
+        quizSubmissionDetail: QuizSubmissionDetail
+    ): Promise<SpendForAdditionalPointsRequest> {
+        return new SpendForAdditionalPointsRequest(
+            tokenOption,
+            quizSubmissionDetail.student,
+            quizSubmissionDetail.submittedTime,
+            quizSubmissionDetail
+        );
+    }
+    public get type(): string {
+        return 'spend-for-additional-points';
+    }
+}

--- a/src/app/requests/spend-for-additional-points-request.ts
+++ b/src/app/requests/spend-for-additional-points-request.ts
@@ -1,0 +1,4 @@
+import { TokenATMRequest } from './token-atm-request';
+import type { SpendForAdditionalPointsTokenOption } from 'app/token-options/spend-for-additional-points-token-option';
+
+export class SpendForAdditionalPointsRequest extends TokenATMRequest<SpendForAdditionalPointsTokenOption> {}

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -22,6 +22,7 @@ import { unwrapValidation } from 'app/utils/validation-unwrapper';
 import type { CanvasCredential } from 'app/data/token-atm-credentials';
 import { ExponentialBackoffExecutorService } from './exponential-backoff-executor.service';
 import type { CanvasGradingType } from 'app/utils/canvas-grading';
+import { AssignmentGroupDef, type AssignmentGroup } from 'app/data/assignment-group';
 
 type QuizQuestionResponse = {
     id: string;
@@ -867,7 +868,20 @@ export class CanvasService {
         return data.id;
     }
 
+    public async getAssignmentGroups(courseId: string): Promise<PaginatedResult<AssignmentGroup>> {
+        return new PaginatedResult<AssignmentGroup>(
+            await this.rawAPIRequest(`/api/v1/courses/${courseId}/assignment_groups`, {
+                params: {
+                    per_page: 100
+                }
+            }),
+            async (url: string) => await this.paginatedRequestHandler(url),
+            (data: unknown[]) => data.map((entry) => unwrapValidation(AssignmentGroupDef.decode(entry)))
+        );
+    }
+
     public async getAssignmentGroupIdByName(courseId: string, assignmentGroupName: string) {
+        // TODO: Use getAssignmentGroups method
         const assignmentGroups = new PaginatedResult<[string, string]>(
             await this.rawAPIRequest(`/api/v1/courses/${courseId}/assignment_groups`, {
                 params: {

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1578,6 +1578,17 @@ export class CanvasService {
         });
     }
 
+    public async getAssignmentGradingType(
+        courseId: string,
+        assignmentId: string
+    ): Promise<keyof typeof CanvasGradingType> {
+        const data = await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}`);
+        if (typeof data['grading_type'] != 'string') {
+            throw new Error('Invalid data');
+        }
+        return data['grading_type'] as keyof typeof CanvasGradingType;
+    }
+
     public async getAssignmentGradingTypeAndPointsPossible(
         courseId: string,
         assignmentId: string

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -21,6 +21,7 @@ import { Section } from 'app/data/section';
 import { unwrapValidation } from 'app/utils/validation-unwrapper';
 import type { CanvasCredential } from 'app/data/token-atm-credentials';
 import { ExponentialBackoffExecutorService } from './exponential-backoff-executor.service';
+import type { CanvasGradingType } from 'app/utils/canvas-grading';
 
 type QuizQuestionResponse = {
     id: string;
@@ -1579,12 +1580,15 @@ export class CanvasService {
     public async getAssignmentGradingTypeAndPointsPossible(
         courseId: string,
         assignmentId: string
-    ): Promise<{ gradingType: string; pointsPossible: number }> {
+    ): Promise<{ gradingType: keyof typeof CanvasGradingType; pointsPossible: number }> {
         const data = await this.apiRequest(`/api/v1/courses/${courseId}/assignments/${assignmentId}`);
         if (typeof data['grading_type'] != 'string' || typeof data['points_possible'] != 'number') {
             throw new Error('Invalid data');
         }
-        return { gradingType: data['grading_type'], pointsPossible: data['points_possible'] };
+        return {
+            gradingType: data['grading_type'] as keyof typeof CanvasGradingType,
+            pointsPossible: data['points_possible']
+        };
     }
 
     public async getSubmissionGradeAndScore(

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1607,13 +1607,13 @@ export class CanvasService {
         courseId: string,
         assignmentId: string,
         studentId: string
-    ): Promise<{ grade: string; score: number; gradeMatchesCurrentSubmission: boolean }> {
+    ): Promise<{ grade: string | null; score: number | null; gradeMatchesCurrentSubmission: boolean }> {
         const data = await this.apiRequest(
             `/api/v1/courses/${courseId}/assignments/${assignmentId}/submissions/${studentId}`
         );
         if (
-            typeof data['grade'] != 'string' ||
-            typeof data['score'] != 'number' ||
+            !(typeof data['grade'] === 'string' || data['grade'] === null) ||
+            !(typeof data['score'] === 'number' || data['score'] === null) ||
             typeof data['grade_matches_current_submission'] != 'boolean'
         ) {
             throw new Error('Invalid data');

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -880,23 +880,10 @@ export class CanvasService {
         );
     }
 
-    public async getAssignmentGroupIdByName(courseId: string, assignmentGroupName: string) {
-        // TODO: Use getAssignmentGroups method
-        const assignmentGroups = new PaginatedResult<[string, string]>(
-            await this.rawAPIRequest(`/api/v1/courses/${courseId}/assignment_groups`, {
-                params: {
-                    per_page: 100
-                }
-            }),
-            async (url: string) => await this.paginatedRequestHandler(url),
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (data: any) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                return data.map((entry: any) => [entry.id, entry.name]);
-            }
-        );
+    public async getAssignmentGroupIdByName(courseId: string, assignmentGroupName: string): Promise<string> {
+        const assignmentGroups = await this.getAssignmentGroups(courseId);
         let result: string | undefined = undefined;
-        for await (const [id, name] of assignmentGroups) {
+        for await (const { id, name } of assignmentGroups) {
             if (name != assignmentGroupName) continue;
             if (result == undefined) {
                 result = id;
@@ -1359,7 +1346,7 @@ export class CanvasService {
         return result;
     }
 
-    public async getAssignmentIdByName(courseId: string, assignmentName: string) {
+    public async getAssignmentIdByName(courseId: string, assignmentName: string): Promise<string> {
         const assignments = new PaginatedResult<Assignment>(
             await this.rawAPIRequest(`/api/v1/courses/${courseId}/assignments`, {
                 params: {

--- a/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
@@ -92,7 +92,6 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                 )
                 .appendBuilder(createExcludeTokenOptionsComponentBuilder(environmentInjector))
                 .transformSrc((value: SpendForAdditionalPointsTokenOption | TokenOptionGroup) => {
-                    // TODO: Collect and use changeMaxPossiblePoints from TokenOption
                     if (value instanceof TokenOptionGroup) {
                         const courseId = value.configuration.course.id;
                         return [

--- a/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
@@ -1,0 +1,127 @@
+import {
+    TokenOptionFieldComponentFactory,
+    createAssignmentFieldComponentBuilder,
+    createExcludeTokenOptionsComponentBuilder,
+    createFieldComponentWithLabel,
+    createGradeThresholdComponentBuilder,
+    tokenOptionFieldComponentBuilder,
+    tokenOptionValidationWrapper
+} from './token-option-field-component-factory';
+import { TokenOptionGroup } from 'app/data/token-option-group';
+import { Injectable, type EnvironmentInjector, type ViewContainerRef, Inject } from '@angular/core';
+import type { FormField } from 'app/utils/form-field/form-field';
+import {
+    SpendForAdditionalPointsTokenOptionDataDef,
+    type SpendForAdditionalPointsTokenOption,
+    type SpendForAdditionalPointsTokenOptionData
+} from 'app/token-options/spend-for-additional-points-token-option';
+import { CanvasService } from 'app/services/canvas.service';
+import { OptionalFieldComponent } from 'app/components/form-fields/optional-field/optional-field.component';
+import { NumberInputFieldComponent } from 'app/components/form-fields/number-input-field/number-input-field.component';
+
+@Injectable()
+export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends TokenOptionFieldComponentFactory<SpendForAdditionalPointsTokenOption> {
+    constructor(@Inject(CanvasService) private canvasService: CanvasService) {
+        super();
+    }
+
+    public create(environmentInjector: EnvironmentInjector): [
+        (viewContainerRef: ViewContainerRef) => void,
+        FormField<
+            SpendForAdditionalPointsTokenOption | TokenOptionGroup,
+            SpendForAdditionalPointsTokenOptionData,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            any
+        >
+    ] {
+        return tokenOptionValidationWrapper(
+            // TODO: Add Validator for Assignment grading type
+            //       Replace Grade Threshold Component for Canvas points/percent Component
+            environmentInjector,
+            tokenOptionFieldComponentBuilder(environmentInjector)
+                .appendBuilder(
+                    createAssignmentFieldComponentBuilder(
+                        this.canvasService,
+                        environmentInjector,
+                        'Canvas Assignment / Quiz'
+                    )
+                )
+                .appendBuilder(createGradeThresholdComponentBuilder(environmentInjector, 'Grade Threshold'))
+                .appendBuilder(
+                    createFieldComponentWithLabel(
+                        OptionalFieldComponent<NumberInputFieldComponent>,
+                        'Allow multiple approved requests',
+                        environmentInjector
+                    ).editField((field) => {
+                        field.fieldBuilder = createFieldComponentWithLabel(
+                            NumberInputFieldComponent,
+                            'Allowed maximum number of approved requests (-1 for unlimited)',
+                            environmentInjector
+                        ).editField((field) => {
+                            field.validator = async ([x, v]: [NumberInputFieldComponent, number]) => {
+                                x.errorMessage = undefined;
+                                if (!Number.isInteger(v)) {
+                                    x.errorMessage = 'Should be an integer (floating number is not allowed)';
+                                    return false;
+                                }
+                                if (v != -1 && v < 0) {
+                                    x.errorMessage = 'Negative number is not allowed (except for -1)';
+                                    return false;
+                                }
+                                return true;
+                            };
+                        });
+                    })
+                )
+                .appendBuilder(createExcludeTokenOptionsComponentBuilder(environmentInjector))
+                .transformSrc((value: SpendForAdditionalPointsTokenOption | TokenOptionGroup) => {
+                    if (value instanceof TokenOptionGroup)
+                        return [
+                            value,
+                            [value.configuration.course.id, undefined],
+                            1,
+                            [false, 1],
+                            ['', value.configuration]
+                        ];
+                    else
+                        return [
+                            value,
+                            [
+                                value.group.configuration.course.id,
+                                {
+                                    id: value.assignmentId,
+                                    name: value.assignmentName
+                                }
+                            ],
+                            value.gradeThreshold,
+                            [value.allowedRequestCnt != 1, value.allowedRequestCnt],
+                            [value.excludeTokenOptionIds.join(','), value.group.configuration]
+                        ];
+                })
+                .transformDest(
+                    async ([
+                        tokenOptionData,
+                        { id: assignmentId, name: assignmentName },
+                        gradeThreshold,
+                        allowedRequestCnt,
+                        excludeTokenOptionIds
+                    ]) => {
+                        return {
+                            ...tokenOptionData,
+                            type: 'spend-for-additional-points',
+                            assignmentName,
+                            assignmentId,
+                            gradeThreshold,
+                            allowedRequestCnt: allowedRequestCnt ?? 1,
+                            excludeTokenOptionIds
+                        };
+                    }
+                ),
+            SpendForAdditionalPointsTokenOptionDataDef.is
+        ).build();
+    }
+
+    public get type(): string {
+        return 'spend-for-additional-points';
+    }
+}

--- a/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
@@ -105,20 +105,34 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                         ];
                     } else {
                         const courseId = value.group.configuration.course.id;
-                        const convertedPropNames =
-                            value.changeMaxPossiblePoints == null
-                                ? undefined
-                                : ([
-                                      value.changeMaxPossiblePoints[0],
-                                      {
-                                          name: value.changeMaxPossiblePoints[1].groupName,
-                                          id: value.changeMaxPossiblePoints[1].groupId
-                                      }
-                                  ] as [string, AssignmentGroup]);
+                        // Code to adapt when more than just assignment groups can be selected
+                        // const convertedPropNames =
+                        //     value.changeMaxPossiblePoints == null
+                        //         ? undefined
+                        //         : ([
+                        //               value.changeMaxPossiblePoints[0],
+                        //               {
+                        //                   name: value.changeMaxPossiblePoints[1].groupName,
+                        //                   id: value.changeMaxPossiblePoints[1].groupId
+                        //               }
+                        //           ] as [string, AssignmentGroup]);
+                        // const maxPointsSelection =
+                        //     value.changeMaxPossiblePoints == null
+                        //         ? [false, [courseId, convertedPropNames as undefined]]
+                        //         : [true, [courseId, convertedPropNames as [string, AssignmentGroup]]];
                         const maxPointsSelection =
                             value.changeMaxPossiblePoints == null
-                                ? [false, [courseId, convertedPropNames as undefined]]
-                                : [true, [courseId, convertedPropNames as [string, AssignmentGroup]]];
+                                ? [false, [courseId, undefined]]
+                                : [
+                                      true,
+                                      [
+                                          courseId,
+                                          {
+                                              name: value.changeMaxPossiblePoints[1].groupName,
+                                              id: value.changeMaxPossiblePoints[1].groupId
+                                          }
+                                      ]
+                                  ];
                         return [
                             value,
                             [

--- a/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
@@ -90,6 +90,7 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                 )
                 .appendBuilder(createExcludeTokenOptionsComponentBuilder(environmentInjector))
                 .transformSrc((value: SpendForAdditionalPointsTokenOption | TokenOptionGroup) => {
+                    // TODO: Collect and use changeMaxPossiblePoints from TokenOption
                     if (value instanceof TokenOptionGroup) {
                         const courseId = value.configuration.course.id;
                         return [
@@ -127,14 +128,19 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                         allowedRequestCnt,
                         excludeTokenOptionIds
                     ]) => {
-                        // TODO: Add search criteria and assignmentGroupData to token option
-                        assignmentGroupData;
+                        const selectionTuple = assignmentGroupData
+                            ? [
+                                  'assignmentGroup',
+                                  { groupName: assignmentGroupData.name, groupId: assignmentGroupData.id }
+                              ]
+                            : null;
                         return {
                             ...tokenOptionData,
                             type: 'spend-for-additional-points',
                             assignmentName,
                             assignmentId,
                             additionalScore,
+                            changeMaxPossiblePoints: selectionTuple,
                             allowedRequestCnt: allowedRequestCnt ?? 1,
                             excludeTokenOptionIds
                         };

--- a/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
@@ -22,6 +22,8 @@ import { NumberInputFieldComponent } from 'app/components/form-fields/number-inp
 import { FormFieldComponentBuilder } from 'app/utils/form-field/form-field-component-builder';
 import { StringInputFieldComponent } from 'app/components/form-fields/string-input-field/string-input-field.component';
 import { parseCanvasPercentsAndPoints } from 'app/utils/canvas-grading';
+import type { AssignmentGroupMixinData } from 'app/token-options/mixins/assignment-group-mixin';
+import type { AssignmentGroup } from 'app/data/assignment-group';
 
 @Injectable()
 export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends TokenOptionFieldComponentFactory<SpendForAdditionalPointsTokenOption> {
@@ -103,6 +105,20 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                         ];
                     } else {
                         const courseId = value.group.configuration.course.id;
+                        const convertedPropNames =
+                            value.changeMaxPossiblePoints == null
+                                ? undefined
+                                : ([
+                                      value.changeMaxPossiblePoints[0],
+                                      {
+                                          name: value.changeMaxPossiblePoints[1].groupName,
+                                          id: value.changeMaxPossiblePoints[1].groupId
+                                      }
+                                  ] as [string, AssignmentGroup]);
+                        const maxPointsSelection =
+                            value.changeMaxPossiblePoints == null
+                                ? [false, [courseId, convertedPropNames as undefined]]
+                                : [true, [courseId, convertedPropNames as [string, AssignmentGroup]]];
                         return [
                             value,
                             [
@@ -113,7 +129,7 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                                 }
                             ],
                             value.additionalScore,
-                            [false, [courseId, undefined]],
+                            maxPointsSelection as [boolean, [string, undefined]] | [boolean, [string, AssignmentGroup]],
                             [value.allowedRequestCnt != 1, value.allowedRequestCnt],
                             [value.excludeTokenOptionIds.join(','), value.group.configuration]
                         ];
@@ -129,11 +145,11 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                         excludeTokenOptionIds
                     ]) => {
                         const selectionTuple = assignmentGroupData
-                            ? [
+                            ? ([
                                   'assignmentGroup',
                                   { groupName: assignmentGroupData.name, groupId: assignmentGroupData.id }
-                              ]
-                            : null;
+                              ] as [string, AssignmentGroupMixinData])
+                            : undefined;
                         return {
                             ...tokenOptionData,
                             type: 'spend-for-additional-points',

--- a/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/spend-for-additional-points-token-option-field-component-factory.ts
@@ -146,7 +146,7 @@ export class SpendForAdditionalPointsTokenOptionFieldComponentFactory extends To
                     ]) => {
                         const selectionTuple = assignmentGroupData
                             ? ([
-                                  'assignmentGroup',
+                                  'assignment-group',
                                   { groupName: assignmentGroupData.name, groupId: assignmentGroupData.id }
                               ] as [string, AssignmentGroupMixinData])
                             : undefined;

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
@@ -25,6 +25,7 @@ import { SpendForQuizRevisionTokenOptionFieldComponentFactory } from './spend-fo
 import { SpendForAssignmentExtensionTokenOptionFieldComponentFactory } from './spend-for-assignment-extension-token-option-field-component-factory';
 import { SpendForPassingAssignmentTokenOptionFieldComponentFactory } from './spend-for-passing-assignment-token-option-field-component-factory';
 import { PlaceholderTokenOptionFieldComponentFactory } from './placeholder-token-option-field-component-factory';
+import { SpendForAdditionalPointsTokenOptionFieldComponentFactory } from './spend-for-additional-points-token-option-field-component-factory';
 
 export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOptionFieldComponentFactory<TokenOption>>[] =
     [
@@ -41,7 +42,8 @@ export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOption
         SpendForQuizRevisionTokenOptionFieldComponentFactory,
         SpendForAssignmentExtensionTokenOptionFieldComponentFactory,
         SpendForPassingAssignmentTokenOptionFieldComponentFactory,
-        PlaceholderTokenOptionFieldComponentFactory
+        PlaceholderTokenOptionFieldComponentFactory,
+        SpendForAdditionalPointsTokenOptionFieldComponentFactory
     ];
 
 export const TOKEN_OPTION_FIELD_COMPONENT_FACTORY_INJECTION_TOKEN = new InjectionToken<

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
@@ -323,7 +323,7 @@ export function createAssignmentFieldComponentBuilder(
                 displayNames[displayNames.length - 1] = `or ${displayNames[displayNames.length - 1]}`;
             }
             const nameList = displayNames.length == 2 ? displayNames.join(' ') : displayNames.join(', ');
-            selectionField.errorMessage = `${assignmentName} must display its grade as ${nameList}`;
+            selectionField.errorMessage = `${assignmentName} must display its grade as ${nameList} to work`;
         }
         return false;
     }

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
@@ -315,7 +315,7 @@ export function createAssignmentFieldComponentBuilder(
         selectionField: SingleSelectionFieldComponent<string>
     ): Promise<boolean> {
         if (validTypes === undefined) return true;
-        const { gradingType } = await canvasService.getAssignmentGradingTypeAndPointsPossible(courseId, assignmentId);
+        const gradingType = await canvasService.getAssignmentGradingType(courseId, assignmentId);
         if (validTypes.includes(gradingType)) {
             return true;
         } else {

--- a/src/app/token-option-resolvers/token-option-resolver-registry.ts
+++ b/src/app/token-option-resolvers/token-option-resolver-registry.ts
@@ -18,6 +18,7 @@ import { SpendForQuizRevisionTokenOption } from 'app/token-options/spend-for-qui
 import { SpendForAssignmentExtensionTokenOption } from 'app/token-options/spend-for-assignment-extension-token-option';
 import { SpendForPassingAssignmentTokenOption } from 'app/token-options/spend-for-passing-assignment-token-option';
 import { PlaceholderTokenOption } from 'app/token-options/placeholder-token-option';
+import { SpendForAdditionalPointsTokenOption } from 'app/token-options/spend-for-additional-points-token-option';
 
 export const REGISTERED_TOKEN_OPTION_RESOLVERS: Type<TokenOptionResolver<TokenOption>>[] = [];
 
@@ -42,7 +43,8 @@ export const DEFAULT_TOKEN_OPTION_RESOLVERS: {
     'spend-for-quiz-revision': SpendForQuizRevisionTokenOption,
     'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption,
     'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption,
-    'placeholder-token-option': PlaceholderTokenOption
+    'placeholder-token-option': PlaceholderTokenOption,
+    'spend-for-additional-points': SpendForAdditionalPointsTokenOption
 };
 
 interface ITokenOptionType {

--- a/src/app/token-options/mixins/additional-canvas-score-mixin.ts
+++ b/src/app/token-options/mixins/additional-canvas-score-mixin.ts
@@ -1,0 +1,28 @@
+import * as t from 'io-ts';
+import type { Constructor } from 'app/utils/mixin-helper';
+import type { IGridViewDataSource } from './grid-view-data-source-mixin';
+
+export const AdditionalCanvasScoreMixinDataDef = t.strict({
+    additionalScore: t.string
+});
+
+export type AdditionalCanvasScoreMixinData = t.TypeOf<typeof AdditionalCanvasScoreMixinDataDef>;
+export type RawAdditionalCanvasScoreMixinData = t.OutputOf<typeof AdditionalCanvasScoreMixinDataDef>;
+
+export type IAdditionalCanvasScore = AdditionalCanvasScoreMixinData & IGridViewDataSource;
+
+export function AdditionalCanvasScoreMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IAdditionalCanvasScore {
+        additionalScore = '';
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+            this.registerDataPointSource(() => ({
+                colName: 'Add to Canvas Assingment / Quiz Score',
+                type: 'string', // TODO: Create a type for valid Canvas posted grade arguments
+                value: this.additionalScore
+            }));
+        }
+    };
+}

--- a/src/app/token-options/mixins/assignment-group-mixin.ts
+++ b/src/app/token-options/mixins/assignment-group-mixin.ts
@@ -1,0 +1,30 @@
+import * as t from 'io-ts';
+import type { Constructor } from 'app/utils/mixin-helper';
+import type { IGridViewDataSource } from './grid-view-data-source-mixin';
+
+export const AssignmentGroupMixinDataDef = t.strict({
+    groupName: t.string,
+    groupId: t.string
+});
+
+export type AssignmentGroupMixinData = t.TypeOf<typeof AssignmentGroupMixinDataDef>;
+export type RawAssignmentGroupMixinData = t.OutputOf<typeof AssignmentGroupMixinDataDef>;
+
+export type IAssignmentGroup = AssignmentGroupMixinData & IGridViewDataSource;
+
+export function AssignmentGroupMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IAssignmentGroup {
+        groupName = '';
+        groupId = '';
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+            this.registerDataPointSource(() => ({
+                colName: 'Canvas Assignment Group Name',
+                type: 'string',
+                value: this.groupName
+            }));
+        }
+    };
+}

--- a/src/app/token-options/mixins/optional-max-points-selection.ts
+++ b/src/app/token-options/mixins/optional-max-points-selection.ts
@@ -1,0 +1,36 @@
+import * as t from 'io-ts';
+import type { Constructor } from 'app/utils/mixin-helper';
+import type { IGridViewDataSource } from './grid-view-data-source-mixin';
+import { AssignmentGroupMixinData, AssignmentGroupMixinDataDef } from './assignment-group-mixin';
+
+// TODO: Expand to include other selection options (also update registered data points)
+const Selectable = t.tuple([t.string, AssignmentGroupMixinDataDef]);
+
+export const OptionalMaxPointsSelectionMixinDataDef = t.strict({
+    changeMaxPossiblePoints: t.union([Selectable, t.null])
+});
+
+export type OptionalMaxPointsSelectionMixinData = t.TypeOf<typeof OptionalMaxPointsSelectionMixinDataDef>;
+export type RawOptionalMaxPointsSelectionMixinData = t.OutputOf<typeof OptionalMaxPointsSelectionMixinDataDef>;
+
+export type IOptionalMaxPointsSelection = OptionalMaxPointsSelectionMixinData & IGridViewDataSource;
+
+export function OptionalMaxPointsSelectionMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IOptionalMaxPointsSelection {
+        changeMaxPossiblePoints: [string, AssignmentGroupMixinData] | null = null;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+            this.registerDataPointSource(() =>
+                this.changeMaxPossiblePoints !== null
+                    ? {
+                          colName: 'Base Max Possible Points on',
+                          type: 'string',
+                          value: 'Canvas Assignment Group'
+                      }
+                    : undefined
+            );
+        }
+    };
+}

--- a/src/app/token-options/mixins/optional-max-points-selection.ts
+++ b/src/app/token-options/mixins/optional-max-points-selection.ts
@@ -7,7 +7,7 @@ import { AssignmentGroupMixinData, AssignmentGroupMixinDataDef } from './assignm
 const Selectable = t.tuple([t.string, AssignmentGroupMixinDataDef]);
 
 export const OptionalMaxPointsSelectionMixinDataDef = t.strict({
-    changeMaxPossiblePoints: t.union([Selectable, t.null])
+    changeMaxPossiblePoints: t.union([Selectable, t.undefined])
 });
 
 export type OptionalMaxPointsSelectionMixinData = t.TypeOf<typeof OptionalMaxPointsSelectionMixinDataDef>;
@@ -17,13 +17,13 @@ export type IOptionalMaxPointsSelection = OptionalMaxPointsSelectionMixinData & 
 
 export function OptionalMaxPointsSelectionMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
     return class extends Base implements IOptionalMaxPointsSelection {
-        changeMaxPossiblePoints: [string, AssignmentGroupMixinData] | null = null;
+        changeMaxPossiblePoints: [string, AssignmentGroupMixinData] | undefined = undefined;
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         constructor(...args: any[]) {
             super(...args);
             this.registerDataPointSource(() =>
-                this.changeMaxPossiblePoints !== null
+                this.changeMaxPossiblePoints != null
                     ? {
                           colName: 'Base Max Possible Points on',
                           type: 'string',

--- a/src/app/token-options/spend-for-additional-points-token-option.ts
+++ b/src/app/token-options/spend-for-additional-points-token-option.ts
@@ -7,11 +7,17 @@ import { ToJSONMixin } from './mixins/to-json-mixin';
 import { ExcludeTokenOptionIdsMixin, ExcludeTokenOptionIdsMixinDataDef } from './mixins/exclude-token-option-ids-mixin';
 import { MultipleRequestsMixin, MultipleRequestsMixinDataDef } from './mixins/multiple-requests-mixin';
 import { AdditionalCanvasScoreMixinDataDef, AdditionalCanvasScoreMixin } from './mixins/additional-canvas-score-mixin';
+// import {
+//     OptionalMaxPointsSelectionMixin,
+//     OptionalMaxPointsSelectionMixinDataDef
+// } from './mixins/optional-max-points-selection';
 
+// TODO: Fix type inference for Optional Max Points Selection
 export const SpendForAdditionalPointsTokenOptionDataDef = t.intersection([
     TokenOptionDataDef,
     AssignmentMixinDataDef,
     AdditionalCanvasScoreMixinDataDef,
+    // OptionalMaxPointsSelectionMixinDataDef,
     MultipleRequestsMixinDataDef,
     ExcludeTokenOptionIdsMixinDataDef
 ]);
@@ -20,6 +26,11 @@ export type SpendForAdditionalPointsTokenOptionData = t.TypeOf<typeof SpendForAd
 
 export class SpendForAdditionalPointsTokenOption extends FromDataMixin(
     ToJSONMixin(
+        // ExcludeTokenOptionIdsMixin(
+        //     MultipleRequestsMixin(
+        //         OptionalMaxPointsSelectionMixin(AdditionalCanvasScoreMixin(AssignmentMixin(ATokenOption)))
+        //     )
+        // ),
         ExcludeTokenOptionIdsMixin(MultipleRequestsMixin(AdditionalCanvasScoreMixin(AssignmentMixin(ATokenOption)))),
         SpendForAdditionalPointsTokenOptionDataDef.encode
     ),

--- a/src/app/token-options/spend-for-additional-points-token-option.ts
+++ b/src/app/token-options/spend-for-additional-points-token-option.ts
@@ -1,0 +1,29 @@
+import * as t from 'io-ts';
+import { AssignmentMixin, AssignmentMixinDataDef } from './mixins/assignment-mixin';
+import { ATokenOption, TokenOptionDataDef } from './token-option';
+import { FromDataMixin } from './mixins/from-data-mixin';
+import { unwrapValidationFunc } from 'app/utils/validation-unwrapper';
+import { ToJSONMixin } from './mixins/to-json-mixin';
+import { GradeThresholdMixin, GradeThresholdMixinDataDef } from './mixins/grade-threshold-mixin';
+import { ExcludeTokenOptionIdsMixin, ExcludeTokenOptionIdsMixinDataDef } from './mixins/exclude-token-option-ids-mixin';
+import { MultipleRequestsMixin, MultipleRequestsMixinDataDef } from './mixins/multiple-requests-mixin';
+
+// TODO: - replace GradeThresholdMixin with new Canvas Points/Percent
+export const SpendForAdditionalPointsTokenOptionDataDef = t.intersection([
+    TokenOptionDataDef,
+    AssignmentMixinDataDef,
+    GradeThresholdMixinDataDef,
+    MultipleRequestsMixinDataDef,
+    ExcludeTokenOptionIdsMixinDataDef
+]);
+
+export type SpendForAdditionalPointsTokenOptionData = t.TypeOf<typeof SpendForAdditionalPointsTokenOptionDataDef>;
+
+export class SpendForAdditionalPointsTokenOption extends FromDataMixin(
+    ToJSONMixin(
+        ExcludeTokenOptionIdsMixin(MultipleRequestsMixin(GradeThresholdMixin(AssignmentMixin(ATokenOption)))),
+        SpendForAdditionalPointsTokenOptionDataDef.encode
+    ),
+    unwrapValidationFunc(SpendForAdditionalPointsTokenOptionDataDef.decode),
+    SpendForAdditionalPointsTokenOptionDataDef.is
+) {}

--- a/src/app/token-options/spend-for-additional-points-token-option.ts
+++ b/src/app/token-options/spend-for-additional-points-token-option.ts
@@ -12,9 +12,9 @@ import {
     OptionalMaxPointsSelectionMixinDataDef
 } from './mixins/optional-max-points-selection';
 
-// Note: t.intersection seems to have an upper limit of DataDefs
-//       once there are 6 all the types are labeled as t.mixed
-//       Using multiple t.intersection's works around this.
+// Note: t.intersection seems to have an upper limit of DataDefs.
+//       Once there are 6 all the types are labeled as t.mixed.
+//       Using multiple t.intersections works around this.
 export const SpendForAdditionalPointsTokenOptionDataDef = t.intersection([
     t.intersection([TokenOptionDataDef, AssignmentMixinDataDef, AdditionalCanvasScoreMixinDataDef]),
     t.intersection([

--- a/src/app/token-options/spend-for-additional-points-token-option.ts
+++ b/src/app/token-options/spend-for-additional-points-token-option.ts
@@ -4,15 +4,14 @@ import { ATokenOption, TokenOptionDataDef } from './token-option';
 import { FromDataMixin } from './mixins/from-data-mixin';
 import { unwrapValidationFunc } from 'app/utils/validation-unwrapper';
 import { ToJSONMixin } from './mixins/to-json-mixin';
-import { GradeThresholdMixin, GradeThresholdMixinDataDef } from './mixins/grade-threshold-mixin';
 import { ExcludeTokenOptionIdsMixin, ExcludeTokenOptionIdsMixinDataDef } from './mixins/exclude-token-option-ids-mixin';
 import { MultipleRequestsMixin, MultipleRequestsMixinDataDef } from './mixins/multiple-requests-mixin';
+import { AdditionalCanvasScoreMixinDataDef, AdditionalCanvasScoreMixin } from './mixins/additional-canvas-score-mixin';
 
-// TODO: - replace GradeThresholdMixin with new Canvas Points/Percent
 export const SpendForAdditionalPointsTokenOptionDataDef = t.intersection([
     TokenOptionDataDef,
     AssignmentMixinDataDef,
-    GradeThresholdMixinDataDef,
+    AdditionalCanvasScoreMixinDataDef,
     MultipleRequestsMixinDataDef,
     ExcludeTokenOptionIdsMixinDataDef
 ]);
@@ -21,7 +20,7 @@ export type SpendForAdditionalPointsTokenOptionData = t.TypeOf<typeof SpendForAd
 
 export class SpendForAdditionalPointsTokenOption extends FromDataMixin(
     ToJSONMixin(
-        ExcludeTokenOptionIdsMixin(MultipleRequestsMixin(GradeThresholdMixin(AssignmentMixin(ATokenOption)))),
+        ExcludeTokenOptionIdsMixin(MultipleRequestsMixin(AdditionalCanvasScoreMixin(AssignmentMixin(ATokenOption)))),
         SpendForAdditionalPointsTokenOptionDataDef.encode
     ),
     unwrapValidationFunc(SpendForAdditionalPointsTokenOptionDataDef.decode),

--- a/src/app/token-options/spend-for-additional-points-token-option.ts
+++ b/src/app/token-options/spend-for-additional-points-token-option.ts
@@ -7,31 +7,33 @@ import { ToJSONMixin } from './mixins/to-json-mixin';
 import { ExcludeTokenOptionIdsMixin, ExcludeTokenOptionIdsMixinDataDef } from './mixins/exclude-token-option-ids-mixin';
 import { MultipleRequestsMixin, MultipleRequestsMixinDataDef } from './mixins/multiple-requests-mixin';
 import { AdditionalCanvasScoreMixinDataDef, AdditionalCanvasScoreMixin } from './mixins/additional-canvas-score-mixin';
-// import {
-//     OptionalMaxPointsSelectionMixin,
-//     OptionalMaxPointsSelectionMixinDataDef
-// } from './mixins/optional-max-points-selection';
+import {
+    OptionalMaxPointsSelectionMixin,
+    OptionalMaxPointsSelectionMixinDataDef
+} from './mixins/optional-max-points-selection';
 
-// TODO: Fix type inference for Optional Max Points Selection
+// Note: t.intersection seems to have an upper limit of DataDefs
+//       once there are 6 all the types are labeled as t.mixed
+//       Using multiple t.intersection's works around this.
 export const SpendForAdditionalPointsTokenOptionDataDef = t.intersection([
-    TokenOptionDataDef,
-    AssignmentMixinDataDef,
-    AdditionalCanvasScoreMixinDataDef,
-    // OptionalMaxPointsSelectionMixinDataDef,
-    MultipleRequestsMixinDataDef,
-    ExcludeTokenOptionIdsMixinDataDef
+    t.intersection([TokenOptionDataDef, AssignmentMixinDataDef, AdditionalCanvasScoreMixinDataDef]),
+    t.intersection([
+        OptionalMaxPointsSelectionMixinDataDef,
+        MultipleRequestsMixinDataDef,
+        ExcludeTokenOptionIdsMixinDataDef
+    ])
 ]);
 
 export type SpendForAdditionalPointsTokenOptionData = t.TypeOf<typeof SpendForAdditionalPointsTokenOptionDataDef>;
+export type RawSpendForAdditionalPointsTokenOptionData = t.OutputOf<typeof SpendForAdditionalPointsTokenOptionDataDef>;
 
 export class SpendForAdditionalPointsTokenOption extends FromDataMixin(
     ToJSONMixin(
-        // ExcludeTokenOptionIdsMixin(
-        //     MultipleRequestsMixin(
-        //         OptionalMaxPointsSelectionMixin(AdditionalCanvasScoreMixin(AssignmentMixin(ATokenOption)))
-        //     )
-        // ),
-        ExcludeTokenOptionIdsMixin(MultipleRequestsMixin(AdditionalCanvasScoreMixin(AssignmentMixin(ATokenOption)))),
+        ExcludeTokenOptionIdsMixin(
+            MultipleRequestsMixin(
+                OptionalMaxPointsSelectionMixin(AdditionalCanvasScoreMixin(AssignmentMixin(ATokenOption)))
+            )
+        ),
         SpendForAdditionalPointsTokenOptionDataDef.encode
     ),
     unwrapValidationFunc(SpendForAdditionalPointsTokenOptionDataDef.decode),

--- a/src/app/token-options/token-option-registry.ts
+++ b/src/app/token-options/token-option-registry.ts
@@ -15,6 +15,7 @@ import { SpendForAssignmentExtensionTokenOption } from './spend-for-assignment-e
 import { SpendForPassingAssignmentTokenOption } from './spend-for-passing-assignment-token-option';
 import type { Constructor } from 'app/utils/mixin-helper';
 import { PlaceholderTokenOption } from './placeholder-token-option';
+import { SpendForAdditionalPointsTokenOption } from './spend-for-additional-points-token-option';
 
 @Injectable({
     providedIn: 'root'
@@ -36,7 +37,8 @@ export class TokenOptionRegistry {
         'spend-for-quiz-revision': 'Spend Tokens for Revision Assignment on Canvas after not passing Canvas Quiz',
         'spend-for-assignment-extension': 'Spend Tokens for Canvas Assignment Extension (No Longer Marked Late)',
         'spend-for-passing-assignment': 'Spend Tokens for Assignment / Quiz Grade',
-        'placeholder-token-option': 'Placeholder Token Option'
+        'placeholder-token-option': 'Placeholder Token Option',
+        'spend-for-additional-points': 'Spend Tokens for Additional Canvas Assignment Points'
     };
 
     private static TOKEN_OPTION_CLASS_REGISTRY: {
@@ -56,7 +58,8 @@ export class TokenOptionRegistry {
         'spend-for-quiz-revision': SpendForQuizRevisionTokenOption,
         'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption,
         'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption,
-        'placeholder-token-option': PlaceholderTokenOption
+        'placeholder-token-option': PlaceholderTokenOption,
+        'spend-for-additional-points': SpendForAdditionalPointsTokenOption
     };
 
     public getDescriptiveName(tokenOptionType: string): string | undefined {

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -119,7 +119,8 @@ describe('Basic Conversions', () => {
         { input: [-1.1, '0', 10], result: '-1.1' },
         { input: [-1.2, '0', 10], result: '-1.2' },
         { input: [-1.3, '0', 10], result: '-1.3' },
-        { input: [-0.2, '0', 10], result: '-0.2' }
+        { input: [-0.2, '0', 10], result: '-0.2' },
+        { input: [0.222, '0', 0], result: '0.22' }
     ];
 
     pointsToPointsTests.forEach((params) => {

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -12,12 +12,12 @@ type addingScoreTypesTestingParameters = { input: [number, string, number]; resu
 
 function addingScores(
     params: addingScoreTypesTestingParameters,
-    func: (add: number, current: string, possible: number) => string,
+    func: (add: number, current: string, possible: number, maxDecimals?: number) => string,
     asPercent = false
 ) {
     const [add, current, possible] = params.input;
     it(`Adding ${add}${asPercent ? ' (as percent)' : ''} to ${current} of ${possible}`, () => {
-        expect(func(add, current, possible)).toBe(params.result);
+        expect(func(add, current, possible, 2)).toBe(params.result);
     });
 }
 
@@ -521,7 +521,7 @@ describe('Test that converting from different denominators preserves the actual 
         {
             add: '2.555',
             target: percent([null, null, 20]),
-            result: [noMes('12.78%'), noMes('32.56')],
+            result: [noMes('12.775%'), noMes('32.555')],
             basedOn: 60,
             matchingBasedOnScore: 30
         },

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -287,3 +287,6 @@ describe('Testing Canvas Score Inputs that should fail to parse.', () => {
 
     parseFailures.forEach(testNaN);
 });
+
+// TODO: Add tests for collectPointsPossible
+//       - null/NaN 'points_possible', null skip value, unique skip property, etc.

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -288,7 +288,13 @@ describe('Testing Canvas Score Inputs that should fail to parse.', () => {
         '%0%',
         '0%0%',
         '0.0%0.0',
-        '0%0.0%0'
+        '0%0.0%0',
+        '0-10.0',
+        ' -.20',
+        '--20',
+        '-100.00%%',
+        '-abc.qwe',
+        '205-02'
     ];
 
     function testNaN(testString: string) {

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -1,0 +1,256 @@
+import { addPercentToPointsOrPercentType, addPointsToPercentOrPointsType } from './canvas-grading';
+
+type addingScoreTypesTestingParameters = { input: [number, string, number]; result: string };
+
+function addingScores(
+    params: addingScoreTypesTestingParameters,
+    func: (add: number, current: string, possible: number) => string,
+    asPercent = false
+) {
+    const [add, current, possible] = params.input;
+    it(`Adding ${add}${asPercent ? ' (as percent)' : ''} to ${current} of ${possible}`, () => {
+        expect(func(add, current, possible)).toBe(params.result);
+    });
+}
+
+describe('Basic Conversions', () => {
+    const percentToPercentTests: addingScoreTypesTestingParameters[] = [
+        { input: [0.1, '100%', 10], result: '110%' },
+        { input: [0.1001, '100%', 10], result: '110.01%' },
+        { input: [0.10015, '100%', 10], result: '110.02%' },
+        { input: [0.100149, '100%', 10], result: '110.01%' },
+        { input: [0.100109, '100%', 10], result: '110.01%' },
+        { input: [0.100099, '100%', 10], result: '110.01%' },
+        { input: [0.10001, '100%', 10], result: '110%' },
+        { input: [1, '100%', 10], result: '200%' },
+        { input: [1.2, '100%', 10], result: '220%' },
+        { input: [-1.1, '100%', 10], result: '-10%' },
+        { input: [-1.2, '100%', 10], result: '-20%' },
+        { input: [-1.3, '100%', 10], result: '-30%' },
+        { input: [-0.2, '100%', 10], result: '80%' },
+        { input: [-0.2, '10%', 10], result: '-10%' },
+        { input: [0.1, '100%', 10], result: '110%' },
+        // Adding to 0%
+        { input: [0.1001, '0%', 10], result: '10.01%' },
+        { input: [0.10015, '0%', 10], result: '10.02%' },
+        { input: [0.100149, '0%', 10], result: '10.01%' },
+        { input: [0.100109, '0%', 10], result: '10.01%' },
+        { input: [0.100099, '0%', 10], result: '10.01%' },
+        { input: [0.10001, '0%', 10], result: '10%' },
+        { input: [1, '0%', 10], result: '100%' },
+        { input: [1.2, '0%', 10], result: '120%' },
+        { input: [-1.1, '0%', 10], result: '-110%' },
+        { input: [-1.2, '0%', 10], result: '-120%' },
+        { input: [-1.3, '0%', 10], result: '-130%' },
+        { input: [-0.2, '0%', 10], result: '-20%' },
+        { input: [-0.2, '0%', 10], result: '-20%' },
+        { input: [-0.001, '0%', 10], result: '-0.1%' }
+    ];
+
+    percentToPercentTests.forEach((params) => {
+        addingScores(params, addPercentToPointsOrPercentType, true);
+    });
+
+    const pointsToPointsTests: addingScoreTypesTestingParameters[] = [
+        // # Adding to 100 possiblePoints
+        // Adding to 100 of 100
+        { input: [0.1, '100', 100], result: '100.1' },
+        { input: [0.101, '100', 100], result: '100.1' },
+        { input: [0.115, '100', 100], result: '100.12' },
+        { input: [0.1149, '100', 100], result: '100.11' },
+        { input: [0.1109, '100', 100], result: '100.11' },
+        { input: [0.1099, '100', 100], result: '100.11' },
+        { input: [0.101, '100', 100], result: '100.1' },
+        { input: [1, '100', 100], result: '101' },
+        { input: [1.2, '100', 100], result: '101.2' },
+        { input: [-1.1, '100', 100], result: '98.9' },
+        { input: [-1.2, '100', 100], result: '98.8' },
+        { input: [-1.3, '100', 100], result: '98.7' },
+        { input: [-0.2, '100', 100], result: '99.8' },
+        { input: [-0.2, '10', 100], result: '9.8' },
+        { input: [0.1, '10', 100], result: '10.1' },
+        // Adding to 0 of 100
+        { input: [0.11, '0', 100], result: '0.11' },
+        { input: [0.115, '0', 100], result: '0.12' },
+        { input: [0.1149, '0', 100], result: '0.11' },
+        { input: [0.1109, '0', 100], result: '0.11' },
+        { input: [0.1099, '0', 100], result: '0.11' },
+        { input: [0.101, '0', 100], result: '0.1' },
+        { input: [1, '0', 100], result: '1' },
+        { input: [1.2, '0', 100], result: '1.2' },
+        { input: [-1.1, '0', 100], result: '-1.1' },
+        { input: [-1.2, '0', 100], result: '-1.2' },
+        { input: [-1.3, '0', 100], result: '-1.3' },
+        { input: [-0.2, '0', 100], result: '-0.2' },
+        // # Adding to 10 possiblePoints
+        // Adding to 10 of 10
+        { input: [0.1, '10', 10], result: '10.1' },
+        { input: [0.11, '10', 10], result: '10.11' },
+        { input: [0.115, '10', 10], result: '10.12' },
+        { input: [0.1149, '10', 10], result: '10.11' },
+        { input: [0.1109, '10', 10], result: '10.11' },
+        { input: [0.1099, '10', 10], result: '10.11' },
+        { input: [0.101, '10', 10], result: '10.1' },
+        { input: [1, '10', 10], result: '11' },
+        { input: [1.2, '10', 10], result: '11.2' },
+        { input: [-1.1, '10', 10], result: '8.9' },
+        { input: [-1.2, '10', 10], result: '8.8' },
+        { input: [-1.3, '10', 10], result: '8.7' },
+        { input: [-0.2, '10', 10], result: '9.8' },
+        { input: [-0.2, '1', 10], result: '0.8' },
+        { input: [0.1, '1', 10], result: '1.1' },
+        // Adding to 0 of 10
+        { input: [0.11, '0', 10], result: '0.11' },
+        { input: [0.115, '0', 10], result: '0.12' },
+        { input: [0.1149, '0', 10], result: '0.11' },
+        { input: [0.1109, '0', 10], result: '0.11' },
+        { input: [0.1099, '0', 10], result: '0.11' },
+        { input: [0.101, '0', 10], result: '0.1' },
+        { input: [1, '0', 10], result: '1' },
+        { input: [1.2, '0', 10], result: '1.2' },
+        { input: [-1.1, '0', 10], result: '-1.1' },
+        { input: [-1.2, '0', 10], result: '-1.2' },
+        { input: [-1.3, '0', 10], result: '-1.3' },
+        { input: [-0.2, '0', 10], result: '-0.2' }
+    ];
+
+    pointsToPointsTests.forEach((params) => {
+        addingScores(params, addPointsToPercentOrPointsType, false);
+    });
+});
+
+describe('Cross Type Conversions', () => {
+    const percentToPointsTests: addingScoreTypesTestingParameters[] = [
+        // # Adding to 100 possiblePoints
+        // Adding to 100 of 100
+        { input: [0.1, '100', 100], result: '110' },
+        { input: [0.1001, '100', 100], result: '110.01' },
+        { input: [0.10015, '100', 100], result: '110.02' },
+        { input: [0.100149, '100', 100], result: '110.01' },
+        { input: [0.100109, '100', 100], result: '110.01' },
+        { input: [0.100099, '100', 100], result: '110.01' },
+        { input: [0.10001, '100', 100], result: '110' },
+        { input: [1, '100', 100], result: '200' },
+        { input: [1.2, '100', 100], result: '220' },
+        { input: [-1.1, '100', 100], result: '-10' },
+        { input: [-1.2, '100', 100], result: '-20' },
+        { input: [-1.3, '100', 100], result: '-30' },
+        { input: [-0.2, '100', 100], result: '80' },
+        { input: [-0.2, '10', 100], result: '-10' },
+        { input: [0.1, '10', 100], result: '20' },
+        // Adding to 0 of 100
+        { input: [0.1001, '0', 100], result: '10.01' },
+        { input: [0.10015, '0', 100], result: '10.02' },
+        { input: [0.100149, '0', 100], result: '10.01' },
+        { input: [0.100109, '0', 100], result: '10.01' },
+        { input: [0.100099, '0', 100], result: '10.01' },
+        { input: [0.10001, '0', 100], result: '10' },
+        { input: [1, '0', 100], result: '100' },
+        { input: [1.2, '0', 100], result: '120' },
+        { input: [-1.1, '0', 100], result: '-110' },
+        { input: [-1.2, '0', 100], result: '-120' },
+        { input: [-1.3, '0', 100], result: '-130' },
+        { input: [-0.2, '0', 100], result: '-20' },
+        // # Adding to 10 possiblePoints
+        // Adding to 10 of 10
+        { input: [0.1, '10', 10], result: '11' },
+        { input: [0.101, '10', 10], result: '11.01' },
+        { input: [0.1015, '10', 10], result: '11.02' },
+        { input: [0.10149, '10', 10], result: '11.01' },
+        { input: [0.10109, '10', 10], result: '11.01' },
+        { input: [0.10099, '10', 10], result: '11.01' },
+        { input: [0.1001, '10', 10], result: '11' },
+        { input: [1, '10', 10], result: '20' },
+        { input: [1.2, '10', 10], result: '22' },
+        { input: [-1.1, '10', 10], result: '-1' },
+        { input: [-1.2, '10', 10], result: '-2' },
+        { input: [-1.3, '10', 10], result: '-3' },
+        { input: [-0.2, '10', 10], result: '8' },
+        { input: [-0.2, '1', 10], result: '-1' },
+        { input: [0.1, '1', 10], result: '2' },
+        // Adding to 0 of 10
+        { input: [0.101, '0', 10], result: '1.01' },
+        { input: [0.1015, '0', 10], result: '1.02' },
+        { input: [0.10149, '0', 10], result: '1.01' },
+        { input: [0.10109, '0', 10], result: '1.01' },
+        { input: [0.10099, '0', 10], result: '1.01' },
+        { input: [0.1001, '0', 10], result: '1' },
+        { input: [1, '0', 10], result: '10' },
+        { input: [1.2, '0', 10], result: '12' },
+        { input: [-1.1, '0', 10], result: '-11' },
+        { input: [-1.2, '0', 10], result: '-12' },
+        { input: [-1.3, '0', 10], result: '-13' },
+        { input: [-0.2, '0', 10], result: '-2' }
+    ];
+
+    percentToPointsTests.forEach((params) => {
+        addingScores(params, addPercentToPointsOrPercentType, true);
+    });
+
+    const pointsToPercentTests: addingScoreTypesTestingParameters[] = [
+        // # Adding to 100 possiblePoints
+        // Adding to 100% of 100
+        { input: [0.1, '100%', 100], result: '100.1%' },
+        { input: [0.101, '100%', 100], result: '100.1%' },
+        { input: [0.115, '100%', 100], result: '100.12%' },
+        { input: [0.149, '100%', 100], result: '100.15%' },
+        { input: [0.109, '100%', 100], result: '100.11%' },
+        { input: [0.199, '100%', 100], result: '100.2%' },
+        { input: [0.101, '100%', 100], result: '100.1%' },
+        { input: [1, '100%', 100], result: '101%' },
+        { input: [1.2, '100%', 100], result: '101.2%' },
+        { input: [-1.1, '100%', 100], result: '98.9%' },
+        { input: [-1.2, '100%', 100], result: '98.8%' },
+        { input: [-1.3, '100%', 100], result: '98.7%' },
+        { input: [-0.2, '100%', 100], result: '99.8%' },
+        { input: [-0.2, '10%', 100], result: '9.8%' },
+        { input: [0.1, '10%', 100], result: '10.1%' },
+        // Adding to 0% of 100
+        { input: [0.11, '0%', 100], result: '0.11%' },
+        { input: [0.115, '0%', 100], result: '0.12%' },
+        { input: [0.1149, '0%', 100], result: '0.11%' },
+        { input: [0.1109, '0%', 100], result: '0.11%' },
+        { input: [0.1099, '0%', 100], result: '0.11%' },
+        { input: [0.101, '0%', 100], result: '0.1%' },
+        { input: [1, '0%', 100], result: '1%' },
+        { input: [1.2, '0%', 100], result: '1.2%' },
+        { input: [-1.1, '0%', 100], result: '-1.1%' },
+        { input: [-1.2, '0%', 100], result: '-1.2%' },
+        { input: [-1.3, '0%', 100], result: '-1.3%' },
+        { input: [-0.2, '0%', 100], result: '-0.2%' },
+        // # Adding to 10 possiblePoints
+        // Adding to 100% of 10
+        { input: [0.1, '100%', 10], result: '101%' },
+        { input: [0.11, '100%', 10], result: '101.1%' },
+        { input: [0.115, '100%', 10], result: '101.15%' },
+        { input: [0.1149, '100%', 10], result: '101.15%' },
+        { input: [0.1109, '100%', 10], result: '101.11%' },
+        { input: [0.1099, '100%', 10], result: '101.1%' },
+        { input: [0.101, '100%', 10], result: '101.01%' },
+        { input: [1, '100%', 10], result: '110%' },
+        { input: [1.2, '100%', 10], result: '112%' },
+        { input: [-1.1, '100%', 10], result: '89%' },
+        { input: [-1.2, '100%', 10], result: '88%' },
+        { input: [-1.3, '100%', 10], result: '87%' },
+        { input: [-0.2, '100%', 10], result: '98%' },
+        { input: [-0.2, '10%', 10], result: '8%' },
+        { input: [0.1, '10%', 10], result: '11%' },
+        // Adding to 0% of 10
+        { input: [0.11, '0%', 10], result: '1.1%' },
+        { input: [0.115, '0%', 10], result: '1.15%' },
+        { input: [0.1149, '0%', 10], result: '1.15%' },
+        { input: [0.1109, '0%', 10], result: '1.11%' },
+        { input: [0.1099, '0%', 10], result: '1.1%' },
+        { input: [0.101, '0%', 10], result: '1.01%' },
+        { input: [1, '0%', 10], result: '10%' },
+        { input: [1.2, '0%', 10], result: '12%' },
+        { input: [-1.1, '0%', 10], result: '-11%' },
+        { input: [-1.2, '0%', 10], result: '-12%' },
+        { input: [-1.3, '0%', 10], result: '-13%' },
+        { input: [-0.2, '0%', 10], result: '-2%' }
+    ];
+
+    pointsToPercentTests.forEach((params) => {
+        addingScores(params, addPointsToPercentOrPointsType, false);
+    });
+});

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -52,7 +52,14 @@ describe('Basic Conversions', () => {
         { input: [-1.3, '0%', 10], result: '-130%' },
         { input: [-0.2, '0%', 10], result: '-20%' },
         { input: [-0.2, '0%', 10], result: '-20%' },
-        { input: [-0.001, '0%', 10], result: '-0.1%' }
+        { input: [-0.001, '0%', 10], result: '-0.1%' },
+        { input: [1.2, '-10%', 10], result: '110%' },
+        { input: [-1.1, '-10%', 10], result: '-120%' },
+        { input: [-1.2, '-10%', 10], result: '-130%' },
+        { input: [-1.3, '-10%', 10], result: '-140%' },
+        { input: [-0.2, '-10%', 10], result: '-30%' },
+        { input: [-0.2, '-10%', 10], result: '-30%' },
+        { input: [-0.001, '-10%', 10], result: '-10.1%' }
     ];
 
     percentToPercentTests.forEach((params) => {

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -641,20 +641,34 @@ function testTemplate(a: string, b: string, orig: string, final: string) {
 describe('Check Update Messages are as expected.', () => {
     const messages = [
         testTemplate('10', '0 out of 0 points', '0', '10'),
-        testTemplate('10 out of 1 total point', '0% of 0 points', '0', '10'),
+        testTemplate('10 points', '0% of 0 points', '0', '10'),
         testTemplate('10%', '50% of 10 points', '50%', '60%'),
         testTemplate('1', '1 out of 10 points', '1', '2'),
         testTemplate('100% of 1 total point', '1 out of 10 points', '1', '2'),
-        testTemplate('0%', '0% of 0 points', '0', '0')
+        testTemplate('0% of 0 total points', '0% of 0 points', '0', '0'),
+        testTemplate('1 point', '20% of 10 points', '20%', '30%'),
+        testTemplate('1', '2 out of 10 points', '2', '3'),
+        testTemplate('50% of 0 total points', '102 out of 10 points', '102', '102'),
+        testTemplate('0.0 points', '1020% of 10 points', '1020%', '1020%'),
+        testTemplate('0.1 points', '0% of 0 points', '0', '0.1'),
+        testTemplate('1 point', '0% of 0 points', '0', '1'),
+        testTemplate('1.0 points', '0% of 0 points', '0', '1')
     ];
-    const posted = ['10', '10', '60%', '2', '2', '0'];
+    const posted = ['10', '10', '60%', '2', '2', '0', '30%', '3', '102', '1020%', '0.1', '1', '1'];
     const inputs = [
         { add: '10', target: points(['0%', 0, 0]), basedOn: undefined },
         { add: '10', target: percent(['0%', 0, 0]), basedOn: 1 },
         { add: '10%', target: percent(['50%', 5, 10]), basedOn: undefined },
         { add: '1', target: points(['1%', 1, 10]), basedOn: 0 },
         { add: '100%', target: points(['10%', 1, 10]), basedOn: 1 },
-        { add: '0%', target: percent(['0%', 0, 0]), basedOn: 0 }
+        { add: '0%', target: percent(['0%', 0, 0]), basedOn: 0 },
+        { add: '1', target: percent(['20%', 2, 10]), basedOn: 200 },
+        { add: '1', target: points(['20%', 2, 10]), basedOn: 200 },
+        { add: '50%', target: points(['1020%', 102, 10]), basedOn: 0 },
+        { add: '0.0', target: percent(['1020%', 102, 10]), basedOn: undefined },
+        { add: '0.1', target: percent(['0%', 0, 0]), basedOn: 1 },
+        { add: '1', target: percent(['0%', 0, 0]), basedOn: 1 },
+        { add: '1.0', target: percent(['0%', 0, 0]), basedOn: 1 }
     ];
 
     messages.forEach((v, i) => {

--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -1,4 +1,8 @@
-import { addPercentToPointsOrPercentType, addPointsToPercentOrPointsType } from './canvas-grading';
+import {
+    addPercentToPointsOrPercentType,
+    addPointsToPercentOrPointsType,
+    parseCanvasPercentsAndPoints
+} from './canvas-grading';
 
 type addingScoreTypesTestingParameters = { input: [number, string, number]; result: string };
 
@@ -253,4 +257,33 @@ describe('Cross Type Conversions', () => {
     pointsToPercentTests.forEach((params) => {
         addingScores(params, addPointsToPercentOrPointsType, false);
     });
+});
+
+describe('Testing Canvas Score Inputs that should fail to parse.', () => {
+    const parseFailures = [
+        '',
+        '200%A',
+        'a100',
+        '55a%',
+        'a',
+        'A',
+        '0xffe',
+        '1,000',
+        '1 000',
+        '1_000_000',
+        '1.0.0',
+        '%%0',
+        '%0%',
+        '0%0%',
+        '0.0%0.0',
+        '0%0.0%0'
+    ];
+
+    function testNaN(testString: string) {
+        it(`${testString} should not be a number.`, () => {
+            expect(parseCanvasPercentsAndPoints(testString)).toBeNaN();
+        });
+    }
+
+    parseFailures.forEach(testNaN);
 });

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -1,6 +1,8 @@
 // type CanvasGradingTypes = 'pass_fail' | 'percent' | 'points';
 // type UnsupportedGradingTypes = 'letter_grade' | 'gpa_scale';
 
+import { pluralize } from './pluralize';
+
 /**
  * Keys are grading types provided by Canvas.
  * Values are display names use in Canvas UI.
@@ -28,7 +30,17 @@ export enum CanvasGradingType {
 //             a number + '%', only 0% or 100%
 
 // N.B. for adding to a current score, only percent and points grading_type are supported
+const MAX_DECIMALS = 2;
 
+/**
+ * Adds a percentage of the pointsPossible to the current grade, and returns new grade in same format as current.
+ *
+ * Only guaranteed to work for 'points' and 'percent' grading_type assignments.
+ * @param additionalPercentage percentage to add in decimal number format
+ * @param current string of the current grade/score on Canvas (e.g. '10' or '10%')
+ * @param pointsPossible the denominator used for ratio conversions
+ * @returns A string for the Canvas submission posted_grade
+ */
 export function addPercentToPointsOrPercentType(
     additionalPercentage: number,
     current: string,
@@ -44,6 +56,16 @@ export function addPercentToPointsOrPercentType(
     }
 }
 
+/**
+ * Adds points to the current grade, and returns new grade in the same format as current.
+ * Uses pointsPossible to convert to/from percentages, if needed.
+ *
+ * Only guaranteed to work for 'points' and 'percent' Canvas grading_type assignments.
+ * @param additionalPoints points to add
+ * @param current string of the current grade/score on Canvas (e.g. '10' or '10%')
+ * @param pointsPossible the denominator used for ratio conversions
+ * @returns A string for the Canvas submission posted_grade
+ */
 export function addPointsToPercentOrPointsType(
     additionalPoints: number,
     current: string,
@@ -57,6 +79,297 @@ export function addPointsToPercentOrPointsType(
         const sum = additionalPoints + cur;
         return convertNumberToMaxDecimalString(sum);
     }
+}
+
+export type CanvasGradeScorePossible = {
+    gradeType?: keyof typeof CanvasGradingType;
+    grade: string | null;
+    score: number | null;
+    pointsPossible: number | null;
+};
+type FixedCanvasGradeScorePossible = {
+    gradeType: 'percent' | 'points';
+    grade: string;
+    score: number;
+    pointsPossible: number;
+};
+export type UpdatePostedGrade = { postedGrade: string; updateMessage: string };
+
+/**
+ * Generates strings used to update an existing Canvas Assignment grade.
+ * - Assignments without submissions/grades are treated as having 0 point grades.
+ * - Prioritizes adding whole integers whenever possible.
+ * - Defaults to adding to the target's gradeType if a single best choice isn't available.
+ * - If the target assignment is out of 0 points, forces the addition to be points based.
+ * @param add Amount to add to assignment, can be number or percent (e.g. '10' or '10%')
+ * @param target Grade details of target assignment submission
+ * @param basedOn Optional denominator to scale percentages by
+ * @returns postedGrade that is submitted to Canvas, and updateMessage for submission comment
+ */
+export function addPercentOrPointsToCanvasGrade(
+    add: string,
+    target: CanvasGradeScorePossible,
+    basedOn?: number
+): UpdatePostedGrade {
+    if (target.gradeType == null) {
+        throw new Error('Invalid data, can’t add points to an Assignment without a grading type');
+    }
+    const tar = normalizeGradeScorePossible(target);
+    const postedGrade = decideNewPostedGrade(add, tar, basedOn);
+    const updateMessage = generatePostedGradeMessage(add, tar, postedGrade, basedOn);
+    return { postedGrade, updateMessage };
+}
+function normalizeGradeScorePossible(value: CanvasGradeScorePossible): FixedCanvasGradeScorePossible {
+    const { gradeType, grade, score, pointsPossible } = value;
+    if (gradeType == null || (gradeType !== 'percent' && gradeType !== 'points')) {
+        throw new Error('Invalid data, cannot normalize grades for an assignment without an approved Grade Type');
+    }
+    return {
+        gradeType,
+        grade: grade ?? (!pointsPossible ? '0' : '0%'),
+        score: score ?? 0,
+        pointsPossible: pointsPossible ?? NaN
+    };
+}
+type valueState = 'percent' | 'points';
+function decideNewPostedGrade(add: string, target: FixedCanvasGradeScorePossible, basedOn?: number): string {
+    const forcePointsResult = target.pointsPossible === 0;
+    // If needed, scales addition to be in terms of target's points possible
+    const scaledAdd = scaleAddAndMarkMorePreciseType(add, target, basedOn);
+    const [toAdd, addTo, addTypeState] = decideWhatToAdd(forcePointsResult, scaledAdd, target);
+    const addScoreFunc = addTypeState === 'points' ? addPointsToPercentOrPointsType : addPercentToPointsOrPercentType;
+    const parsedAdd = parseCanvasPercentsAndPoints(toAdd);
+    if (!Number.isFinite(parsedAdd)) {
+        throw new Error(`Invalid number: ${toAdd} was parsed as ${parsedAdd}, which is not a number.`);
+    }
+    return addScoreFunc(parsedAdd, addTo, target.pointsPossible);
+}
+function scaleAddAndMarkMorePreciseType(add: string, target: FixedCanvasGradeScorePossible, conversionDenom?: number) {
+    const { pointsPossible } = target;
+    const addPercent = add.includes('%');
+    const a = parseCanvasPercentsAndPoints(add);
+    const percentResult = () => {
+        if (addPercent) {
+            if (conversionDenom == null) return Number.isNaN(pointsPossible) ? NaN : a * 100;
+            else return ((a * conversionDenom) / pointsPossible) * 100;
+        } else {
+            return (a / pointsPossible) * 100;
+        }
+    };
+    const rGrade = percentResult();
+    const rScore = addPercent ? a * (conversionDenom ?? pointsPossible) : a;
+    function findMorePreciseType(grade: number, score: number, attemptsLeft = MAX_DECIMALS + 2): valueState | null {
+        const check = (v: number) => Number.isInteger(v) && v !== 0;
+        if (attemptsLeft === 0) return null;
+        const a = check(grade);
+        const b = check(score);
+        if (a !== b) {
+            return a && check(grade) ? 'percent' : 'points';
+        }
+        return findMorePreciseType(grade * 10, score * 10, attemptsLeft - 1);
+    }
+    return {
+        gradeType: (addPercent ? 'percent' : 'points') as valueState,
+        grade: rGrade.toString(10) + '%',
+        score: rScore,
+        pointsPossible,
+        mostPreciseType: findMorePreciseType(rGrade, rScore)
+    };
+}
+function decideWhatToAdd(
+    forcePointsResult: boolean,
+    scaledAddInfo: FixedCanvasGradeScorePossible & { mostPreciseType: valueState | null },
+    targetAddToInfo: FixedCanvasGradeScorePossible
+): [string, string, valueState] {
+    type errorState = valueState | 'both' | 'none';
+    type validAdditions = { addGrade?: string; addScore?: string; errorState: errorState };
+    function findValidValues(
+        target: FixedCanvasGradeScorePossible,
+        forceValueType?: valueState,
+        keepPred = isFinite
+    ): validAdditions {
+        function errorState() {
+            let errorType: errorState = 'none';
+            return (e?: errorState) => {
+                if (e !== undefined) {
+                    switch (e) {
+                        case 'none':
+                            errorType = 'none';
+                            break;
+                        case 'both':
+                            errorType = 'both';
+                            break;
+                        case 'percent':
+                            if (errorType === 'both') break;
+                            errorType = errorType === 'points' ? 'both' : e;
+                            break;
+                        case 'points':
+                            if (errorType === 'both') break;
+                            errorType = errorType === 'percent' ? 'both' : e;
+                            break;
+                    }
+                }
+                return errorType;
+            };
+        }
+        const errorTracker = errorState();
+        const { grade, score } = target;
+        // Track what fails the predicate
+        [grade, score.toString(10)].map((v) => (!keepPred(v) ? getType(v) : undefined)).forEach(errorTracker);
+        errorTracker(forceValueType ? (forceValueType === 'percent' ? 'points' : 'percent') : undefined);
+        // Grade must be a percent
+        errorTracker(!grade.includes('%') ? 'percent' : undefined);
+        const gNum = parseCanvasPercentsAndPoints(grade);
+        // Both values should be zero or non-zero, otherwise drop the 0 valued type
+        errorTracker(gNum === 0 && score !== 0 ? 'percent' : undefined);
+        errorTracker(score === 0 && gNum !== 0 ? 'points' : undefined);
+        if (errorTracker() === 'both') {
+            return { errorState: errorTracker() };
+        } else if (errorTracker() === 'none') {
+            return { addScore: score.toString(10), addGrade: grade, errorState: errorTracker() };
+        } else {
+            return errorTracker() !== 'points'
+                ? { addScore: score.toString(10), errorState: errorTracker() }
+                : { addGrade: grade, errorState: errorTracker() };
+        }
+    }
+    function isFinite(v: unknown) {
+        return typeof v === 'string' ? !v.includes('NaN') && !v.includes('Infinity') : Number.isFinite(v);
+    }
+    function isInt(v: unknown) {
+        return isFinite(v) && (typeof v === 'string' ? !v.includes('.') : Number.isInteger(v));
+    }
+    function getType(v: string): valueState {
+        return v.includes('%') ? 'percent' : 'points';
+    }
+    function getValidType(v: validAdditions): errorState {
+        if (v.errorState === 'none') return 'both';
+        else if (v.errorState === 'both') return 'none';
+        else if (v.errorState === 'percent') return 'points';
+        /*v.errorState === 'points'*/ else return 'percent';
+    }
+    function getEqualType(v1: validAdditions, v2: validAdditions): errorState {
+        const v1T = getValidType(v1);
+        const v2T = getValidType(v2);
+        if (v1T === 'none' || v2T === 'none') return 'none';
+        else if (v1T === 'both') return v2T;
+        else if (v2T === 'both') return v1T;
+        else if (v1T === v2T) return v2T;
+        else if (v1T !== v2T) return 'none';
+        else throw new Error('Should be unreachable code.');
+    }
+    function singleBestAdd(v: validAdditions, prefer?: valueState): string | null | undefined {
+        const valid = getValidType(v);
+        if (valid === 'both') return prefer ? (prefer === 'percent' ? v.addGrade : v.addScore) ?? null : null;
+        else if (valid === 'none') return undefined;
+        else return (valid === 'percent' ? v.addGrade : v.addScore) ?? null;
+    }
+    const resolve = (keepPred = isInt): { addTo: string; toAdd: string } => {
+        const { gradeType: originalAddType, mostPreciseType, pointsPossible: denom } = scaledAddInfo;
+        const { gradeType: addToPreference } = targetAddToInfo;
+        const toAddPreference = mostPreciseType ?? undefined;
+
+        const validToAdds = findValidValues(scaledAddInfo, undefined, keepPred);
+        const validAddTos = findValidValues(targetAddToInfo, forcePointsResult ? 'points' : undefined, keepPred);
+
+        // If only one best option for each exists, use them
+        let toAdd = singleBestAdd(validToAdds) ?? '';
+        let addTo = singleBestAdd(validAddTos) ?? '';
+
+        // If only integer values are valid...
+        if (keepPred === isInt) {
+            const intPair = getEqualType(validToAdds, validAddTos);
+            // No matching int pairs, fallback to checking finite values instead of just ints
+            if (intPair === 'none') ({ toAdd, addTo } = resolve(isFinite));
+            else if (intPair !== 'both') {
+                // If there is only a single way to add a pair of ints, use it
+                [toAdd, addTo] =
+                    intPair === 'percent'
+                        ? [singleBestAdd(validToAdds, 'percent') ?? '', singleBestAdd(validAddTos, 'percent') ?? '']
+                        : [singleBestAdd(validToAdds, 'points') ?? '', singleBestAdd(validAddTos, 'points') ?? ''];
+            } else {
+                // Nothing. Use same resolution code as finite values below
+            }
+        }
+
+        // If the best choice for the addition value hasn't been found yet,
+        // Prioritize by: 1) more precise addition value, then
+        //                2) target assignment type, and finally
+        //                3) type of addition originally provided
+        if (!toAdd)
+            toAdd =
+                singleBestAdd(validToAdds, toAddPreference) ??
+                singleBestAdd(validToAdds, addToPreference) ??
+                singleBestAdd(validToAdds, originalAddType) ??
+                '';
+
+        // If the best choice for the posted grade type hasn't been found yet,
+        // Prioritize using 1) the more precise addition value type.
+        if (!addTo) addTo = singleBestAdd(validAddTos, toAddPreference) ?? '';
+
+        // If the best choice for the posted grade type still hasn't been found,
+        // attempt to use 2) whatever type the addition value has settled on.
+        if (!!toAdd && !addTo) {
+            addTo = singleBestAdd(validAddTos, getType(toAdd)) ?? '';
+        }
+
+        // And if the best posted grade type still isn't found, fallback to,
+        // 3) the target assignment type, or 4) the type of addition originally provided
+        if (!addTo) {
+            addTo = singleBestAdd(validAddTos, addToPreference) ?? singleBestAdd(validAddTos, originalAddType) ?? '';
+        }
+
+        if (!toAdd && !!addTo && Number.isNaN(denom)) {
+            // Throw Error?
+            // if (getValidType(validToAdds) === 'none') throw new Error(`Found no valid way to add to this assignment.`);
+            // Or default to adding 0?
+            toAdd = getType(addTo) === 'percent' ? '0%' : '0';
+        }
+
+        if (!toAdd && denom === 0 && forcePointsResult) {
+            toAdd = '0';
+            if (!addTo) {
+                addTo = '0';
+            }
+        }
+
+        // At this point both addTo and toAdd should entirely be resolved.
+        // But the type checking doesn't agree with that, so here is a catch.
+        if (!toAdd || !addTo)
+            throw new Error(`UNRESOLVED ADDITION CHOICE! toAdd: '${toAdd}' addTo: '${addTo}' denom: ${denom}`);
+
+        // TODO: Handle no int values but an addition would return an int
+        //       - Requires precalc-ing both and possibly changing both toAdd and addTo
+
+        return { addTo, toAdd };
+    };
+
+    // toAdd: The value to be added
+    // addTo: Decides the type of the posted grade
+    const { toAdd, addTo } = resolve();
+    // Decides which addition function will be used
+    const addTypeState = getType(toAdd);
+    return [toAdd, addTo, addTypeState];
+}
+function generatePostedGradeMessage(
+    add: string,
+    target: FixedCanvasGradeScorePossible,
+    postedGrade: string,
+    basedOn?: number
+): string {
+    // decides connection phrase: 'out of' for points, 'of' for percents
+    const of = (n: string | number, d: number) => `${n} ${`${n}`.includes('%') ? '' : 'out '}of ${d}`;
+    // append 'total ' to 'point(s)', if using custom pointsPossible
+    const points = (count: number, total = false) => `${total ? 'total ' : ''}${pluralize('points', count)}`;
+    const ofPoints = (n: string | number, d: number, total = false) => `${of(n, d)} ${points(d, total)}`;
+    // Displays the change provided by instructor, and grade display of assignment
+    const firstLine = `Added ${basedOn ? ofPoints(add, basedOn, true) : add} to ${ofPoints(
+        target.gradeType === 'percent' ? target.grade : target.score,
+        target.pointsPossible
+    )}\n`;
+    // Displays the actual change provided to Canvas via posted_grade
+    const secondLine = `Change: ${postedGrade.includes('%') ? target.score : target.grade} => ${postedGrade}`;
+    return firstLine + secondLine;
 }
 
 /**
@@ -75,7 +388,7 @@ export function parseCanvasPercentsAndPoints(postedGrade: string): number {
     return parsed / (isPercent ? 100 : 1);
 }
 
-function convertNumberToMaxDecimalString(num: number, maxDecimals = 2): string {
+function convertNumberToMaxDecimalString(num: number, maxDecimals = MAX_DECIMALS): string {
     const sign = num < 0 ? -1 : 1;
     // fixes Javascript rounding, now rounds away from 0 and attempts to maintain an arbirary number of decimal places
     return `${sign * (Math.round((num * sign + Number.EPSILON) * 10 ** maxDecimals) / 10 ** maxDecimals)}`;

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -1,6 +1,19 @@
 // type CanvasGradingTypes = 'pass_fail' | 'percent' | 'points';
 // type UnsupportedGradingTypes = 'letter_grade' | 'gpa_scale';
 
+/**
+ * Keys are grading types provided by Canvas.
+ * Values are display names use in Canvas UI.
+ */
+export enum CanvasGradingType {
+    pass_fail = 'Complete/Incomplete',
+    percent = 'Percentage',
+    points = 'Points',
+    letter_grade = 'Letter Grade',
+    gpa_scale = 'GPA Scale',
+    not_graded = 'Not Graded'
+}
+
 // 'points' allows:
 //      a number, which can be > assignment.points_possible
 

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -364,10 +364,21 @@ function generatePostedGradeMessage(
     const points = (count: number, total = false) => `${total ? 'total ' : ''}${pluralize('point', count)}`;
     const ofPoints = (n: string | number, d: number, total = false) => `${of(n, d)} ${points(d, total)}`;
     // Displays the change provided by instructor, and grade display of assignment
-    const firstLine = `Added ${basedOn ? ofPoints(add, basedOn, true) : add} to ${ofPoints(
-        target.gradeType === 'percent' ? target.grade : target.score,
-        target.pointsPossible
-    )}\n`;
+    const addType = add.includes('%') ? 'percent' : 'points';
+    const gradeType = target.gradeType;
+    const curGrade = gradeType === 'percent' ? target.grade : target.score;
+    const hasTotal = basedOn !== undefined;
+    const addText =
+        addType === 'points'
+            ? gradeType === 'points'
+                ? add
+                : `${add} ${add.match(/^1\.0+$/g) != null ? 'points' : pluralize('point', Number.parseFloat(add))}`
+            : hasTotal
+            ? ofPoints(add, basedOn, true)
+            : gradeType === 'points'
+            ? ofPoints(add, target.pointsPossible)
+            : add;
+    const firstLine = `Added ${addText} to ${ofPoints(curGrade, target.pointsPossible)}\n`;
     // Displays the actual change provided to Canvas via posted_grade
     const secondLine = `Change: ${postedGrade.includes('%') ? target.grade : target.score} => ${postedGrade}`;
     return firstLine + secondLine;

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -357,7 +357,7 @@ function generatePostedGradeMessage(
     // decides connection phrase: 'out of' for points, 'of' for percents
     const of = (n: string | number, d: number) => `${n} ${`${n}`.includes('%') ? '' : 'out '}of ${d}`;
     // append 'total ' to 'point(s)', if using custom pointsPossible
-    const points = (count: number, total = false) => `${total ? 'total ' : ''}${pluralize('points', count)}`;
+    const points = (count: number, total = false) => `${total ? 'total ' : ''}${pluralize('point', count)}`;
     const ofPoints = (n: string | number, d: number, total = false) => `${of(n, d)} ${points(d, total)}`;
     // Displays the change provided by instructor, and grade display of assignment
     const firstLine = `Added ${basedOn ? ofPoints(add, basedOn, true) : add} to ${ofPoints(
@@ -365,7 +365,7 @@ function generatePostedGradeMessage(
         target.pointsPossible
     )}\n`;
     // Displays the actual change provided to Canvas via posted_grade
-    const secondLine = `Change: ${postedGrade.includes('%') ? target.score : target.grade} => ${postedGrade}`;
+    const secondLine = `Change: ${postedGrade.includes('%') ? target.grade : target.score} => ${postedGrade}`;
     return firstLine + secondLine;
 }
 

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -378,7 +378,7 @@ function generatePostedGradeMessage(
  * @returns The parsed number in decimals, or NaN if not correctly parsable.
  */
 export function parseCanvasPercentsAndPoints(postedGrade: string): number {
-    const checkNonNumber = /[^\d.%]/m;
+    const checkNonNumber = /[^\d.%-]/m;
     if (postedGrade.match(checkNonNumber) || postedGrade.split('.').length > 2 || postedGrade.split('%').length > 2) {
         return Number.NaN;
     }

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -1,0 +1,61 @@
+// type CanvasGradingTypes = 'pass_fail' | 'percent' | 'points';
+// type UnsupportedGradingTypes = 'letter_grade' | 'gpa_scale';
+
+// 'points' allows:
+//      a number, which can be > assignment.points_possible
+
+// 'percent' allows:
+//      a number with a '%' appended, where 100% == assignment.points_possible
+//                                    and >100% is possible
+
+// 'pass_fail' allows:
+//      'pass' or  'complete', which are converted to 100%
+//      'fail' or 'incomplete, which are converted to a score of 0
+//             a number      , only 0  or assignment.points_possible
+//             a number + '%', only 0% or 100%
+
+// N.B. for adding to a current score, only percent and points grading_type are supported
+
+export function addPercentToPointsOrPercentType(
+    additionalPercentage: number,
+    current: string,
+    pointsPossible: number
+): string {
+    const cur = parseCanvasPercentsAndPoints(current);
+    if (current.endsWith('%')) {
+        const sum = additionalPercentage + cur;
+        return convertNumberToMaxDecimalString(sum * 100) + '%';
+    } else {
+        const sum = additionalPercentage * pointsPossible + cur;
+        return convertNumberToMaxDecimalString(sum);
+    }
+}
+
+export function addPointsToPercentOrPointsType(
+    additionalPoints: number,
+    current: string,
+    pointsPossible: number
+): string {
+    const cur = parseCanvasPercentsAndPoints(current);
+    if (current.endsWith('%')) {
+        const sum = additionalPoints / pointsPossible + cur;
+        return convertNumberToMaxDecimalString(sum * 100) + '%';
+    } else {
+        const sum = additionalPoints + cur;
+        return convertNumberToMaxDecimalString(sum);
+    }
+}
+
+function parseCanvasPercentsAndPoints(postedGrade: string): number {
+    const isPercent = postedGrade.endsWith('%');
+    const isFloat = postedGrade.includes('.');
+    const numString = isPercent ? postedGrade.slice(0, postedGrade.length - 1) : postedGrade;
+    const parsed = isFloat ? Number.parseFloat(numString) : Number.parseInt(numString, 10);
+    return parsed / (isPercent ? 100 : 1);
+}
+
+function convertNumberToMaxDecimalString(num: number, maxDecimals = 2): string {
+    const sign = num < 0 ? -1 : 1;
+    // fixes Javascript rounding, now rounds away from 0 and attempts to maintain an arbirary number of decimal places
+    return `${sign * (Math.round((num * sign + Number.EPSILON) * 10 ** maxDecimals) / 10 ** maxDecimals)}`;
+}

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -1,6 +1,3 @@
-// type CanvasGradingTypes = 'pass_fail' | 'percent' | 'points';
-// type UnsupportedGradingTypes = 'letter_grade' | 'gpa_scale';
-
 import { pluralize } from './pluralize';
 
 /**
@@ -389,7 +386,9 @@ export function parseCanvasPercentsAndPoints(postedGrade: string): number {
 }
 
 function convertNumberToMaxDecimalString(num: number, maxDecimals = MAX_DECIMALS): string {
+    if (num === 0) return '0';
     const sign = num < 0 ? -1 : 1;
+    maxDecimals = +maxDecimals;
     // fixes Javascript rounding, now rounds away from 0 and attempts to maintain an arbirary number of decimal places
     return `${sign * (Math.round((num * sign + Number.EPSILON) * 10 ** maxDecimals) / 10 ** maxDecimals)}`;
 }

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -46,7 +46,7 @@ export function addPointsToPercentOrPointsType(
     }
 }
 
-function parseCanvasPercentsAndPoints(postedGrade: string): number {
+export function parseCanvasPercentsAndPoints(postedGrade: string): number {
     const isPercent = postedGrade.endsWith('%');
     const isFloat = postedGrade.includes('.');
     const numString = isPercent ? postedGrade.slice(0, postedGrade.length - 1) : postedGrade;

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -46,7 +46,15 @@ export function addPointsToPercentOrPointsType(
     }
 }
 
+/**
+ * @param postedGrade The score or grade posted on canvas as a string.
+ * @returns The parsed number in decimals, or NaN if not correctly parsable.
+ */
 export function parseCanvasPercentsAndPoints(postedGrade: string): number {
+    const checkNonNumber = /[^\d.%]/m;
+    if (postedGrade.match(checkNonNumber) || postedGrade.split('.').length > 2 || postedGrade.split('%').length > 2) {
+        return Number.NaN;
+    }
     const isPercent = postedGrade.endsWith('%');
     const isFloat = postedGrade.includes('.');
     const numString = isPercent ? postedGrade.slice(0, postedGrade.length - 1) : postedGrade;

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -379,7 +379,13 @@ function generatePostedGradeMessage(
  */
 export function parseCanvasPercentsAndPoints(postedGrade: string): number {
     const checkNonNumber = /[^\d.%-]/m;
-    if (postedGrade.match(checkNonNumber) || postedGrade.split('.').length > 2 || postedGrade.split('%').length > 2) {
+    if (
+        postedGrade.match(checkNonNumber) ||
+        postedGrade.split('.').length > 2 ||
+        postedGrade.split('%').length > 2 ||
+        postedGrade.split('-').length > 2 ||
+        (postedGrade.split('-').length === 2 && postedGrade.split('-')[0] !== '')
+    ) {
         return Number.NaN;
     }
     const isPercent = postedGrade.endsWith('%');

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -80,3 +80,35 @@ function convertNumberToMaxDecimalString(num: number, maxDecimals = 2): string {
     // fixes Javascript rounding, now rounds away from 0 and attempts to maintain an arbirary number of decimal places
     return `${sign * (Math.round((num * sign + Number.EPSILON) * 10 ** maxDecimals) / 10 ** maxDecimals)}`;
 }
+
+/**
+ * Collects the value for the 'points_possible' property of a Canvas Assignment JSON object.
+ * @param canvasAssignmentJSON Raw JSON object. (Assumed to be a Canvas Assignment)
+ * @param skipCountingIf Optionally used to skip this assignment's points possible. Takes an
+ * object where if any of the key-value pairs strictly equal (===) the same properties in the
+ * canvasAssignmentJSON, then 0 is returned.
+ *
+ * If a given value is an array, the array's elements are used for the strict equality check.
+ * @returns the Canvas Assignment's points possible or 0
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function collectPointsPossible(canvasAssignmentJSON: any, skipCountingIf?: { [x: string]: any }): number {
+    const currentPointsPossible: number = (canvasAssignmentJSON['points_possible'] ?? 0) as number;
+    const skip = (): boolean => {
+        if (currentPointsPossible === 0 || skipCountingIf == null) {
+            return false;
+        }
+        return Object.entries(skipCountingIf).some(([prop, check]) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const propEquality = (compare: any) => {
+                return canvasAssignmentJSON[prop] === compare;
+            };
+            if (Array.isArray(check)) {
+                return check.some(propEquality);
+            } else {
+                return propEquality(check);
+            }
+        });
+    };
+    return skip() ? 0 : currentPointsPossible;
+}

--- a/src/app/utils/pluralize.ts
+++ b/src/app/utils/pluralize.ts
@@ -3,7 +3,7 @@ export function countAndNoun(count: number, noun: string) {
 }
 
 export function pluralize(word: string, count: number): string {
-    return word + (count == 1 ? '' : 's');
+    return word + (count === 1 ? '' : 's');
 }
 
 import { Pipe, PipeTransform } from '@angular/core';


### PR DESCRIPTION
### Description

A new type of token option (spend for additional points) is implemented in this pull request. This token option serves as a way to add additional points to a Canvas assignment / quiz by spending tokens. Along with the standard configuration for all token options, the following configurations are available for this type of token option:

1. Canvas Assignment / Quiz to add points to (restricted to those with a `percent` or `points` Canvas grade type)
2. Score to add to the assignment (supplied as a number, `2.5`, or percentage, `10.5%`)
3. Optionally choose an Canvas Assignment Group to base the denominator of additional points on
4. Optionally allow multiple approved requests (-1 for unlimited)
5. Exclude other token options

A student's request will only be approved if all of the following conditions are met:

1. The student does not reach the maximum allowed amount of approved requests for this token option. If the amount of multiple requests is unlimited (-1), this condition will always be met.
2. The student does not have any approved request for token options that this token option is excluded with.
3. If the token balance change for this token option is negative, the student must have sufficient tokens (i.e., have a non-negative balance after spending for this token option)

Token ATM will throw an error and not process student requests if:

- The grading type for the assignment / quiz is not `points` or `percentage` at the time of request processing
- The automatically collected submission score to add points to is does not match the current assignment / quiz score on Canvas

When approved, Token ATM will update the grade of the configured assignment / quiz (including an submission comment of the change executed), record the request, and make the corresponding token balance change.

#### How Grading is Handled Note

The updated grade posted to Canvas can be either a number or percentage, which can be different from the type given as the "Score to add" or the assignment / quiz grade type. Token ATM attempts to chose the most precise representation to update on Canvas. I.e, adding 1 to an assignment currently scored at 50% of 30, will update the grade to 16 not 53.333...%. The grading submission comment attempts to provide the necessary info to check that this math was done correctly.

- Assignments / Quizzes without submissions are treated as 0 scored and then added to.
- The second line of the grading submission comment is given in terms of the data provided in the token option configuration and assignment / quiz info from Canvas.
- The third line of the grading submission comment provides the actual updated grade posted to Canvas, and the original value of the same type that Canvas provided which was added to.

### Testing Note

1. Please test if the new type of token option works as described.
2. Please look over `canvas-grading.spec.ts` for any glaring untested edge-cases. The `canvas-grading.ts` utility provides the code for identifying, parsing, handling, and calculating what should be the updated posted grade that is provided to Canvas.