### PR TITLE
Feature: Earn by QuestionPro Survey Token Option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8175,9 +8175,9 @@
             "dev": true
         },
         "node_modules/express": {
-            "version": "4.19.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.19.1.tgz",
-            "integrity": "sha512-K4w1/Bp7y8iSiVObmCrtq8Cs79XjJc/RU2YYkZQ7wpUu5ZyZ7MtPHkqoMz4pf+mgXfNvo2qft8D9OnrH2ABk9w==",
+            "version": "4.19.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -852,21 +852,21 @@
             "dev": true
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+            "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
             "dependencies": {
-                "@babel/highlight": "^7.23.4",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.2",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-            "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.1.tgz",
+            "integrity": "sha512-Pc65opHDliVpRHuKfzI+gSA4zcgr65O4cl64fFJIWEEh8JoHIHh0Oez1Eo8Arz8zq/JhgKodQaxEwUPRtZylVA==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -914,13 +914,13 @@
             }
         },
         "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -966,9 +966,9 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/browserslist": {
-            "version": "4.22.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-            "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -984,8 +984,8 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001565",
-                "electron-to-chromium": "^1.4.601",
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
                 "node-releases": "^2.0.14",
                 "update-browserslist-db": "^1.0.13"
             },
@@ -997,9 +997,9 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.6.tgz",
-            "integrity": "sha512-cBXU1vZni/CpGF29iTu4YRbOZt3Wat6zCoMDxRF1MayiEc4URxOj31tT65HUM0CRpMowA3HCJaAOVOUnMf96cw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.1.tgz",
+            "integrity": "sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
@@ -1007,7 +1007,7 @@
                 "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-member-expression-to-functions": "^7.23.0",
                 "@babel/helper-optimise-call-expression": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.20",
+                "@babel/helper-replace-supers": "^7.24.1",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
                 "semver": "^6.3.1"
@@ -1110,13 +1110,13 @@
             }
         },
         "node_modules/@babel/helper-function-name/node_modules/@babel/template": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/parser": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1146,11 +1146,11 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
             "dependencies": {
-                "@babel/types": "^7.22.15"
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1198,9 +1198,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-            "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+            "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -1236,13 +1236,13 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
-            "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.1.tgz",
+            "integrity": "sha512-QCR1UqC9BzG5vZl8BMicmZ28RuUBnHhAMddD8yHFHDRH9lLTZ9uUPehX8ctVPT8l0TKblJidqcgUUKGVrePleQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-member-expression-to-functions": "^7.22.15",
+                "@babel/helper-member-expression-to-functions": "^7.23.0",
                 "@babel/helper-optimise-call-expression": "^7.22.5"
             },
             "engines": {
@@ -1288,9 +1288,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-            "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+            "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -1326,62 +1326,63 @@
             }
         },
         "node_modules/@babel/helper-wrap-function/node_modules/@babel/template": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/parser": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
-            "integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.1.tgz",
+            "integrity": "sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==",
             "dependencies": {
-                "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.23.6",
-                "@babel/types": "^7.23.6"
+                "@babel/template": "^7.24.0",
+                "@babel/traverse": "^7.24.1",
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers/node_modules/@babel/template": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/parser": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+            "version": "7.24.2",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+            "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.22.20",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-            "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+            "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1390,12 +1391,12 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz",
-            "integrity": "sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.24.1.tgz",
+            "integrity": "sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1405,14 +1406,14 @@
             }
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.23.3.tgz",
-            "integrity": "sha512-WwlxbfMNdVEpQjZmK5mhm7oSwD3dS6eU+Iwsi4Knl9wAletWem7kaRsGOG+8UEbRyqxY4SS5zvtfXwX+jMxUwQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.1.tgz",
+            "integrity": "sha512-Hj791Ii4ci8HqnaKHAlLNs+zaLXb0EzSDhiAWp5VNlyvCNymYfacs64pxTxbH1znW/NcArSmwpmG9IKE/TUVVQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/plugin-transform-optional-chaining": "^7.23.3"
+                "@babel/plugin-transform-optional-chaining": "^7.24.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1749,12 +1750,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.23.3.tgz",
-            "integrity": "sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.1.tgz",
+            "integrity": "sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1878,12 +1879,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.23.3.tgz",
-            "integrity": "sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.1.tgz",
+            "integrity": "sha512-ngT/3NkRhsaep9ck9uj2Xhv9+xB1zShY3tM3g6om4xxCELwCDN4g4Aq5dRn48+0hasAql7s2hdBOysCfNpr4fw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1910,12 +1911,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.23.3.tgz",
-            "integrity": "sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.1.tgz",
+            "integrity": "sha512-TWWC18OShZutrv9C6mye1xwtam+uNi2bnTOCBUd5sZxyHOiWbU6ztSROofIMrK84uweEZC219POICK/sTYwfgg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1925,12 +1926,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
-            "integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.1.tgz",
+            "integrity": "sha512-h71T2QQvDgM2SmT29UYU6ozjMlAt7s7CSs5Hvy8f8cf/GM/Z4a2zMfN+fjVGaieeCrXR3EdQl6C4gQG+OgmbKw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1940,18 +1941,17 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.5.tgz",
-            "integrity": "sha512-jvOTR4nicqYC9yzOHIhXG5emiFEOpappSJAl73SDSEDcybD+Puuze8Tnpb9p9qEyYup24tq891gkaygIFvWDqg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.1.tgz",
+            "integrity": "sha512-ZTIe3W7UejJd3/3R4p7ScyyOoafetUShSf4kCqV0O7F/RiHxVj/wRaRnQlrGwflvcehNA8M42HkAiEDYZu2F1Q==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.15",
+                "@babel/helper-compilation-targets": "^7.23.6",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-optimise-call-expression": "^7.22.5",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.20",
+                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-replace-supers": "^7.24.1",
                 "@babel/helper-split-export-declaration": "^7.22.6",
                 "globals": "^11.1.0"
             },
@@ -1987,13 +1987,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.23.3.tgz",
-            "integrity": "sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.1.tgz",
+            "integrity": "sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/template": "^7.22.15"
+                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/template": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2003,26 +2003,26 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties/node_modules/@babel/template": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-            "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+            "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.13",
-                "@babel/parser": "^7.22.15",
-                "@babel/types": "^7.22.15"
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.24.0",
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.3.tgz",
-            "integrity": "sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.1.tgz",
+            "integrity": "sha512-ow8jciWqNxR3RYbSNVuF4U2Jx130nwnBnhRw6N6h1bOejNkABmcI5X5oz29K4alWX7vf1C+o6gtKXikzRKkVdw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2032,13 +2032,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.23.3.tgz",
-            "integrity": "sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.1.tgz",
+            "integrity": "sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2048,12 +2048,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.23.3.tgz",
-            "integrity": "sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.1.tgz",
+            "integrity": "sha512-msyzuUnvsjsaSaocV6L7ErfNsa5nDWL1XKNnDePLgmz+WdU4w/J8+AxBMrWfi9m4IxfL5sZQKUPQKDQeeAT6lA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2063,13 +2063,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.23.3.tgz",
-            "integrity": "sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.1.tgz",
+            "integrity": "sha512-U1yX13dVBSwS23DEAqU+Z/PkwE9/m7QQy8Y9/+Tdb8UWYaGNDYwTLi19wqIAiROr8sXVum9A/rtiH5H0boUcTw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2079,12 +2079,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
-            "integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.1.tgz",
+            "integrity": "sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
             },
             "engines": {
@@ -2095,14 +2095,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.23.3.tgz",
-            "integrity": "sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.1.tgz",
+            "integrity": "sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.22.15",
+                "@babel/helper-compilation-targets": "^7.23.6",
                 "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2112,12 +2112,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.23.3.tgz",
-            "integrity": "sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.1.tgz",
+            "integrity": "sha512-zn9pwz8U7nCqOYIiBaOxoQOtYmMODXTJnkxG4AtX8fPmnCRYWBOHD0qcpwS9e2VDSp1zNJYpdnFMIKb8jmwu6g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2127,12 +2127,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.23.3.tgz",
-            "integrity": "sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.1.tgz",
+            "integrity": "sha512-4ojai0KysTWXzHseJKa1XPNXKRbuUrhkOPY4rEGeR+7ChlJVKxFa3H3Bz+7tWaGKgJAXUWKOGmltN+u9B3+CVg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2142,13 +2142,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.3.tgz",
-            "integrity": "sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.1.tgz",
+            "integrity": "sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2158,13 +2158,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
-            "integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.1.tgz",
+            "integrity": "sha512-szog8fFTUxBfw0b98gEWPaEqF42ZUD/T3bkynW/wtgx2p/XCP55WEsb+VosKceRSd6njipdZvNogqdtI4Q0chw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "@babel/helper-simple-access": "^7.22.5"
             },
             "engines": {
@@ -2175,14 +2175,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz",
-            "integrity": "sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.24.1.tgz",
+            "integrity": "sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "@babel/helper-validator-identifier": "^7.22.20"
             },
             "engines": {
@@ -2193,13 +2193,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.23.3.tgz",
-            "integrity": "sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.1.tgz",
+            "integrity": "sha512-tuA3lpPj+5ITfcCluy6nWonSL7RvaG0AOTeAuvXqEKS34lnLzXpDb0dcP6K8jD0zWZFNDVly90AGFJPnm4fOYg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2225,12 +2225,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.23.3.tgz",
-            "integrity": "sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.1.tgz",
+            "integrity": "sha512-/rurytBM34hYy0HKZQyA0nHbQgQNFm4Q/BOc9Hflxi2X3twRof7NaE5W46j4kQitm7SvACVRXsa6N/tSZxvPug==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2240,13 +2240,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.23.3.tgz",
-            "integrity": "sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.1.tgz",
+            "integrity": "sha512-oKJqR3TeI5hSLRxudMjFQ9re9fBVUU0GICqM3J1mi8MqlhVr6hC/ZN4ttAyMuQR6EZZIY6h/exe5swqGNNIkWQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.20"
+                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-replace-supers": "^7.24.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2256,12 +2256,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
-            "integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.1.tgz",
+            "integrity": "sha512-n03wmDt+987qXwAgcBlnUUivrZBPZ8z1plL0YvgQalLm+ZE5BMhGm94jhxXtA1wzv1Cu2aaOv1BM9vbVttrzSg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
                 "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             },
@@ -2273,12 +2273,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz",
-            "integrity": "sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.1.tgz",
+            "integrity": "sha512-8Jl6V24g+Uw5OGPeWNKrKqXPDw2YDjLc53ojwfMcKwlEoETKU9rU0mHUtcg9JntWI/QYzGAXNWEcVHZ+fR+XXg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2288,12 +2288,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.23.3.tgz",
-            "integrity": "sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.1.tgz",
+            "integrity": "sha512-LetvD7CrHmEx0G442gOomRr66d7q8HzzGGr4PMHGr+5YIm6++Yke+jxj246rpvsbyhJwCLxcTn6zW1P1BSenqA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2303,12 +2303,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.23.3.tgz",
-            "integrity": "sha512-KP+75h0KghBMcVpuKisx3XTu9Ncut8Q8TuvGO4IhY+9D5DFEckQefOuIsB/gQ2tG71lCke4NMrtIPS8pOj18BQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.1.tgz",
+            "integrity": "sha512-sJwZBCzIBE4t+5Q4IGLaaun5ExVMRY0lYwos/jNecjMrVCygCdph3IKv0tkP5Fc87e/1+bebAmEAGBfnRD+cnw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "regenerator-transform": "^0.15.2"
             },
             "engines": {
@@ -2319,12 +2319,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.23.3.tgz",
-            "integrity": "sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.1.tgz",
+            "integrity": "sha512-JAclqStUfIwKN15HrsQADFgeZt+wexNQ0uLhuqvqAUFoqPMjEcFCYZBhq0LUdz6dZK/mD+rErhW71fbx8RYElg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2354,12 +2354,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
-            "integrity": "sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.1.tgz",
+            "integrity": "sha512-LyjVB1nsJ6gTTUKRjRWx9C1s9hE7dLfP/knKdrfeH9UPtAGjYGgxIbFfx7xyLIEWs7Xe1Gnf8EWiUqfjLhInZA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2369,12 +2369,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.23.3.tgz",
-            "integrity": "sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.1.tgz",
+            "integrity": "sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
             },
             "engines": {
@@ -2385,12 +2385,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.23.3.tgz",
-            "integrity": "sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.1.tgz",
+            "integrity": "sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2400,12 +2400,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.23.3.tgz",
-            "integrity": "sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.1.tgz",
+            "integrity": "sha512-WRkhROsNzriarqECASCNu/nojeXCDTE/F2HmRgOzi7NGvyfYGq1NEjKBK3ckLfRgGc6/lPAqP0vDOSw3YtG34g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2415,12 +2415,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.23.3.tgz",
-            "integrity": "sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.1.tgz",
+            "integrity": "sha512-CBfU4l/A+KruSUoW+vTQthwcAdwuqbpRNB8HQKlZABwHRhsdHZ9fezp4Sn18PeAlYxTNiLMlx4xUBV3AWfg1BA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2430,12 +2430,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.23.3.tgz",
-            "integrity": "sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.1.tgz",
+            "integrity": "sha512-RlkVIcWT4TLI96zM660S877E7beKlQw7Ig+wqkKBiWfj0zH5Q4h50q6er4wzZKRNSYpfo6ILJ+hrJAGSX2qcNw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2445,13 +2445,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.23.3.tgz",
-            "integrity": "sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.1.tgz",
+            "integrity": "sha512-2A/94wgZgxfTsiLaQ2E36XAOdcZmGAaEEgVmxQWwZXWkGhvoHbaqXcKnU8zny4ycpu3vNqg0L/PcCiYtHtA13g==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-create-regexp-features-plugin": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2597,18 +2597,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
-            "integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.1.tgz",
+            "integrity": "sha512-xuU6o9m68KeqZbQuDt2TcKSxUw/mrsvavlEqQ1leZ/B+C9tk6E4sRWy97WaXgvq5E+nU3cXMxv3WKOCanVMCmQ==",
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/generator": "^7.23.6",
+                "@babel/code-frame": "^7.24.1",
+                "@babel/generator": "^7.24.1",
                 "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
                 "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.6",
-                "@babel/types": "^7.23.6",
+                "@babel/parser": "^7.24.1",
+                "@babel/types": "^7.24.0",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -2617,13 +2617,13 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.1.tgz",
+            "integrity": "sha512-DfCRfZsBcrPEHUfuBMgbJ1Ut01Y/itOs+hY2nFLgqsqXd52/iSiVq5TITtUasIUgm+IIKdY2/1I7auiQOEeC9A==",
             "dependencies": {
-                "@babel/types": "^7.23.6",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.24.0",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -2642,22 +2642,22 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-            "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+            "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.23.4",
                 "@babel/helper-validator-identifier": "^7.22.20",
@@ -3152,9 +3152,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-            "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3167,13 +3167,13 @@
             "dev": true
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+            "version": "0.11.14",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.1",
-                "debug": "^4.1.1",
+                "@humanwhocodes/object-schema": "^2.0.2",
+                "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
             "engines": {
@@ -3194,9 +3194,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+            "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
             "dev": true
         },
         "node_modules/@isaacs/cliui": {
@@ -3333,40 +3333,40 @@
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -3378,9 +3378,9 @@
             "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -4626,9 +4626,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.44.9",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.9.tgz",
-            "integrity": "sha512-6yBxcvwnnYoYT1Uk2d+jvIfsuP4mb2EdIxFnrPABj5a/838qe5bGkNLFOiipX4ULQ7XVQvTxOh7jO+BTAiqsEw==",
+            "version": "8.56.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.6.tgz",
+            "integrity": "sha512-ymwc+qb1XkjT/gfoQwxIeHZ6ixH23A+tCT2ADSA/DPVKzAjwYkTXBMCQ/f6fe4wEa85Lhp26VPeUxI7wMhAi7A==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -4664,9 +4664,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.41",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-            "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+            "version": "4.17.43",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
+            "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -4703,9 +4703,9 @@
             "dev": true
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.202",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-            "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+            "version": "4.17.0",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+            "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
             "dev": true
         },
         "node_modules/@types/mdast": {
@@ -4724,18 +4724,18 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.10.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-            "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+            "version": "20.11.30",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+            "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
             "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
         },
         "node_modules/@types/node-forge": {
-            "version": "1.3.10",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.10.tgz",
-            "integrity": "sha512-y6PJDYN4xYBxwd22l+OVH35N+1fCYWiuC3aiP2SlXVE6Lo7SS+rSx9r89hLxrP4pn6n1lBGhHJ12pj3F3Mpttw==",
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+            "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -4763,9 +4763,9 @@
             "dev": true
         },
         "node_modules/@types/qs": {
-            "version": "6.9.10",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-            "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
+            "version": "6.9.14",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.14.tgz",
+            "integrity": "sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
@@ -4781,9 +4781,9 @@
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-            "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+            "version": "7.5.8",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
             "dev": true
         },
         "node_modules/@types/send": {
@@ -4832,9 +4832,9 @@
             "dev": true
         },
         "node_modules/@types/uuid": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-            "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+            "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
             "dev": true
         },
         "node_modules/@types/ws": {
@@ -5252,9 +5252,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -5540,22 +5540,25 @@
             }
         },
         "node_modules/array-buffer-byte-length": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+            "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "is-array-buffer": "^3.0.1"
+                "call-bind": "^1.0.5",
+                "is-array-buffer": "^3.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/array-flatten": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-            "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "dev": true
         },
         "node_modules/array-union": {
@@ -5568,17 +5571,18 @@
             }
         },
         "node_modules/arraybuffer.prototype.slice": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-            "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+            "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
             "dev": true,
             "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "get-intrinsic": "^1.2.1",
-                "is-array-buffer": "^3.0.2",
+                "array-buffer-byte-length": "^1.0.1",
+                "call-bind": "^1.0.5",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.22.3",
+                "es-errors": "^1.2.1",
+                "get-intrinsic": "^1.2.3",
+                "is-array-buffer": "^3.0.4",
                 "is-shared-array-buffer": "^1.0.2"
             },
             "engines": {
@@ -5627,10 +5631,13 @@
             }
         },
         "node_modules/available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "dev": true,
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5639,11 +5646,11 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+            "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
             "dependencies": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -5779,11 +5786,14 @@
             }
         },
         "node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/bl": {
@@ -5851,13 +5861,11 @@
             "dev": true
         },
         "node_modules/bonjour-service": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
-            "integrity": "sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
+            "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
             "dev": true,
             "dependencies": {
-                "array-flatten": "^2.1.2",
-                "dns-equal": "^1.0.0",
                 "fast-deep-equal": "^3.1.3",
                 "multicast-dns": "^7.2.5"
             }
@@ -5869,9 +5877,9 @@
             "dev": true
         },
         "node_modules/bootstrap": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
-            "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
             "funding": [
                 {
                     "type": "github",
@@ -5887,9 +5895,9 @@
             }
         },
         "node_modules/bootstrap-icons": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.2.tgz",
-            "integrity": "sha512-TgdiPv+IM9tgDb+dsxrnGIyocsk85d2M7T0qIgkvPedZeoZfyeG/j+yiAE4uHCEayKef2RP05ahQ0/e9Sv75Wg==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+            "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
             "funding": [
                 {
                     "type": "github",
@@ -6031,14 +6039,19 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dev": true,
             "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.1",
-                "set-function-length": "^1.1.1"
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6091,9 +6104,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001570",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
-            "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+            "version": "1.0.30001600",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+            "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6591,12 +6604,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.34.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.34.0.tgz",
-            "integrity": "sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==",
+            "version": "3.36.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.36.1.tgz",
+            "integrity": "sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.22.2"
+                "browserslist": "^4.23.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -6604,9 +6617,9 @@
             }
         },
         "node_modules/core-js-compat/node_modules/browserslist": {
-            "version": "4.22.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-            "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "dev": true,
             "funding": [
                 {
@@ -6623,8 +6636,8 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001565",
-                "electron-to-chromium": "^1.4.601",
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
                 "node-releases": "^2.0.14",
                 "update-browserslist-db": "^1.0.13"
             },
@@ -6845,6 +6858,57 @@
             "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
             "dev": true
         },
+        "node_modules/data-view-buffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+            "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.6",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/data-view-byte-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+            "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/data-view-byte-offset": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+            "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+            "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.6",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/date-fns": {
             "version": "2.30.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -6861,9 +6925,9 @@
             }
         },
         "node_modules/date-fns/node_modules/@babel/runtime": {
-            "version": "7.23.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
-            "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
+            "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -7003,17 +7067,20 @@
             }
         },
         "node_modules/define-data-property": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/define-lazy-prop": {
@@ -7111,12 +7178,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-            "dev": true
-        },
-        "node_modules/dns-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-            "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
             "dev": true
         },
         "node_modules/dns-packet": {
@@ -7222,9 +7283,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.614",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.614.tgz",
-            "integrity": "sha512-X4ze/9Sc3QWs6h92yerwqv7aB/uU8vCjZcrMjA8N9R1pjMFRe44dLsck5FzLilOYvcXuDn93B+bpGYyufc70gQ=="
+            "version": "1.4.715",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
+            "integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -7294,18 +7355,18 @@
             }
         },
         "node_modules/engine.io-parser": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
-            "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+            "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.15.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
-            "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+            "version": "5.16.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
+            "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -7368,56 +7429,84 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.22.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
-            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
+            "version": "1.23.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
+            "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
             "dev": true,
             "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "arraybuffer.prototype.slice": "^1.0.2",
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.5",
-                "es-set-tostringtag": "^2.0.1",
+                "array-buffer-byte-length": "^1.0.1",
+                "arraybuffer.prototype.slice": "^1.0.3",
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.7",
+                "data-view-buffer": "^1.0.1",
+                "data-view-byte-length": "^1.0.1",
+                "data-view-byte-offset": "^1.0.0",
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "es-set-tostringtag": "^2.0.3",
                 "es-to-primitive": "^1.2.1",
                 "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.2",
-                "get-symbol-description": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
+                "get-symbol-description": "^1.0.2",
                 "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "has-proto": "^1.0.1",
+                "has-property-descriptors": "^1.0.2",
+                "has-proto": "^1.0.3",
                 "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0",
-                "internal-slot": "^1.0.5",
-                "is-array-buffer": "^3.0.2",
+                "hasown": "^2.0.2",
+                "internal-slot": "^1.0.7",
+                "is-array-buffer": "^3.0.4",
                 "is-callable": "^1.2.7",
-                "is-negative-zero": "^2.0.2",
+                "is-data-view": "^1.0.1",
+                "is-negative-zero": "^2.0.3",
                 "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
+                "is-shared-array-buffer": "^1.0.3",
                 "is-string": "^1.0.7",
-                "is-typed-array": "^1.1.12",
+                "is-typed-array": "^1.1.13",
                 "is-weakref": "^1.0.2",
                 "object-inspect": "^1.13.1",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "safe-array-concat": "^1.0.1",
-                "safe-regex-test": "^1.0.0",
-                "string.prototype.trim": "^1.2.8",
-                "string.prototype.trimend": "^1.0.7",
+                "object.assign": "^4.1.5",
+                "regexp.prototype.flags": "^1.5.2",
+                "safe-array-concat": "^1.1.2",
+                "safe-regex-test": "^1.0.3",
+                "string.prototype.trim": "^1.2.9",
+                "string.prototype.trimend": "^1.0.8",
                 "string.prototype.trimstart": "^1.0.7",
-                "typed-array-buffer": "^1.0.0",
-                "typed-array-byte-length": "^1.0.0",
-                "typed-array-byte-offset": "^1.0.0",
-                "typed-array-length": "^1.0.4",
+                "typed-array-buffer": "^1.0.2",
+                "typed-array-byte-length": "^1.0.1",
+                "typed-array-byte-offset": "^1.0.2",
+                "typed-array-length": "^1.0.5",
                 "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.13"
+                "which-typed-array": "^1.1.15"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/es-get-iterator": {
@@ -7446,15 +7535,27 @@
             "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
             "dev": true
         },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
+        "node_modules/es-object-atoms": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+            "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.2.2",
-                "has-tostringtag": "^1.0.0",
-                "hasown": "^2.0.0"
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+            "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+            "dev": true,
+            "dependencies": {
+                "get-intrinsic": "^1.2.4",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7528,9 +7629,9 @@
             }
         },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "engines": {
                 "node": ">=6"
             }
@@ -7550,16 +7651,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.56.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-            "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.56.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -8074,17 +8175,17 @@
             "dev": true
         },
         "node_modules/express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+            "version": "4.19.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.19.1.tgz",
+            "integrity": "sha512-K4w1/Bp7y8iSiVObmCrtq8Cs79XjJc/RU2YYkZQ7wpUu5ZyZ7MtPHkqoMz4pf+mgXfNvo2qft8D9OnrH2ABk9w==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
+                "body-parser": "1.20.2",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.5.0",
+                "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -8115,40 +8216,10 @@
                 "node": ">= 0.10.0"
             }
         },
-        "node_modules/express/node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true
-        },
-        "node_modules/express/node_modules/body-parser": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.11.0",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
         "node_modules/express/node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -8186,21 +8257,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
-        },
-        "node_modules/express/node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/express/node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -8304,9 +8360,9 @@
             "dev": true
         },
         "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -8452,14 +8508,14 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-            "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",
@@ -8535,9 +8591,9 @@
             }
         },
         "node_modules/fp-ts": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.1.tgz",
-            "integrity": "sha512-by7U5W8dkIzcvDofUcO42yl9JbnHTEDBrzu3pt5fKT+Z4Oy85I21K80EYJYdjQGC2qum4Vo55Ag57iiIK4FYuA=="
+            "version": "2.16.4",
+            "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.4.tgz",
+            "integrity": "sha512-EkV/l6oHaf/w/DlVc5UiqLibqTV1S+idiDdcWQ+UjnLLflL9pZG28ebJfPLor8ifoL8NgEFDIo9fOvHyiSCrJQ=="
         },
         "node_modules/fraction.js": {
             "version": "4.3.7",
@@ -8692,15 +8748,19 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dev": true,
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
                 "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -8728,13 +8788,14 @@
             }
         },
         "node_modules/get-symbol-description": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+            "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.1"
+                "call-bind": "^1.0.5",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -8909,21 +8970,21 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.2.2"
+                "es-define-property": "^1.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
@@ -8945,12 +9006,12 @@
             }
         },
         "node_modules/has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "has-symbols": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -8966,9 +9027,9 @@
             "dev": true
         },
         "node_modules/hasown": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -9051,9 +9112,9 @@
             }
         },
         "node_modules/html-entities": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.4.0.tgz",
-            "integrity": "sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+            "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
             "dev": true,
             "funding": [
                 {
@@ -9390,9 +9451,9 @@
             "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
         },
         "node_modules/immutable": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-            "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+            "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
             "dev": true
         },
         "node_modules/import-fresh": {
@@ -9564,12 +9625,12 @@
             }
         },
         "node_modules/internal-slot": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
-            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+            "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
             "dev": true,
             "dependencies": {
-                "get-intrinsic": "^1.2.2",
+                "es-errors": "^1.3.0",
                 "hasown": "^2.0.0",
                 "side-channel": "^1.0.4"
             },
@@ -9585,10 +9646,23 @@
                 "fp-ts": "^2.5.0"
             }
         },
-        "node_modules/ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dev": true,
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ip-address/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
             "dev": true
         },
         "node_modules/ipaddr.js": {
@@ -9641,14 +9715,16 @@
             }
         },
         "node_modules/is-array-buffer": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+            "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.0",
-                "is-typed-array": "^1.1.10"
+                "get-intrinsic": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9718,6 +9794,21 @@
             "dev": true,
             "dependencies": {
                 "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-data-view": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+            "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+            "dev": true,
+            "dependencies": {
+                "is-typed-array": "^1.1.13"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9816,18 +9907,21 @@
             "dev": true
         },
         "node_modules/is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
             "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-negative-zero": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
@@ -9909,21 +10003,27 @@
             }
         },
         "node_modules/is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
             "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-shared-array-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2"
+                "call-bind": "^1.0.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9972,12 +10072,12 @@
             }
         },
         "node_modules/is-typed-array": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+            "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
             "dev": true,
             "dependencies": {
-                "which-typed-array": "^1.1.11"
+                "which-typed-array": "^1.1.14"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9999,10 +10099,13 @@
             }
         },
         "node_modules/is-weakmap": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-            "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
             "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -10020,13 +10123,16 @@
             }
         },
         "node_modules/is-weakset": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-            "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
+            "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.1"
+                "call-bind": "^1.0.7",
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -10182,9 +10288,9 @@
             }
         },
         "node_modules/istanbul-reports": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-            "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+            "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
             "dev": true,
             "dependencies": {
                 "html-escaper": "^2.0.0",
@@ -10257,9 +10363,9 @@
             }
         },
         "node_modules/js-base64": {
-            "version": "3.7.5",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
-            "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+            "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -10278,6 +10384,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "dev": true
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
@@ -10367,9 +10479,9 @@
             }
         },
         "node_modules/karma": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.2.tgz",
-            "integrity": "sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.3.tgz",
+            "integrity": "sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==",
             "dev": true,
             "dependencies": {
                 "@colors/colors": "1.5.0",
@@ -10391,7 +10503,7 @@
                 "qjobs": "^1.2.0",
                 "range-parser": "^1.2.1",
                 "rimraf": "^3.0.2",
-                "socket.io": "^4.4.1",
+                "socket.io": "^4.7.2",
                 "source-map": "^0.6.1",
                 "tmp": "^0.2.1",
                 "ua-parser-js": "^0.7.30",
@@ -10886,9 +10998,9 @@
             }
         },
         "node_modules/loglevel": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
-            "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+            "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6.0"
@@ -11794,9 +11906,9 @@
             }
         },
         "node_modules/node-gyp-build": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
-            "integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+            "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -12181,13 +12293,13 @@
             }
         },
         "node_modules/object-is": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -12717,9 +12829,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-            "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+            "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
             "dev": true,
             "engines": {
                 "node": "14 || >=16.14"
@@ -12812,6 +12924,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+            "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.4.31",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -12875,9 +12996,9 @@
             }
         },
         "node_modules/postcss-modules-local-by-default": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.3.tgz",
-            "integrity": "sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.4.tgz",
+            "integrity": "sha512-L4QzMnOdVwRm1Qb8m4x8jsZzKAaPAgrUF1r/hjDR2Xj7R+8Zsf97jAlSQzWtKx5YNiNGN8QxmPFIc/sh+RQl+Q==",
             "dev": true,
             "dependencies": {
                 "icss-utils": "^5.0.0",
@@ -12892,9 +13013,9 @@
             }
         },
         "node_modules/postcss-modules-scope": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.1.tgz",
+            "integrity": "sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==",
             "dev": true,
             "dependencies": {
                 "postcss-selector-parser": "^6.0.4"
@@ -12922,9 +13043,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.13",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-            "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+            "version": "6.0.16",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+            "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -13401,20 +13522,21 @@
             }
         },
         "node_modules/regex-parser": {
-            "version": "2.2.11",
-            "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
-            "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.0.tgz",
+            "integrity": "sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==",
             "dev": true
         },
         "node_modules/regexp.prototype.flags": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-            "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+            "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "set-function-name": "^2.0.0"
+                "call-bind": "^1.0.6",
+                "define-properties": "^1.2.1",
+                "es-errors": "^1.3.0",
+                "set-function-name": "^2.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -13600,9 +13722,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
+            "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
             "dev": true
         },
         "node_modules/rimraf": {
@@ -13681,13 +13803,13 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-            "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+            "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1",
+                "call-bind": "^1.0.7",
+                "get-intrinsic": "^1.2.4",
                 "has-symbols": "^1.0.3",
                 "isarray": "^2.0.5"
             },
@@ -13704,14 +13826,17 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/safe-regex-test": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+            "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
+                "call-bind": "^1.0.6",
+                "es-errors": "^1.3.0",
                 "is-regex": "^1.1.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -13837,9 +13962,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -13933,9 +14058,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -14032,29 +14157,32 @@
             "dev": true
         },
         "node_modules/set-function-length": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "dev": true,
             "dependencies": {
-                "define-data-property": "^1.1.1",
-                "get-intrinsic": "^1.2.1",
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "has-property-descriptors": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/set-function-name": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-            "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
             "dev": true,
             "dependencies": {
-                "define-data-property": "^1.0.1",
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
                 "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.0"
+                "has-property-descriptors": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -14114,14 +14242,18 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -14242,9 +14374,9 @@
             }
         },
         "node_modules/socket.io": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.2.tgz",
-            "integrity": "sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==",
+            "version": "4.7.5",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+            "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.4",
@@ -14260,11 +14392,12 @@
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
+            "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
             "dev": true,
             "dependencies": {
+                "debug": "~4.3.4",
                 "ws": "~8.11.0"
             }
         },
@@ -14302,16 +14435,16 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
+            "integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
             "dev": true,
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },
@@ -14339,9 +14472,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -14410,9 +14543,9 @@
             }
         },
         "node_modules/spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
             "dev": true
         },
         "node_modules/spdx-expression-parse": {
@@ -14426,9 +14559,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.16",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-            "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
+            "version": "3.0.17",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+            "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
             "dev": true
         },
         "node_modules/spdy": {
@@ -14574,14 +14707,15 @@
             }
         },
         "node_modules/string.prototype.padend": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.5.tgz",
-            "integrity": "sha512-DOB27b/2UTTD+4myKUFh+/fXWcu/UDyASIXfg+7VzoCNNGOfWvoyU/x5pvVHr++ztyt/oSYI1BcWBBG/hmlNjA==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+            "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.2",
+                "es-object-atoms": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -14591,14 +14725,15 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-            "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+            "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.0",
+                "es-object-atoms": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -14608,28 +14743,31 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-            "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+            "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/string.prototype.trimstart": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-            "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+            "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -14748,9 +14886,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-            "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
@@ -14834,16 +14972,16 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.9",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
-            "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
+            "version": "5.3.10",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+            "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@jridgewell/trace-mapping": "^0.3.20",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.1",
-                "terser": "^5.16.8"
+                "terser": "^5.26.0"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -14917,9 +15055,9 @@
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/terser": {
-            "version": "5.26.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
-            "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+            "version": "5.29.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.2.tgz",
+            "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -15190,29 +15328,30 @@
             }
         },
         "node_modules/typed-array-buffer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+            "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1",
-                "is-typed-array": "^1.1.10"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.13"
             },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/typed-array-byte-length": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+            "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.7",
                 "for-each": "^0.3.3",
-                "has-proto": "^1.0.1",
-                "is-typed-array": "^1.1.10"
+                "gopd": "^1.0.1",
+                "has-proto": "^1.0.3",
+                "is-typed-array": "^1.1.13"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -15222,16 +15361,17 @@
             }
         },
         "node_modules/typed-array-byte-offset": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+            "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
             "dev": true,
             "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.7",
                 "for-each": "^0.3.3",
-                "has-proto": "^1.0.1",
-                "is-typed-array": "^1.1.10"
+                "gopd": "^1.0.1",
+                "has-proto": "^1.0.3",
+                "is-typed-array": "^1.1.13"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -15241,14 +15381,20 @@
             }
         },
         "node_modules/typed-array-length": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+            "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
             "dev": true,
             "dependencies": {
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.7",
                 "for-each": "^0.3.3",
-                "is-typed-array": "^1.1.9"
+                "gopd": "^1.0.1",
+                "has-proto": "^1.0.3",
+                "is-typed-array": "^1.1.13",
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -15598,9 +15744,9 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
+            "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
             "dev": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
@@ -15676,9 +15822,9 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.0.1.tgz",
-            "integrity": "sha512-PZPZ6jFinmqVPJZbisfggDiC+2EeGZ1ZByyMP5sOFJcPPWSexalISz+cvm+j+oYPT7FIJyxT76esjnw9DhE5sw==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.2.tgz",
+            "integrity": "sha512-Wu+EHmX326YPYUpQLKmKbTyZZJIB8/n6R09pTmB03kJmnMsVPTo9COzHZFr01txwaCAuZvfBJE4ZCHRcKs5JaQ==",
             "dev": true,
             "dependencies": {
                 "colorette": "^2.0.10",
@@ -15696,6 +15842,11 @@
             },
             "peerDependencies": {
                 "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-dev-server": {
@@ -15751,29 +15902,6 @@
                 "webpack-cli": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/webpack-dev-middleware": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-            "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
-            "dev": true,
-            "dependencies": {
-                "colorette": "^2.0.10",
-                "memfs": "^3.4.3",
-                "mime-types": "^2.1.31",
-                "range-parser": "^1.2.1",
-                "schema-utils": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 12.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
             }
         },
         "node_modules/webpack-merge": {
@@ -15951,31 +16079,34 @@
             }
         },
         "node_modules/which-collection": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-            "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
             "dev": true,
             "dependencies": {
-                "is-map": "^2.0.1",
-                "is-set": "^2.0.1",
-                "is-weakmap": "^2.0.1",
-                "is-weakset": "^2.0.1"
+                "is-map": "^2.0.3",
+                "is-set": "^2.0.3",
+                "is-weakmap": "^2.0.2",
+                "is-weakset": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+            "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
             "dev": true,
             "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.4",
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.7",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "typescript": "~4.9.4"
     },
     "overrides": {
-        "semver": "^7.5.3"
+        "semver": "^7.5.3",
+        "webpack-dev-middleware": "^6.1.2"
     }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -84,6 +84,11 @@ import { CountAndNounPipe, PluralizePipe } from './utils/pluralize';
 import { OptionalCredentialManagementComponent } from './components/optional-credential-management/optional-credential-management.component';
 import { CREDENTIAL_HANDLER_INJECT_TOKEN, REGISTERED_CREDENTIAL_HANDLERS } from './services/credential-manager.service';
 import { MultipleChoiceModalComponent } from './components/multiple-choice-modal/multiple-choice-modal.component';
+import { QuestionProValidationFieldComponent } from './components/form-fields/question-pro-validation-field/question-pro-validation-field.component';
+import { LazySingleSelectionFieldComponent } from './components/form-fields/selection-fields/single-selection-field/lazy-single-selection-field.component';
+import { SwitchFieldComponent } from './components/form-fields/switch-field/switch-field.component';
+import { SwitchFieldItemWrapperComponent } from './components/form-fields/switch-field/switch-field-item-wrapper.component';
+import { EarnByQuestionProSurveyFormFieldComponent } from './token-option-field-component-factories/earn-by-question-pro-survey-token-option-field-component-factory';
 
 @NgModule({
     declarations: [
@@ -133,7 +138,12 @@ import { MultipleChoiceModalComponent } from './components/multiple-choice-modal
         CountAndNounPipe,
         PluralizePipe,
         OptionalCredentialManagementComponent,
-        MultipleChoiceModalComponent
+        MultipleChoiceModalComponent,
+        QuestionProValidationFieldComponent,
+        LazySingleSelectionFieldComponent,
+        SwitchFieldComponent,
+        SwitchFieldItemWrapperComponent,
+        EarnByQuestionProSurveyFormFieldComponent
     ],
     imports: [
         BrowserModule,

--- a/src/app/components/form-fields/question-pro-validation-field/question-pro-validation-field.component.html
+++ b/src/app/components/form-fields/question-pro-validation-field/question-pro-validation-field.component.html
@@ -1,0 +1,2 @@
+<button class="btn btn-outline-primary" [disabled]="!canValidate" (click)="onManualValidate()">Validate</button>
+<p *ngIf="message">{{ message }}</p>

--- a/src/app/components/form-fields/question-pro-validation-field/question-pro-validation-field.component.spec.ts
+++ b/src/app/components/form-fields/question-pro-validation-field/question-pro-validation-field.component.spec.ts
@@ -1,0 +1,22 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { QuestionProValidationFieldComponent } from './question-pro-validation-field.component';
+
+// describe('QuestionProValidationFieldComponent', () => {
+//     let component: QuestionProValidationFieldComponent;
+//     let fixture: ComponentFixture<QuestionProValidationFieldComponent>;
+
+//     beforeEach(async () => {
+//         await TestBed.configureTestingModule({
+//             declarations: [QuestionProValidationFieldComponent]
+//         }).compileComponents();
+
+//         fixture = TestBed.createComponent(QuestionProValidationFieldComponent);
+//         component = fixture.componentInstance;
+//         fixture.detectChanges();
+//     });
+
+//     it('should create', () => {
+//         expect(component).toBeTruthy();
+//     });
+// });

--- a/src/app/components/form-fields/question-pro-validation-field/question-pro-validation-field.component.ts
+++ b/src/app/components/form-fields/question-pro-validation-field/question-pro-validation-field.component.ts
@@ -1,0 +1,55 @@
+import { Component, Inject } from '@angular/core';
+import type { QuestionProCredential } from 'app/credential-handlers/question-pro-credential-handler';
+import { QuestionProService } from 'app/services/question-pro.service';
+import { ErrorSerializer } from 'app/utils/error-serailizer';
+import type { ExtractDest, ExtractSrc, ExtractVP, FormField } from 'app/utils/form-field/form-field';
+import type { FormFieldWrapper } from 'app/utils/form-field/form-field-wrapper';
+import { ForwardFormField } from 'app/utils/form-field/forward-form-field';
+import { format } from 'date-fns';
+
+@Component({
+    selector: 'app-question-pro-validation-field',
+    templateUrl: './question-pro-validation-field.component.html',
+    styleUrls: ['./question-pro-validation-field.component.sass']
+})
+export class QuestionProValidationFieldComponent<
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        F extends FormField<QuestionProCredential, QuestionProCredential, any>
+    >
+    extends ForwardFormField<F>
+    implements FormFieldWrapper<F, ExtractSrc<F>, ExtractDest<F>, ExtractVP<F>>
+{
+    isProcessing = false;
+    message?: string = undefined;
+
+    constructor(@Inject(QuestionProService) private questionProService: QuestionProService) {
+        super();
+    }
+
+    set wrappedField(wrappedField: F) {
+        this.forwardedTo = wrappedField;
+    }
+
+    public async onManualValidate(): Promise<void> {
+        if (!this.forwardedTo) return;
+        this.isProcessing = true;
+        this.message = undefined;
+        const result = await this.questionProService.validateCredential(await this.forwardedTo.destValue);
+        if (result === undefined) {
+            this.message = `QuestionPro credential has been validated successfully at ${format(
+                new Date(),
+                'MMM dd, yyyy HH:mm:ss'
+            )}!`;
+        } else {
+            this.message = `QuestionPro credential validation failed at ${format(
+                new Date(),
+                'MMM dd, yyyy HH:mm:ss'
+            )}: ${ErrorSerializer.serailize(result)}`;
+        }
+        this.isProcessing = false;
+    }
+
+    get canValidate(): boolean {
+        return this.forwardedTo !== undefined && !this.isProcessing;
+    }
+}

--- a/src/app/components/form-fields/selection-fields/single-selection-field/lazy-single-selection-field.component.html
+++ b/src/app/components/form-fields/selection-fields/single-selection-field/lazy-single-selection-field.component.html
@@ -1,0 +1,64 @@
+<div class="m-3">
+    <label class="form-label">{{ label }}</label>
+    <div class="d-flex align-items-center">
+        <mat-form-field class="flex-grow-1" subscriptSizing="dynamic">
+            <mat-select
+                [(ngModel)]="value"
+                [disabled]="isProcessing || !hasLoaded"
+                [disableRipple]="true"
+                [compareWith]="isEqual"
+                (valueChange)="onSelectValueChange($event)"
+            >
+                <div class="d-flex align-items-center">
+                    <button *ngIf="copyPasteHandler" mat-icon-button title="Copy" class="ms-auto" (click)="onCopy()">
+                        <mat-icon>content_copy</mat-icon>
+                    </button>
+                    <button
+                        *ngIf="copyPasteHandler"
+                        mat-icon-button
+                        title="Paste"
+                        (click)="onPaste()"
+                        [disabled]="isReadOnly || !hasLoaded"
+                    >
+                        <mat-icon>content_paste</mat-icon>
+                    </button>
+                </div>
+                <mat-divider *ngIf="copyPasteHandler" class="m-1"></mat-divider>
+                <mat-option>
+                    <ngx-mat-select-search [(ngModel)]="filterText" placeholderLabel=""></ngx-mat-select-search>
+                </mat-option>
+                <mat-option *ngIf="allowUnselect" [disabled]="isReadOnly || !hasLoaded">Click to unselect</mat-option>
+                <mat-optgroup
+                    *ngIf="invalidOption"
+                    label="Invalid Selection"
+                    class="warn-color"
+                    [hidden]="!isInvalidOptionFiltered"
+                    [disabled]="isReadOnly || !hasLoaded"
+                >
+                    <mat-option
+                        [value]="invalidOption"
+                        [hidden]="!isInvalidOptionFiltered"
+                        [disabled]="!isInvalidOptionSelected || isReadOnly || !hasLoaded"
+                    >
+                        {{ optionRenderer(invalidOption) }}
+                    </mat-option>
+                </mat-optgroup>
+                <mat-divider *ngIf="isInvalidOptionFiltered" class="m-1"></mat-divider>
+                <mat-option
+                    *ngFor="let option of validOptions; let i = index"
+                    [value]="option"
+                    [hidden]="!filteredValidOptionInds.has(i)"
+                    [disabled]="isReadOnly || !hasLoaded"
+                >
+                    {{ optionRenderer(option) }}
+                </mat-option>
+            </mat-select>
+        </mat-form-field>
+        <button type="button" class="btn btn-outline-dark ms-2" [disabled]="isProcessing" (click)="refreshOptions()">
+            <i class="bi bi-arrow-clockwise"></i>
+        </button>
+    </div>
+    <p *ngIf="isProcessing">Loading...</p>
+    <p *ngIf="!hasLoaded">Option loading has been delayed. Please press the refresh button to load options.</p>
+    <p *ngIf="errorMessage" class="text-danger">{{ errorMessage }}</p>
+</div>

--- a/src/app/components/form-fields/switch-field/switch-field-item-wrapper.component.html
+++ b/src/app/components/form-fields/switch-field/switch-field-item-wrapper.component.html
@@ -1,0 +1,3 @@
+<div [hidden]="!isShown">
+    <ng-container #container></ng-container>
+</div>

--- a/src/app/components/form-fields/switch-field/switch-field-item-wrapper.component.ts
+++ b/src/app/components/form-fields/switch-field/switch-field-item-wrapper.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
+
+@Component({
+    selector: 'app-switch-field-item-wrapper',
+    templateUrl: './switch-field-item-wrapper.component.html'
+})
+export class SwitchFieldItemWrapperComponent implements OnInit {
+    @ViewChild('container', { static: true, read: ViewContainerRef }) containerRef?: ViewContainerRef;
+
+    renderer?: (container: ViewContainerRef) => void;
+
+    isShown = false;
+
+    ngOnInit() {
+        if (!this.renderer || !this.containerRef) throw new Error('Fail to initialize SiwtchFieldItemWrapperComponent');
+        this.renderer(this.containerRef);
+    }
+
+    public show(): void {
+        this.isShown = true;
+    }
+
+    public hide(): void {
+        this.isShown = false;
+    }
+
+    public setDisplayState(state: boolean) {
+        this.isShown = state;
+    }
+}

--- a/src/app/components/form-fields/switch-field/switch-field.component.html
+++ b/src/app/components/form-fields/switch-field/switch-field.component.html
@@ -1,0 +1,2 @@
+<ng-container #container></ng-container>
+<p *ngIf="errorMessage">{{ errorMessage }}</p>

--- a/src/app/components/form-fields/switch-field/switch-field.component.spec.ts
+++ b/src/app/components/form-fields/switch-field/switch-field.component.spec.ts
@@ -1,0 +1,22 @@
+// import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { SwitchFieldComponent } from './switch-field.component';
+
+// describe('SwitchFieldComponent', () => {
+//     let component: SwitchFieldComponent;
+//     let fixture: ComponentFixture<SwitchFieldComponent>;
+
+//     beforeEach(async () => {
+//         await TestBed.configureTestingModule({
+//             declarations: [SwitchFieldComponent]
+//         }).compileComponents();
+
+//         fixture = TestBed.createComponent(SwitchFieldComponent);
+//         component = fixture.componentInstance;
+//         fixture.detectChanges();
+//     });
+
+//     it('should create', () => {
+//         expect(component).toBeTruthy();
+//     });
+// });

--- a/src/app/components/form-fields/switch-field/switch-field.component.ts
+++ b/src/app/components/form-fields/switch-field/switch-field.component.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Component, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
+import type { DirectFormField } from 'app/utils/form-field/direct-form-field';
+import { BaseFormField, FormField, ObservableFormField } from 'app/utils/form-field/form-field';
+import type { FormFieldComponentBuilder } from 'app/utils/form-field/form-field-component-builder';
+import type { FormFieldWrapper } from 'app/utils/form-field/form-field-wrapper';
+import type { Subscription } from 'rxjs';
+import { SwitchFieldItemWrapperComponent } from './switch-field-item-wrapper.component';
+
+@Component({
+    selector: 'app-switch-field',
+    templateUrl: './switch-field.component.html',
+    styleUrls: ['./switch-field.component.sass']
+})
+export class SwitchFieldComponent<
+        K extends string | number | symbol,
+        MK extends { [P in K]: any },
+        MV extends { [P in K]: any }
+    >
+    extends BaseFormField<
+        [undefined, undefined] | { [P in K]: [P, MK[P]] }[K],
+        [undefined, undefined] | { [P in K]: [P, MV[P]] }[K],
+        any
+    >
+    implements
+        FormFieldWrapper<
+            DirectFormField<K | undefined, any> & ObservableFormField<K | undefined>,
+            [undefined, undefined] | { [P in K]: [P, MK[P]] }[K],
+            [undefined, undefined] | { [P in K]: [P, MV[P]] }[K],
+            any
+        >,
+        OnInit,
+        OnDestroy
+{
+    @ViewChild('container', { static: true, read: ViewContainerRef }) containerRef?: ViewContainerRef;
+    private keyField?: DirectFormField<K | undefined, any> & ObservableFormField<K | undefined>;
+    private subscription?: Subscription;
+    private itemMap = new Map<K, SwitchFieldItemWrapperComponent>();
+    private fieldMap = new Map<K, FormField<MK[K], MV[K], any>>();
+    private isInitialized = false;
+    private cachedRenderers: [K, (containerRef: ViewContainerRef) => void][] = [];
+    private curKey?: K;
+
+    public addField<P extends K>(key: P, fieldBuilder: FormFieldComponentBuilder<FormField<MK[P], MV[P], any>>) {
+        const [renderer, field] = fieldBuilder.build();
+        if (this.fieldMap.has(key)) throw new Error('Cannot add more than one field with the same key');
+        this.fieldMap.set(key, field);
+        if (!this.isInitialized) {
+            this.cachedRenderers.push([key, renderer]);
+            return;
+        }
+        if (!this.containerRef) throw new Error('Fail to initialize SwitchFieldComponent');
+        const componentRef = this.containerRef.createComponent(SwitchFieldItemWrapperComponent);
+        componentRef.instance.renderer = renderer;
+        this.itemMap.set(key, componentRef.instance);
+    }
+
+    set wrappedField(wrappedField: DirectFormField<K | undefined, any> & ObservableFormField<K | undefined>) {
+        this.keyField = wrappedField;
+        this.subscription = wrappedField.destValue$.subscribe((x) => this.onValueUpdate(x));
+    }
+
+    private onValueUpdate(key?: K) {
+        if (this.curKey == key) return;
+        const oldKey = this.curKey;
+        this.curKey = key;
+        if (!this.isInitialized) return;
+        if (oldKey !== undefined) this.itemMap.get(oldKey)?.hide();
+        if (key !== undefined) this.itemMap.get(key)?.show();
+    }
+
+    public override set srcValue([key, value]: [undefined, undefined] | { [P in K]: [P, MK[P]] }[K]) {
+        if (value === undefined) throw new Error('Value for switch field cannot be undefined');
+        if (!this.keyField) throw new Error('Fail to initialize SwitchFieldComponent');
+        this.keyField.srcValue = key;
+        if (key === undefined) {
+            return;
+        }
+        const valueField = this.fieldMap.get(key);
+        if (valueField === undefined) throw new Error('Fail to find a field with the provided key');
+        valueField.srcValue = value;
+    }
+
+    public override get destValue(): Promise<[undefined, undefined] | { [P in K]: [P, MV[P]] }[K]> {
+        return (async () => {
+            if (this.curKey === undefined) return [undefined, undefined];
+            const valueField = this.fieldMap.get(this.curKey);
+            if (valueField === undefined) throw new Error('Fail to find a field with the provided key');
+            return [this.curKey, await valueField.destValue];
+        })();
+    }
+
+    public override async validate(): Promise<boolean> {
+        const keyRes = await this.keyField?.validate();
+        const valueRes = this.curKey === undefined ? false : await this.fieldMap.get(this.curKey)?.validate();
+        return (keyRes && valueRes) ?? false;
+    }
+
+    public override set isReadOnly(isReadOnly: boolean) {
+        if (this.keyField) this.keyField.isReadOnly = isReadOnly;
+        for (const field of this.fieldMap.values()) field.isReadOnly = isReadOnly;
+    }
+
+    ngOnInit() {
+        if (!this.containerRef) throw new Error('Fail to initialize SwitchFieldComponent');
+        for (const [key, renderer] of this.cachedRenderers) {
+            const componentRef = this.containerRef.createComponent(SwitchFieldItemWrapperComponent);
+            componentRef.instance.renderer = renderer;
+            this.itemMap.set(key, componentRef.instance);
+        }
+        if (this.curKey) this.itemMap.get(this.curKey)?.show();
+        this.isInitialized = true;
+    }
+
+    ngOnDestroy(): void {
+        this.subscription?.unsubscribe();
+    }
+}

--- a/src/app/credential-handlers/question-pro-credential-handler.ts
+++ b/src/app/credential-handlers/question-pro-credential-handler.ts
@@ -75,7 +75,7 @@ export class QuestionProCredentialHandler implements CredentialHandler<QuestionP
             }
             return true;
         };
-        return createFieldComponentWithLabel(StringInputFieldComponent, 'Environment (ENV)', environmentInjector)
+        return createFieldComponentWithLabel(StringInputFieldComponent, 'Environment Value (ENV)', environmentInjector)
             .editField((field) => {
                 field.validator = validator;
             })

--- a/src/app/credential-handlers/question-pro-credential-handler.ts
+++ b/src/app/credential-handlers/question-pro-credential-handler.ts
@@ -80,7 +80,7 @@ export class QuestionProCredentialHandler implements CredentialHandler<QuestionP
                 field.validator = validator;
             })
             .appendBuilder(
-                createFieldComponentWithLabel(StringInputFieldComponent, 'User ID', environmentInjector).editField(
+                createFieldComponentWithLabel(StringInputFieldComponent, 'Customer ID', environmentInjector).editField(
                     (field) => {
                         field.validator = validator;
                     }
@@ -89,6 +89,7 @@ export class QuestionProCredentialHandler implements CredentialHandler<QuestionP
             .appendBuilder(
                 createFieldComponentWithLabel(StringInputFieldComponent, 'API Key', environmentInjector).editField(
                     (field) => {
+                        field.type = 'password';
                         field.validator = validator;
                     }
                 )

--- a/src/app/credential-handlers/question-pro-credential-handler.ts
+++ b/src/app/credential-handlers/question-pro-credential-handler.ts
@@ -1,0 +1,115 @@
+import { EnvironmentInjector, Inject, Injectable, ViewContainerRef } from '@angular/core';
+import { QuestionProValidationFieldComponent } from 'app/components/form-fields/question-pro-validation-field/question-pro-validation-field.component';
+import { StringInputFieldComponent } from 'app/components/form-fields/string-input-field/string-input-field.component';
+import type { TokenATMCredentials } from 'app/data/token-atm-credentials';
+import { CredentialHandler, RegisterCredentialHandler } from 'app/services/credential-manager.service';
+import { QuestionProService } from 'app/services/question-pro.service';
+import { createFieldComponentWithLabel } from 'app/token-option-field-component-factories/token-option-field-component-factory';
+import type { FormField } from 'app/utils/form-field/form-field';
+import type { FormFieldComponentBuilder } from 'app/utils/form-field/form-field-component-builder';
+
+export type QuestionProCredential = {
+    questionProEnv: string;
+    questionProUserId: string;
+    questionProAPIKey: string;
+};
+
+export const QUESTION_PRO_CREDENTIAL_KEY = 'question_pro';
+
+@RegisterCredentialHandler
+@Injectable()
+export class QuestionProCredentialHandler implements CredentialHandler<QuestionProCredential> {
+    readonly key = QUESTION_PRO_CREDENTIAL_KEY;
+    readonly descriptiveName = 'QuestionPro';
+    readonly documentLink = 'https://docs.google.com/document/d/1H4cvBXV7wwVp1IA2squ0mtrug5HkDVlBf4qKhh1o_vQ/view';
+
+    constructor(@Inject(QuestionProService) private questionProService: QuestionProService) {}
+
+    public has(credentials: TokenATMCredentials): boolean {
+        return this.key in credentials && credentials[this.key] !== undefined;
+    }
+
+    public get(credentials: TokenATMCredentials): QuestionProCredential | undefined {
+        return credentials[this.key] as QuestionProCredential | undefined;
+    }
+
+    public set(credentials: TokenATMCredentials, credential: QuestionProCredential): void {
+        credentials[this.key] = credential;
+    }
+
+    public delete(credentials: TokenATMCredentials): void {
+        delete credentials[this.key];
+    }
+
+    public async validate(): Promise<unknown> {
+        // Note: skip default validation due to API call limit
+        return undefined;
+    }
+
+    public async configure(credential: QuestionProCredential): Promise<void> {
+        await this.questionProService.configureCredential(credential);
+    }
+
+    public clear(): void {
+        this.questionProService.clearCredential();
+    }
+
+    public generateErrorMessage(): string {
+        // Note: no error message since default validation is skipped
+        return '';
+    }
+
+    public isConfigured(): boolean {
+        return this.questionProService.hasCredentialConfigured();
+    }
+
+    private _buildFormFieldComponentWithoutValidation(
+        environmentInjector: EnvironmentInjector
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): FormFieldComponentBuilder<FormField<QuestionProCredential, QuestionProCredential, any>> {
+        const validator = async ([f, v]: [StringInputFieldComponent, string]) => {
+            f.errorMessage = undefined;
+            if (v.trim().length == 0) {
+                f.errorMessage = 'Value cannot be empty!';
+                return false;
+            }
+            return true;
+        };
+        return createFieldComponentWithLabel(StringInputFieldComponent, 'Environment (ENV)', environmentInjector)
+            .editField((field) => {
+                field.validator = validator;
+            })
+            .appendBuilder(
+                createFieldComponentWithLabel(StringInputFieldComponent, 'User ID', environmentInjector).editField(
+                    (field) => {
+                        field.validator = validator;
+                    }
+                )
+            )
+            .appendBuilder(
+                createFieldComponentWithLabel(StringInputFieldComponent, 'API Key', environmentInjector).editField(
+                    (field) => {
+                        field.validator = validator;
+                    }
+                )
+            )
+            .transformSrc((v: QuestionProCredential) => [v.questionProEnv, v.questionProUserId, v.questionProAPIKey])
+            .transformDest(
+                async ([env, userId, apiKey]: [string, string, string]) =>
+                    <QuestionProCredential>{
+                        questionProEnv: env,
+                        questionProUserId: userId,
+                        questionProAPIKey: apiKey
+                    }
+            );
+    }
+
+    public buildFormFieldComponent(
+        environmentInjector: EnvironmentInjector
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): [(viewContainerRef: ViewContainerRef) => void, FormField<QuestionProCredential, QuestionProCredential, any>] {
+        return this._buildFormFieldComponentWithoutValidation(environmentInjector)
+            .wrapSuffix(createFieldComponentWithLabel(QuestionProValidationFieldComponent, '', environmentInjector))
+            .build();
+    }
+}

--- a/src/app/request-handlers/earn-by-question-pro-survey-request-handler.ts
+++ b/src/app/request-handlers/earn-by-question-pro-survey-request-handler.ts
@@ -1,0 +1,59 @@
+import { Inject, Injectable } from '@angular/core';
+import { ProcessedRequest } from 'app/data/processed-request';
+import type { StudentRecord } from 'app/data/student-record';
+import type { TokenATMConfiguration } from 'app/data/token-atm-configuration';
+import type { EarnByQuestionProSurveyRequest } from 'app/requests/earn-by-question-pro-survey-request';
+import { QuestionProService } from 'app/services/question-pro.service';
+// import { QuestionProService } from 'app/services/question-pro.service';
+import type { EarnByQuestionProSurveyTokenOption } from 'app/token-options/earn-by-question-pro-survey-token-option';
+import { EndDateGuard } from './guards/end-date-guard';
+import { QuestionProSurveyParticipationGuard } from './guards/question-pro-survey-participation-guard';
+import { RepeatRequestGuard } from './guards/repeat-request-guard';
+import { RequestHandlerGuardExecutor } from './guards/request-handler-guard-executor';
+import { StartDateGuard } from './guards/start-date-guard';
+import { RequestHandler } from './request-handlers';
+
+@Injectable()
+export class EarnByQuestionProSurveyRequestHandler extends RequestHandler<
+    EarnByQuestionProSurveyTokenOption,
+    EarnByQuestionProSurveyRequest
+> {
+    constructor(@Inject(QuestionProService) private questionProService: QuestionProService) {
+        super();
+    }
+
+    public async handle(
+        configuration: TokenATMConfiguration,
+        studentRecord: StudentRecord,
+        request: EarnByQuestionProSurveyRequest
+    ): Promise<ProcessedRequest> {
+        const guardExecutor = new RequestHandlerGuardExecutor([
+            new StartDateGuard(request.submittedTime, request.tokenOption.startTime),
+            new EndDateGuard(request.submittedTime, request.tokenOption.endTime),
+            new RepeatRequestGuard(request.tokenOption, studentRecord.processedRequests),
+            new QuestionProSurveyParticipationGuard(
+                request.tokenOption.surveyId,
+                request.tokenOption.responseField,
+                studentRecord.student.email,
+                this.questionProService
+            )
+        ]);
+        await guardExecutor.check();
+        return new ProcessedRequest(
+            configuration,
+            request.tokenOption.id,
+            request.tokenOption.name,
+            request.student,
+            !guardExecutor.isRejected,
+            request.submittedTime,
+            new Date(),
+            guardExecutor.isRejected ? 0 : request.tokenOption.tokenBalanceChange,
+            guardExecutor.message,
+            request.tokenOption.group.id
+        );
+    }
+
+    public get type(): string {
+        return 'earn-by-question-pro-survey';
+    }
+}

--- a/src/app/request-handlers/guards/question-pro-survey-participation-guard.ts
+++ b/src/app/request-handlers/guards/question-pro-survey-participation-guard.ts
@@ -1,0 +1,31 @@
+import type { QuestionProService } from 'app/services/question-pro.service';
+import type { EarnByQuestionProSurveyTokenOptionData } from 'app/token-options/earn-by-question-pro-survey-token-option';
+import { RequestHandlerGuard } from './request-handler-guard';
+
+export class QuestionProSurveyParticipationGuard extends RequestHandlerGuard {
+    constructor(
+        private surveyId: string,
+        private responseField: EarnByQuestionProSurveyTokenOptionData['responseField'],
+        private participationId: string,
+        private questionProService: QuestionProService
+    ) {
+        super();
+    }
+
+    public async check(onReject: (message: string) => Promise<void>): Promise<void> {
+        if (this.participationId == '') {
+            onReject('Your Canvas email address is not visible, please contact your institution for help.');
+            return;
+        }
+        const result = await this.questionProService.checkParticipation(
+            this.surveyId,
+            this.responseField,
+            this.participationId
+        );
+        if (!result) {
+            onReject(
+                'You did not complete the survey. Or your default email address on Canvas doesn’t match the email connected with the QuestionPro survey.'
+            );
+        }
+    }
+}

--- a/src/app/request-handlers/request-handler-registry.ts
+++ b/src/app/request-handlers/request-handler-registry.ts
@@ -20,6 +20,7 @@ import { SpendForAssignmentExtensionRequestHandler } from './spend-for-assignmen
 import { SpendForPassingAssignmentRequestHandler } from './spend-for-passing-assignment-request-handler';
 import { PlaceholderRequestHandler } from './placeholder-request-handler';
 import { SpendForAdditionalPointsRequestHandler } from './spend-for-additional-points-request-handler';
+import { EarnByQuestionProSurveyRequestHandler } from './earn-by-question-pro-survey-request-handler';
 
 type GenericRequestHandler = RequestHandler<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -38,7 +39,8 @@ export const REGISTERED_REQUEST_HANDLERS: Type<GenericRequestHandler>[] = [
     SpendForAssignmentExtensionRequestHandler,
     SpendForPassingAssignmentRequestHandler,
     PlaceholderRequestHandler,
-    SpendForAdditionalPointsRequestHandler
+    SpendForAdditionalPointsRequestHandler,
+    EarnByQuestionProSurveyRequestHandler
 ];
 
 export const REQUEST_HANDLER_INJECT_TOKEN = new InjectionToken<GenericRequestHandler[]>('REQUEST_HANDLERS');

--- a/src/app/request-resolvers/earn-by-question-pro-survey-request-resolver.ts
+++ b/src/app/request-resolvers/earn-by-question-pro-survey-request-resolver.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import type { QuizSubmissionDetail } from 'app/data/quiz-submission-detail';
+import { EarnByQuestionProSurveyRequest } from 'app/requests/earn-by-question-pro-survey-request';
+import type { EarnByQuestionProSurveyTokenOption } from 'app/token-options/earn-by-question-pro-survey-token-option';
+import { RequestResolver } from './request-resolver';
+
+@Injectable()
+export class EarnByQuestionProSurveyRequestResolver extends RequestResolver<
+    EarnByQuestionProSurveyTokenOption,
+    EarnByQuestionProSurveyRequest
+> {
+    public async resolve(
+        tokenOption: EarnByQuestionProSurveyTokenOption,
+        quizSubmissionDetail: QuizSubmissionDetail
+    ): Promise<EarnByQuestionProSurveyRequest> {
+        return new EarnByQuestionProSurveyRequest(
+            tokenOption,
+            quizSubmissionDetail.student,
+            quizSubmissionDetail.submittedTime,
+            quizSubmissionDetail
+        );
+    }
+    public get type(): string {
+        return 'earn-by-question-pro-survey';
+    }
+}

--- a/src/app/request-resolvers/request-resolver-registry.ts
+++ b/src/app/request-resolvers/request-resolver-registry.ts
@@ -19,6 +19,7 @@ import { SpendForAssignmentExtensionRequestResolver } from './spend-for-assignme
 import { SpendForPassingAssignmentRequestResolver } from './spend-for-passing-assignment-request-resolver';
 import { PlaceholderRequestResolver } from './placeholder-request-resolver';
 import { SpendForAdditionalPointsRequestResolver } from './spend-for-additional-points-request-resolver';
+import { EarnByQuestionProSurveyRequestResolver } from './earn-by-question-pro-survey-request-resolver';
 
 type GenericRequestResolver = RequestResolver<TokenOption, TokenATMRequest<TokenOption>>;
 
@@ -37,7 +38,8 @@ export const REGISTERED_REQUEST_RESOLVERS: Type<GenericRequestResolver>[] = [
     SpendForAssignmentExtensionRequestResolver,
     SpendForPassingAssignmentRequestResolver,
     PlaceholderRequestResolver,
-    SpendForAdditionalPointsRequestResolver
+    SpendForAdditionalPointsRequestResolver,
+    EarnByQuestionProSurveyRequestResolver
 ];
 
 export const REQUEST_RESOLVER_INJECT_TOKEN = new InjectionToken<GenericRequestResolver[]>('REQUEST_RESOLVERS');

--- a/src/app/requests/earn-by-question-pro-survey-request.ts
+++ b/src/app/requests/earn-by-question-pro-survey-request.ts
@@ -1,0 +1,4 @@
+import type { EarnByQuestionProSurveyTokenOption } from 'app/token-options/earn-by-question-pro-survey-token-option';
+import { TokenATMRequest } from './token-atm-request';
+
+export class EarnByQuestionProSurveyRequest extends TokenATMRequest<EarnByQuestionProSurveyTokenOption> {}

--- a/src/app/services/question-pro.service.spec.ts
+++ b/src/app/services/question-pro.service.spec.ts
@@ -1,0 +1,16 @@
+// import { TestBed } from '@angular/core/testing';
+
+// import { QuestionProService } from './question-pro.service';
+
+// describe('QuestionProService', () => {
+//     let service: QuestionProService;
+
+//     beforeEach(() => {
+//         TestBed.configureTestingModule({});
+//         service = TestBed.inject(QuestionProService);
+//     });
+
+//     it('should be created', () => {
+//         expect(service).toBeTruthy();
+//     });
+// });

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -210,6 +210,7 @@ export class QuestionProService {
         const tmpSet = this.participationCache.get(surveyId)?.get(typeStr);
         const responses = await this.getResponses(surveyId);
         for await (const response of responses) {
+            if (response?.['responseStatus'] != 'Completed') continue;
             if (responseField.type == 'customVariable') {
                 const data = response?.['customVariables']?.[responseField.variableName];
                 if (!data) continue;

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -1,0 +1,192 @@
+import { Inject, Injectable } from '@angular/core';
+import { AxiosService, IPCCompatibleAxiosResponse } from './axios.service';
+import type { AxiosRequestConfig } from 'axios';
+import type { QuestionProCredential } from 'app/credential-handlers/question-pro-credential-handler';
+import type { PaginatedResult } from 'app/utils/pagination/paginated-result';
+import { QuestionProPaginatedResult } from 'app/utils/pagination/question-pro-paginated-result';
+import type { QuestionProSurveyMixinData } from 'app/token-options/mixins/question-pro-survey-mixin';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class QuestionProService {
+    #env?: string;
+    #userId?: string;
+    #apiKey?: string;
+
+    private participationCache: Map<string, Map<string, Set<string>>> = new Map<string, Map<string, Set<string>>>();
+
+    constructor(@Inject(AxiosService) private axiosService: AxiosService) {}
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    #rawAPIRequest<T = any>(
+        endpoint: string,
+        config?: AxiosRequestConfig,
+        credential?: QuestionProCredential
+    ): Promise<IPCCompatibleAxiosResponse<T>> {
+        const env = credential?.questionProEnv ?? this.#env;
+        const apiKey = credential?.questionProAPIKey ?? this.#apiKey;
+        return this.axiosService.request<T>({
+            ...config,
+            url: `https://api.questionpro.${env}/a/api/v2` + endpoint,
+            headers: {
+                ...config?.headers,
+                'api-key': apiKey
+            }
+        });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async #apiRequest<T = any>(
+        endpoint: string,
+        config?: AxiosRequestConfig,
+        credential?: QuestionProCredential
+    ): Promise<T> {
+        return (await this.#rawAPIRequest<T>(endpoint, config, credential)).data;
+    }
+
+    public hasCredentialConfigured(): boolean {
+        return this.#env !== undefined && this.#userId !== undefined && this.#apiKey !== undefined;
+    }
+
+    public async validateCredential(credential: QuestionProCredential): Promise<unknown | undefined> {
+        try {
+            await this.#apiRequest(`/users/${credential.questionProUserId}`, {}, credential);
+        } catch (err: unknown) {
+            return err;
+        }
+        return undefined;
+    }
+
+    public async clearCredential() {
+        this.#env = undefined;
+        this.#userId = undefined;
+        this.#apiKey = undefined;
+    }
+
+    public clearCache() {
+        this.participationCache.clear();
+    }
+
+    public async configureCredential({
+        questionProEnv,
+        questionProUserId,
+        questionProAPIKey
+    }: QuestionProCredential): Promise<unknown | undefined> {
+        this.#env = questionProEnv;
+        this.#userId = questionProUserId;
+        this.#apiKey = questionProAPIKey;
+        return undefined;
+    }
+
+    public async getSurveys(): Promise<PaginatedResult<[string, string]>> {
+        return new QuestionProPaginatedResult(
+            await this.#rawAPIRequest(`/users/${this.#userId}/surveys`, {
+                params: {
+                    perPage: 1000,
+                    page: 1
+                }
+            }),
+            (url: string) => this.#rawAPIRequest(url),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (v) => v.map((x: any) => [x['surveyID'].toString(), x['name']])
+        );
+    }
+
+    public async hasSurvey(surveyId: string): Promise<boolean> {
+        try {
+            await this.#apiRequest(`/surveys/${surveyId}`);
+        } catch (_: unknown) {
+            return false;
+        }
+        return true;
+    }
+
+    public async getQuestions(surveyId: string): Promise<PaginatedResult<[string, string]>> {
+        // TODO: support unpacking questions with multiple rows (e.g., contact_information)
+        return new QuestionProPaginatedResult(
+            await this.#rawAPIRequest(`/surveys/${surveyId}/questions`, {
+                params: {
+                    perPage: 1000,
+                    page: 1
+                }
+            }),
+            (url: string) => this.#rawAPIRequest(url),
+            (v) =>
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                v.map((x: any) => {
+                    if (x['type'] == 'text_email') return [x['questionID'].toString(), x['rows'][0]['text']];
+                    return [x['questionID'].toString(), x['text']];
+                })
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private async getResponses(surveyId: string): Promise<PaginatedResult<any>> {
+        return new QuestionProPaginatedResult(
+            await this.#rawAPIRequest(`/surveys/${surveyId}/questions`, {
+                params: {
+                    perPage: 1000,
+                    page: 1
+                }
+            }),
+            (url: string) => this.#rawAPIRequest(url),
+            (v) => v
+        );
+    }
+
+    public async hasQuestion(surveyId: string, questionId: string): Promise<boolean> {
+        try {
+            await this.#apiRequest(`/surveys/${surveyId}/questions/${questionId}`);
+        } catch (_: unknown) {
+            return false;
+        }
+        return true;
+    }
+
+    private getTypeStr(responseField: QuestionProSurveyMixinData['responseField']): string {
+        return responseField.type == 'customVariable'
+            ? `customVariable: ${responseField.variableName}`
+            : `studentResponse: ${responseField.questionId}`;
+    }
+
+    private async cacheSurveyParticipation(
+        surveyId: string,
+        responseField: QuestionProSurveyMixinData['responseField']
+    ): Promise<void> {
+        const typeStr = this.getTypeStr(responseField);
+        if (!this.participationCache.has(surveyId))
+            this.participationCache.set(surveyId, new Map<string, Set<string>>());
+        if (this.participationCache.get(surveyId)?.has(typeStr)) return;
+        this.participationCache.get(surveyId)?.set(typeStr, new Set<string>());
+        const tmpSet = this.participationCache.get(surveyId)?.get(typeStr);
+        const responses = await this.getResponses(surveyId);
+        for await (const response of responses) {
+            if (responseField.type == 'customVariable') {
+                const data = response?.['customVariables'][responseField.variableName];
+                if (!data) continue;
+                tmpSet?.add(data);
+            } else {
+                if (!Array.isArray(response?.['responseSet'])) continue;
+                for (const v of response['responseSet']) {
+                    if (v?.['questionID'].toString() != responseField.questionId) continue;
+                    if (!Array.isArray(v?.['answerValues'])) continue;
+                    const data = v?.['answerValues']?.[0]?.['answerText'];
+                    if (!data) continue;
+                    tmpSet?.add(data);
+                }
+            }
+        }
+    }
+
+    public async checkParticipation(
+        surveyId: string,
+        responseField: QuestionProSurveyMixinData['responseField'],
+        participationId: string
+    ): Promise<boolean> {
+        await this.cacheSurveyParticipation(surveyId, responseField);
+        return (
+            this.participationCache.get(surveyId)?.get(this.getTypeStr(responseField))?.has(participationId) ?? false
+        );
+    }
+}

--- a/src/app/services/request-process-manager.service.ts
+++ b/src/app/services/request-process-manager.service.ts
@@ -16,6 +16,7 @@ import { QualtricsService } from './qualtrics.service';
 import { RawRequestFetcherService } from './raw-request-fetcher.service';
 import { StudentRecordManagerService } from './student-record-manager.service';
 import { countAndNoun } from 'app/utils/pluralize';
+import { QuestionProService } from './question-pro.service';
 
 @Injectable({
     providedIn: 'root'
@@ -31,7 +32,8 @@ export class RequestProcessManagerService {
         @Inject(RequestResolverRegistry) private requestResolverRegistry: RequestResolverRegistry,
         @Inject(StudentRecordManagerService) private studentRecordManagerService: StudentRecordManagerService,
         @Inject(RequestHandlerRegistry) private requestHandlerRegistry: RequestHandlerRegistry,
-        @Inject(QualtricsService) private qualtricsService: QualtricsService
+        @Inject(QualtricsService) private qualtricsService: QualtricsService,
+        @Inject(QuestionProService) private questionProService: QuestionProService
     ) {}
 
     public startRequestProcessing(configuration: TokenATMConfiguration): Observable<[number, string]> {
@@ -53,6 +55,7 @@ export class RequestProcessManagerService {
         this._isRunning = false;
         this._isStopTriggered = false;
         this.qualtricsService.clearCache();
+        this.questionProService.clearCache();
         if (completeObservable) progressUpdate.complete();
     }
 
@@ -63,6 +66,7 @@ export class RequestProcessManagerService {
         this._isRunning = true;
         this._isStopTriggered = false;
         this.qualtricsService.clearCache();
+        this.questionProService.clearCache();
         let quizSubmissionMap, assignmentIdMap;
         try {
             [quizSubmissionMap, assignmentIdMap] = await this.gatherQuizSubmissions(configuration, progressUpdate);

--- a/src/app/token-option-field-component-factories/earn-by-question-pro-survey-token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/earn-by-question-pro-survey-token-option-field-component-factory.ts
@@ -1,0 +1,469 @@
+import {
+    TokenOptionFieldComponentFactory,
+    createEndTimeComponentBuilder,
+    createFieldComponentWithLabel,
+    createStartTimeComponentBuilder,
+    tokenOptionFieldComponentBuilder
+} from './token-option-field-component-factory';
+import {
+    Injectable,
+    EnvironmentInjector,
+    ViewContainerRef,
+    Inject,
+    Component,
+    OnInit,
+    OnDestroy,
+    ViewChild,
+    createComponent
+} from '@angular/core';
+import { TokenOptionGroup } from 'app/data/token-option-group';
+import { BaseFormField, FormField, ObservableFormField } from 'app/utils/form-field/form-field';
+import { StringInputFieldComponent } from 'app/components/form-fields/string-input-field/string-input-field.component';
+import { set } from 'date-fns';
+import {
+    EarnByQuestionProSurveyTokenOption,
+    EarnByQuestionProSurveyTokenOptionData,
+    EarnByQuestionProSurveyTokenOptionDataDef
+} from 'app/token-options/earn-by-question-pro-survey-token-option';
+import type { DirectFormField } from 'app/utils/form-field/direct-form-field';
+import type { FormFieldWrapper } from 'app/utils/form-field/form-field-wrapper';
+import type { Subscription } from 'rxjs';
+import { QuestionProService } from 'app/services/question-pro.service';
+import { SingleSelectionFieldComponent } from 'app/components/form-fields/selection-fields/single-selection-field/single-selection-field.component';
+import type { FormFieldComponentBuilder } from 'app/utils/form-field/form-field-component-builder';
+import { SwitchFieldComponent } from 'app/components/form-fields/switch-field/switch-field.component';
+import {
+    LazyLoadData,
+    LazySingleSelectionFieldComponent
+} from 'app/components/form-fields/selection-fields/single-selection-field/lazy-single-selection-field.component';
+import type { QuestionProSurveyMixinData } from 'app/token-options/mixins/question-pro-survey-mixin';
+import { isEqual } from 'lodash';
+import { DataConversionHelper } from 'app/utils/data-conversion-helper';
+import { ErrorMessageFieldComponent } from 'app/components/form-fields/error-message-field/error-message-field.component';
+
+type SurveyData = Pick<EarnByQuestionProSurveyTokenOptionData, 'surveyId' | 'surveyName'>;
+type SurveyResponseField = Pick<EarnByQuestionProSurveyTokenOptionData, 'responseField'>;
+type LazyQuestionProSurveyMixinData = {
+    data: QuestionProSurveyMixinData;
+    hasSurveyLoaded: boolean;
+    hasQuestionLoaded: boolean;
+};
+
+@Component({
+    selector: 'app-earn-by-question-pro-survey-form-field',
+    template:
+        '<div [hidden]="survey?.data === undefined"><ng-container #container></ng-container></div><p *ngIf="survey?.data === undefined">Please select a QuestionPro survey first.</p>'
+})
+export class EarnByQuestionProSurveyFormFieldComponent
+    extends BaseFormField<QuestionProSurveyMixinData | undefined, LazyQuestionProSurveyMixinData, unknown>
+    implements
+        FormFieldWrapper<
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            FormField<SurveyData | undefined, LazyLoadData<SurveyData>, any> &
+                ObservableFormField<LazyLoadData<SurveyData>>,
+            QuestionProSurveyMixinData | undefined,
+            LazyQuestionProSurveyMixinData,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            any
+        >,
+        OnInit,
+        OnDestroy
+{
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private subscription?: Subscription;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private surveyField?: FormField<SurveyData | undefined, LazyLoadData<SurveyData>, any> &
+        ObservableFormField<LazyLoadData<SurveyData>>;
+    survey?: LazyLoadData<SurveyData>;
+    private field: FormField<
+        | [undefined, undefined]
+        | [string, 'customVariable', string | undefined]
+        | [string, 'studentResponse', undefined]
+        | [string, 'studentResponse', string, string],
+        LazyLoadData<SurveyResponseField>,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any
+    >;
+    private renderer: (containerRef: ViewContainerRef) => void;
+    @ViewChild('container', { static: true, read: ViewContainerRef }) private containerRef?: ViewContainerRef;
+
+    constructor(
+        @Inject(QuestionProService) private questionProService: QuestionProService,
+        @Inject(EnvironmentInjector) private environmentInjector: EnvironmentInjector
+    ) {
+        super();
+        const _builder = createFieldComponentWithLabel(
+            SingleSelectionFieldComponent<'Custom Variable' | 'Student Response'>,
+            'Collect Email From',
+            this.environmentInjector
+        )
+            .editField((field) => {
+                field.validator = async ([v, f]: [
+                    'Custom Variable' | 'Student Response' | undefined,
+                    typeof field
+                ]) => {
+                    f.errorMessage = undefined;
+                    if (v === undefined) {
+                        f.errorMessage = 'Please select a method to collect student email!';
+                        return false;
+                    }
+                    return true;
+                };
+            })
+            .transformObservableSrc((v: 'Custom Variable' | 'Student Response') => [
+                v,
+                async () => ['Custom Variable', 'Student Response']
+            ]) as FormFieldComponentBuilder<
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            DirectFormField<'Custom Variable' | 'Student Response' | undefined, any> &
+                ObservableFormField<'Custom Variable' | 'Student Response' | undefined>
+        >;
+        [this.renderer, this.field] = _builder
+            .wrapSuffix(
+                createFieldComponentWithLabel(
+                    SwitchFieldComponent<
+                        'Custom Variable' | 'Student Response',
+                        {
+                            'Custom Variable': string;
+                            'Student Response': [[string, string] | undefined, () => Promise<[string, string][]>];
+                        },
+                        {
+                            'Custom Variable': string;
+                            'Student Response': LazyLoadData<[string, string]>;
+                        }
+                    >,
+                    '',
+                    this.environmentInjector
+                ).editField((field) => {
+                    field.addField(
+                        'Custom Variable',
+                        createFieldComponentWithLabel(
+                            StringInputFieldComponent,
+                            'Custom Variable Name',
+                            this.environmentInjector
+                        ).editField((field) => {
+                            field.validator = async ([f, v]: [typeof field, string]) => {
+                                f.errorMessage = undefined;
+                                if (v.trim().length == 0) {
+                                    f.errorMessage = 'Custom variable name cannot be empty!';
+                                    return false;
+                                }
+                                return true;
+                            };
+                        })
+                    );
+                    field.addField(
+                        'Student Response',
+                        createFieldComponentWithLabel(
+                            LazySingleSelectionFieldComponent<[string, string]>,
+                            'Question for Email',
+                            this.environmentInjector
+                        ).editField((field) => {
+                            field.allowUnselect = true;
+                            field.optionRenderer = (v) => v[1];
+                            field.validator = async ([v, f]: [[string, string] | undefined, typeof field]) => {
+                                f.errorMessage = undefined;
+                                if (v === undefined) {
+                                    f.errorMessage = 'Please select a question!';
+                                    return false;
+                                }
+                                return true;
+                            };
+                        })
+                    );
+                })
+            )
+            .transformSrc(
+                (
+                    v:
+                        | [undefined, undefined]
+                        | [string, 'customVariable', string | undefined]
+                        | [string, 'studentResponse', undefined]
+                        | [string, 'studentResponse', string, string]
+                ) => {
+                    if (v[0] === undefined) return ['Custom Variable', ''];
+                    if (v[1] == 'customVariable') return ['Custom Variable', v[2] ?? ''];
+                    return [
+                        'Student Response',
+                        [
+                            v[2] !== undefined ? [v[2], v[3]] : undefined,
+                            async () =>
+                                await DataConversionHelper.convertAsyncIterableToList(
+                                    await this.questionProService.getQuestions(v[0])
+                                )
+                        ]
+                    ];
+                }
+            )
+            .transformDest(async (v) => {
+                if (v[0] === undefined) throw new Error('Invalid data');
+                switch (v[0]) {
+                    case 'Custom Variable':
+                        return {
+                            data: {
+                                responseField: {
+                                    type: 'customVariable' as const,
+                                    variableName: v[1]
+                                }
+                            },
+                            hasLoaded: true
+                        };
+                    case 'Student Response': {
+                        if (v[1].data === undefined) throw new Error('Invalid data');
+                        return {
+                            data: {
+                                responseField: {
+                                    type: 'studentResponse' as const,
+                                    questionId: v[1].data[0],
+                                    questionName: v[1].data[1]
+                                }
+                            },
+                            hasLoaded: v[1].hasLoaded
+                        };
+                    }
+                }
+            })
+            .build();
+    }
+
+    set wrappedField(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        wrappedField: FormField<SurveyData | undefined, LazyLoadData<SurveyData>, any> &
+            ObservableFormField<LazyLoadData<SurveyData>>
+    ) {
+        this.surveyField = wrappedField;
+        this.subscription = this.surveyField.destValue$.subscribe((x) => this.onValueUpdate(x));
+    }
+
+    private onValueUpdate(key: LazyLoadData<SurveyData>): void {
+        if (isEqual(this.survey, key)) return;
+        const isDataEqual = isEqual(this.survey?.data, key.data);
+        this.survey = key;
+        if (isDataEqual) return;
+        if (this.survey.data === undefined) {
+            this.field.srcValue = [undefined, undefined];
+            return;
+        }
+        this.field.srcValue = [this.survey.data.surveyId, 'studentResponse', undefined];
+        this.field.srcValue = [this.survey.data.surveyId, 'customVariable', undefined];
+    }
+
+    public override set srcValue(value: QuestionProSurveyMixinData | undefined) {
+        if (!this.surveyField) throw new Error('Fail to initialize EarnByQuestionProSurveyFormFieldComponent');
+        this.surveyField.srcValue =
+            value === undefined
+                ? undefined
+                : {
+                      surveyId: value.surveyId,
+                      surveyName: value.surveyName
+                  };
+        if (value !== undefined) {
+            if (value.responseField.type == 'studentResponse') {
+                this.field.srcValue = [
+                    value.surveyId,
+                    'studentResponse',
+                    value.responseField.questionId,
+                    value.responseField.questionName
+                ];
+            } else {
+                this.field.srcValue = [value.surveyId, 'studentResponse', undefined];
+                this.field.srcValue = [value.surveyId, 'customVariable', value.responseField.variableName];
+            }
+        }
+    }
+
+    public override get destValue(): Promise<LazyQuestionProSurveyMixinData> {
+        return (async () => {
+            if (!this.survey || !this.survey.data) throw new Error('Invalid data');
+            const responseField = await this.field.destValue;
+            if (!responseField.data) throw new Error('Invalid data');
+            return {
+                data: {
+                    ...this.survey.data,
+                    ...responseField.data
+                },
+                hasSurveyLoaded: this.survey.hasLoaded,
+                hasQuestionLoaded: responseField.hasLoaded
+            };
+        })();
+    }
+
+    public override async validate(): Promise<boolean> {
+        const surveyRes = await this.surveyField?.validate();
+        const fieldRes = await this.field.validate();
+        return (surveyRes && fieldRes) ?? false;
+    }
+
+    public override set isReadOnly(isReadOnly: boolean) {
+        if (this.surveyField) this.surveyField.isReadOnly = isReadOnly;
+        this.field.isReadOnly = isReadOnly;
+    }
+
+    ngOnInit(): void {
+        if (!this.containerRef) throw new Error('Fail to initialize EarnByQuestionProSurveyFormFieldComponent');
+        this.renderer(this.containerRef);
+    }
+
+    ngOnDestroy() {
+        this.subscription?.unsubscribe();
+    }
+}
+
+@Injectable()
+export class EarnByQuestionProSurveyTokenOptionFieldComponentFactory extends TokenOptionFieldComponentFactory<EarnByQuestionProSurveyTokenOption> {
+    constructor(@Inject(QuestionProService) private questionProService: QuestionProService) {
+        super();
+    }
+
+    public override create(environmentInjector: EnvironmentInjector): [
+        (viewContainerRef: ViewContainerRef) => void,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        FormField<EarnByQuestionProSurveyTokenOption | TokenOptionGroup, EarnByQuestionProSurveyTokenOptionData, any>
+    ] {
+        return tokenOptionFieldComponentBuilder(environmentInjector)
+            .appendBuilder(
+                (
+                    createFieldComponentWithLabel(
+                        LazySingleSelectionFieldComponent<SurveyData>,
+                        'QuestionPro Survey',
+                        environmentInjector
+                    )
+                        .editField((field) => {
+                            field.allowUnselect = true;
+                            field.optionRenderer = (v) => v.surveyName;
+                            field.validator = async ([v, f]: [SurveyData | undefined, typeof field]) => {
+                                f.errorMessage = undefined;
+                                if (v === undefined) {
+                                    f.errorMessage = 'Please select a survey!';
+                                    return false;
+                                }
+                                return true;
+                            };
+                        })
+                        .transformObservableSrc((v: SurveyData | undefined) => [
+                            v,
+                            async () =>
+                                (
+                                    await DataConversionHelper.convertAsyncIterableToList(
+                                        await this.questionProService.getSurveys()
+                                    )
+                                ).map(([surveyId, surveyName]) => ({
+                                    surveyId,
+                                    surveyName
+                                }))
+                        ]) as FormFieldComponentBuilder<
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        FormField<SurveyData | undefined, LazyLoadData<SurveyData>, any> &
+                            ObservableFormField<LazyLoadData<SurveyData>>
+                    >
+                ).wrapSuffix(
+                    createFieldComponentWithLabel(EarnByQuestionProSurveyFormFieldComponent, '', environmentInjector)
+                )
+            )
+            .appendBuilder(createStartTimeComponentBuilder(environmentInjector))
+            .appendBuilder(createEndTimeComponentBuilder(environmentInjector))
+            .transformSrc((value: EarnByQuestionProSurveyTokenOption | TokenOptionGroup) => {
+                if (value instanceof TokenOptionGroup) {
+                    return [
+                        value,
+                        undefined,
+                        set(new Date(), {
+                            hours: 0,
+                            minutes: 0,
+                            seconds: 0,
+                            milliseconds: 0
+                        }),
+                        set(new Date(), {
+                            hours: 23,
+                            minutes: 59,
+                            seconds: 59,
+                            milliseconds: 999
+                        })
+                    ];
+                } else {
+                    return [value, value, value.startTime, value.endTime];
+                }
+            })
+            .transformDest(async ([tokenOptionData, surveyData, startTime, endTime]) => {
+                return {
+                    ...tokenOptionData,
+                    type: 'earn-by-question-pro-survey',
+                    surveyData,
+                    startTime,
+                    endTime
+                };
+            })
+            .appendComp(
+                createComponent(ErrorMessageFieldComponent, {
+                    environmentInjector: environmentInjector
+                })
+            )
+            .modify({
+                validate: async (field, superFunc) => {
+                    const dataField = field.fieldA;
+                    const errField = field.fieldB;
+                    errField.srcValue = undefined;
+                    try {
+                        const superFuncRes = await superFunc();
+                        if (!superFuncRes) {
+                            errField.srcValue =
+                                'Invalid token option data: check error message under each field for details';
+                            return false;
+                        }
+                        const rawData = await dataField.destValue;
+                        const trimmedRawData: typeof rawData | Partial<Pick<typeof rawData, 'surveyData'>> =
+                            structuredClone(rawData);
+                        delete trimmedRawData.surveyData;
+                        const data = {
+                            ...trimmedRawData,
+                            ...rawData.surveyData.data
+                        };
+
+                        if (!EarnByQuestionProSurveyTokenOptionDataDef.is(data)) {
+                            errField.srcValue =
+                                'Invalid token option data: check error message under each field for details';
+                            return false;
+                        }
+                        if (rawData.surveyData.hasSurveyLoaded && rawData.surveyData.hasQuestionLoaded) return true;
+                        if (
+                            !rawData.surveyData.hasSurveyLoaded &&
+                            !(await this.questionProService.hasSurvey(rawData.surveyData.data.surveyId))
+                        ) {
+                            errField.srcValue = 'Invalid QuestionPro survey data: specified survey does not exist';
+                            return false;
+                        }
+                        if (
+                            !rawData.surveyData.hasQuestionLoaded &&
+                            rawData.surveyData.data.responseField.type == 'studentResponse' &&
+                            !(await this.questionProService.hasQuestion(
+                                rawData.surveyData.data.surveyId,
+                                rawData.surveyData.data.responseField.questionId
+                            ))
+                        ) {
+                            errField.srcValue =
+                                'Invalid QuestionPro survey data: specified survey question does not exist';
+                            return false;
+                        }
+                        return true;
+                    } catch (e: unknown) {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        errField.srcValue = `Failed to construct token option data: ${(e as any).toString()}`;
+                        return false;
+                    }
+                }
+            })
+            .transformSrc(
+                (v: EarnByQuestionProSurveyTokenOption | TokenOptionGroup) =>
+                    [v, undefined] as [EarnByQuestionProSurveyTokenOption, undefined] | [TokenOptionGroup, undefined]
+            )
+            .transformDest(async (v) => ({
+                ...v[0],
+                surveyData: undefined,
+                ...v[0].surveyData.data
+            }))
+            .build();
+    }
+    public override get type(): string {
+        return 'earn-by-question-pro-survey';
+    }
+}

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory-registry.ts
@@ -26,6 +26,7 @@ import { SpendForAssignmentExtensionTokenOptionFieldComponentFactory } from './s
 import { SpendForPassingAssignmentTokenOptionFieldComponentFactory } from './spend-for-passing-assignment-token-option-field-component-factory';
 import { PlaceholderTokenOptionFieldComponentFactory } from './placeholder-token-option-field-component-factory';
 import { SpendForAdditionalPointsTokenOptionFieldComponentFactory } from './spend-for-additional-points-token-option-field-component-factory';
+import { EarnByQuestionProSurveyTokenOptionFieldComponentFactory } from './earn-by-question-pro-survey-token-option-field-component-factory';
 
 export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOptionFieldComponentFactory<TokenOption>>[] =
     [
@@ -43,7 +44,8 @@ export const REGISTERED_TOKEN_OPTION_FIELD_COMPONENT_FACTORIES: Type<TokenOption
         SpendForAssignmentExtensionTokenOptionFieldComponentFactory,
         SpendForPassingAssignmentTokenOptionFieldComponentFactory,
         PlaceholderTokenOptionFieldComponentFactory,
-        SpendForAdditionalPointsTokenOptionFieldComponentFactory
+        SpendForAdditionalPointsTokenOptionFieldComponentFactory,
+        EarnByQuestionProSurveyTokenOptionFieldComponentFactory
     ];
 
 export const TOKEN_OPTION_FIELD_COMPONENT_FACTORY_INJECTION_TOKEN = new InjectionToken<

--- a/src/app/token-option-resolvers/token-option-resolver-registry.ts
+++ b/src/app/token-option-resolvers/token-option-resolver-registry.ts
@@ -19,6 +19,7 @@ import { SpendForAssignmentExtensionTokenOption } from 'app/token-options/spend-
 import { SpendForPassingAssignmentTokenOption } from 'app/token-options/spend-for-passing-assignment-token-option';
 import { PlaceholderTokenOption } from 'app/token-options/placeholder-token-option';
 import { SpendForAdditionalPointsTokenOption } from 'app/token-options/spend-for-additional-points-token-option';
+import { EarnByQuestionProSurveyTokenOption } from 'app/token-options/earn-by-question-pro-survey-token-option';
 
 export const REGISTERED_TOKEN_OPTION_RESOLVERS: Type<TokenOptionResolver<TokenOption>>[] = [];
 
@@ -44,7 +45,8 @@ export const DEFAULT_TOKEN_OPTION_RESOLVERS: {
     'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption,
     'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption,
     'placeholder-token-option': PlaceholderTokenOption,
-    'spend-for-additional-points': SpendForAdditionalPointsTokenOption
+    'spend-for-additional-points': SpendForAdditionalPointsTokenOption,
+    'earn-by-question-pro-survey': EarnByQuestionProSurveyTokenOption
 };
 
 interface ITokenOptionType {

--- a/src/app/token-options/earn-by-question-pro-survey-token-option.ts
+++ b/src/app/token-options/earn-by-question-pro-survey-token-option.ts
@@ -1,0 +1,31 @@
+import { QUESTION_PRO_CREDENTIAL_KEY } from 'app/credential-handlers/question-pro-credential-handler';
+import { RequireCredentials } from 'app/services/credential-manager.service';
+import { unwrapValidationFunc } from 'app/utils/validation-unwrapper';
+import * as t from 'io-ts';
+import { EndTimeMixin, EndTimeMixinDataDef } from './mixins/end-time-mixin';
+import { FromDataMixin } from './mixins/from-data-mixin';
+import { QuestionProSurveyMixin, QuestionProSurveyMixinDataDef } from './mixins/question-pro-survey-mixin';
+import { StartTimeMixin, StartTimeMixinDataDef } from './mixins/start-time-mixin';
+import { ToJSONMixin } from './mixins/to-json-mixin';
+import { ATokenOption, TokenOptionDataDef } from './token-option';
+
+export const EarnByQuestionProSurveyTokenOptionDataDef = t.intersection([
+    TokenOptionDataDef,
+    QuestionProSurveyMixinDataDef,
+    StartTimeMixinDataDef,
+    EndTimeMixinDataDef
+]);
+
+export type EarnByQuestionProSurveyTokenOptionData = t.TypeOf<typeof EarnByQuestionProSurveyTokenOptionDataDef>;
+
+export type RawEarnByQuestionProSurveyTokenOptionData = t.OutputOf<typeof EarnByQuestionProSurveyTokenOptionDataDef>;
+
+@RequireCredentials(QUESTION_PRO_CREDENTIAL_KEY)
+export class EarnByQuestionProSurveyTokenOption extends FromDataMixin(
+    ToJSONMixin(
+        EndTimeMixin(StartTimeMixin(QuestionProSurveyMixin(ATokenOption))),
+        EarnByQuestionProSurveyTokenOptionDataDef.encode
+    ),
+    unwrapValidationFunc(EarnByQuestionProSurveyTokenOptionDataDef.decode),
+    EarnByQuestionProSurveyTokenOptionDataDef.is
+) {}

--- a/src/app/token-options/mixins/question-pro-survey-mixin.ts
+++ b/src/app/token-options/mixins/question-pro-survey-mixin.ts
@@ -1,10 +1,10 @@
 import * as t from 'io-ts';
-import type { Constructor } from 'app/utils/mixin-helper';
+import { Base64StringDef, type Constructor } from 'app/utils/mixin-helper';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 
 export const QuestionProSurveyMixinDataDef = t.strict({
     surveyId: t.string,
-    surveyName: t.string,
+    surveyName: Base64StringDef,
     responseField: t.union([
         t.strict({
             type: t.literal('customVariable'),
@@ -13,7 +13,7 @@ export const QuestionProSurveyMixinDataDef = t.strict({
         t.strict({
             type: t.literal('studentResponse'),
             questionId: t.string,
-            questionName: t.string
+            questionName: Base64StringDef
         })
     ])
 });

--- a/src/app/token-options/mixins/question-pro-survey-mixin.ts
+++ b/src/app/token-options/mixins/question-pro-survey-mixin.ts
@@ -1,0 +1,63 @@
+import * as t from 'io-ts';
+import type { Constructor } from 'app/utils/mixin-helper';
+import type { IGridViewDataSource } from './grid-view-data-source-mixin';
+
+export const QuestionProSurveyMixinDataDef = t.strict({
+    surveyId: t.string,
+    surveyName: t.string,
+    responseField: t.union([
+        t.strict({
+            type: t.literal('customVariable'),
+            variableName: t.string
+        }),
+        t.strict({
+            type: t.literal('studentResponse'),
+            questionId: t.string,
+            questionName: t.string
+        })
+    ])
+});
+
+export type QuestionProSurveyMixinData = t.TypeOf<typeof QuestionProSurveyMixinDataDef>;
+export type RawQuestionProSurveyMixinData = t.OutputOf<typeof QuestionProSurveyMixinDataDef>;
+
+export type IQuestionProSurvey = QuestionProSurveyMixinData & IGridViewDataSource;
+
+export function QuestionProSurveyMixin<TBase extends Constructor<IGridViewDataSource>>(Base: TBase) {
+    return class extends Base implements IQuestionProSurvey {
+        surveyId = '';
+        surveyName = '';
+        responseField:
+            | {
+                  type: 'customVariable';
+                  variableName: string;
+              }
+            | {
+                  type: 'studentResponse';
+                  questionId: string;
+                  questionName: string;
+              } = {
+            type: 'customVariable',
+            variableName: ''
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+            this.registerDataPointSource(() => ({
+                colName: 'QuestionPro Survey',
+                type: 'string',
+                value: `${this.surveyName} (${this.surveyId})`
+            }));
+            this.registerDataPointSource(() => ({
+                colName: 'QuestionPro Survey Response Field',
+                type: 'string',
+                value: `${this.responseField.type}: ${
+                    this.responseField.type == 'customVariable'
+                        ? this.responseField.variableName
+                        : this.responseField.questionName + '(' + this.responseField.questionId + ')'
+                }`
+            }));
+        }
+    };
+}

--- a/src/app/token-options/token-option-registry.ts
+++ b/src/app/token-options/token-option-registry.ts
@@ -16,6 +16,7 @@ import { SpendForPassingAssignmentTokenOption } from './spend-for-passing-assign
 import type { Constructor } from 'app/utils/mixin-helper';
 import { PlaceholderTokenOption } from './placeholder-token-option';
 import { SpendForAdditionalPointsTokenOption } from './spend-for-additional-points-token-option';
+import { EarnByQuestionProSurveyTokenOption } from './earn-by-question-pro-survey-token-option';
 
 @Injectable({
     providedIn: 'root'
@@ -38,7 +39,8 @@ export class TokenOptionRegistry {
         'spend-for-assignment-extension': 'Spend Tokens for Canvas Assignment Extension (No Longer Marked Late)',
         'spend-for-passing-assignment': 'Spend Tokens for Assignment / Quiz Grade',
         'placeholder-token-option': 'Placeholder Token Option',
-        'spend-for-additional-points': 'Spend Tokens for Additional Canvas Assignment Points'
+        'spend-for-additional-points': 'Spend Tokens for Additional Canvas Assignment Points',
+        'earn-by-question-pro-survey': 'Earn Tokens by Taking QuestionPro Survey'
     };
 
     private static TOKEN_OPTION_CLASS_REGISTRY: {
@@ -59,7 +61,8 @@ export class TokenOptionRegistry {
         'spend-for-assignment-extension': SpendForAssignmentExtensionTokenOption,
         'spend-for-passing-assignment': SpendForPassingAssignmentTokenOption,
         'placeholder-token-option': PlaceholderTokenOption,
-        'spend-for-additional-points': SpendForAdditionalPointsTokenOption
+        'spend-for-additional-points': SpendForAdditionalPointsTokenOption,
+        'earn-by-question-pro-survey': EarnByQuestionProSurveyTokenOption
     };
 
     public getDescriptiveName(tokenOptionType: string): string | undefined {

--- a/src/app/utils/form-field/form-field-modifier.ts
+++ b/src/app/utils/form-field/form-field-modifier.ts
@@ -3,6 +3,7 @@ import type { ExtractDest, ExtractSrc, ExtractVP, FormField } from './form-field
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormFieldModifierConfig<F extends FormField<any, any, any>> = {
     setIsReadOnly?: (field: F, isReadOnly: boolean, superFunc: (isReadOnly: boolean) => void) => void;
+    validate?: (field: F, superFunc: () => Promise<boolean>) => Promise<boolean>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,6 +55,11 @@ export class FormFieldModifier<F extends FormField<any, any, any>>
     }
 
     public validate(): Promise<boolean> {
-        return this.field.validate();
+        if (!this.config.validate) {
+            return this.field.validate();
+        }
+        return this.config.validate(this.field, () => {
+            return this.field.validate();
+        });
     }
 }

--- a/src/app/utils/form-field/form-field-observable-src-transformer.ts
+++ b/src/app/utils/form-field/form-field-observable-src-transformer.ts
@@ -1,0 +1,53 @@
+import type { Observable } from 'rxjs';
+import type { ExtractSrc, ExtractVP, FormField, ObservableFormField } from './form-field';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class FormFieldObservableSrcTransformer<D, F extends FormField<any, D, any> & ObservableFormField<D>, S1>
+    implements FormField<S1, D, ExtractVP<F>>, ObservableFormField<D>
+{
+    constructor(private field: F, private srcTransformer: (value: S1) => ExtractSrc<F>) {}
+
+    public set label(label: string) {
+        this.field.label = label;
+    }
+
+    public get label(): string {
+        return this.field.label;
+    }
+
+    public set errorMessage(errorMessage: string | undefined) {
+        this.field.errorMessage = errorMessage;
+    }
+
+    public get errorMessage(): string | undefined {
+        return this.field.errorMessage;
+    }
+
+    public set isReadOnly(isReadOnly: boolean) {
+        this.field.isReadOnly = isReadOnly;
+    }
+
+    public get isReadOnly() {
+        return this.field.isReadOnly;
+    }
+
+    public set srcValue(srcValue: S1) {
+        this.field.srcValue = this.srcTransformer(srcValue);
+    }
+
+    public get destValue(): Promise<D> {
+        return this.field.destValue;
+    }
+
+    public get destValue$(): Observable<D> {
+        return this.field.destValue$;
+    }
+
+    public set validator(validator: (value: ExtractVP<F>) => Promise<boolean>) {
+        this.field.validator = validator;
+    }
+
+    public validate(): Promise<boolean> {
+        return this.field.validate();
+    }
+}

--- a/src/app/utils/form-field/form-field-wrapper.ts
+++ b/src/app/utils/form-field/form-field-wrapper.ts
@@ -1,0 +1,19 @@
+import type { FormField } from './form-field';
+import { ForwardFormField } from './forward-form-field';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface FormFieldWrapper<F extends FormField<any, any, any>, S, D, VP> extends FormField<S, D, VP> {
+    set wrappedField(wrappedField: F);
+}
+
+export class FormFieldWrapperApplier<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    F1 extends FormField<any, any, any>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    F2 extends FormFieldWrapper<F1, any, any, any>
+> extends ForwardFormField<F2> {
+    constructor(public fieldA: F1, public fieldB: F2) {
+        super(fieldB);
+        fieldB.wrappedField = fieldA;
+    }
+}

--- a/src/app/utils/form-field/form-field.ts
+++ b/src/app/utils/form-field/form-field.ts
@@ -1,3 +1,5 @@
+import type { Observable } from 'rxjs';
+
 export interface FormField<S, D, VP> {
     set srcValue(srcValue: S);
     get destValue(): Promise<D>;
@@ -6,6 +8,10 @@ export interface FormField<S, D, VP> {
     label: string;
     errorMessage?: string;
     isReadOnly: boolean;
+}
+
+export interface ObservableFormField<V> {
+    get destValue$(): Observable<V>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/utils/form-field/forward-form-field.ts
+++ b/src/app/utils/form-field/forward-form-field.ts
@@ -1,0 +1,128 @@
+import type { ExtractDest, ExtractSrc, ExtractVP, FormField } from './form-field';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class ForwardFormField<F extends FormField<any, any, any>>
+    implements FormField<ExtractSrc<F>, ExtractDest<F>, ExtractVP<F>>
+{
+    private hasCachedIsReadOnly = false;
+    private cachedIsReadOnly = false;
+    private hasCachedSrcValue = false;
+    private cachedSrcValue?: ExtractSrc<F>;
+    private hasCachedValidator = false;
+    private cachedValidator?: (value: ExtractVP<F>) => Promise<boolean>;
+    private hasCachedLabel = false;
+    private cachedLabel?: string;
+    private hasCachedErrorMessage = false;
+    private cachedErrorMessage?: string;
+
+    private _forwardedTo?: F;
+
+    constructor(forwardedTo?: F) {
+        if (forwardedTo) this.forwardedTo = forwardedTo;
+    }
+
+    public set forwardedTo(forwardedTo: F | undefined) {
+        if (!forwardedTo) return;
+        this._forwardedTo = forwardedTo;
+        if (this.hasCachedIsReadOnly) this._forwardedTo.isReadOnly = this.cachedIsReadOnly;
+        if (this.hasCachedSrcValue && this.cachedSrcValue !== undefined)
+            this._forwardedTo.srcValue = this.cachedSrcValue;
+        if (this.hasCachedValidator && this.cachedValidator !== undefined)
+            this._forwardedTo.validator = this.cachedValidator;
+        if (this.hasCachedLabel && this.cachedLabel !== undefined) this._forwardedTo.label = this.cachedLabel;
+        if (this.hasCachedErrorMessage) this._forwardedTo.errorMessage = this.cachedErrorMessage;
+        this.hasCachedIsReadOnly = false;
+        this.hasCachedSrcValue = false;
+        this.hasCachedValidator = false;
+        this.hasCachedLabel = false;
+        this.hasCachedErrorMessage = false;
+    }
+
+    public get forwardedTo(): F | undefined {
+        return this._forwardedTo;
+    }
+
+    public set isReadOnly(isReadOnly: boolean) {
+        if (!this._forwardedTo) {
+            this.hasCachedIsReadOnly = true;
+            this.cachedIsReadOnly = isReadOnly;
+            return;
+        }
+        this._forwardedTo.isReadOnly = isReadOnly;
+    }
+
+    public get isReadOnly(): boolean {
+        if (!this._forwardedTo) return this.hasCachedIsReadOnly ? this.cachedIsReadOnly : true;
+        return this._forwardedTo.isReadOnly;
+    }
+
+    public set srcValue(srcValue: ExtractSrc<F>) {
+        if (!this._forwardedTo) {
+            this.hasCachedSrcValue = true;
+            this.cachedSrcValue = srcValue;
+            return;
+        }
+        this._forwardedTo.srcValue = srcValue;
+    }
+
+    public get destValue(): Promise<ExtractDest<F>> {
+        if (!this._forwardedTo) throw new Error('Forwarded field is not ready yet!');
+        return this._forwardedTo.destValue;
+    }
+
+    public async validate(): Promise<boolean> {
+        if (!this._forwardedTo) return false;
+        return await this._forwardedTo.validate();
+    }
+
+    public set validator(validator: (value: ExtractVP<F>) => Promise<boolean>) {
+        if (!this._forwardedTo) {
+            this.hasCachedValidator = true;
+            this.cachedValidator = validator;
+            return;
+        }
+        this._forwardedTo.validator = validator;
+    }
+
+    public get validator(): (value: ExtractVP<F>) => Promise<boolean> {
+        if (!this._forwardedTo) {
+            if (this.hasCachedValidator && this.cachedValidator !== undefined) return this.cachedValidator;
+            throw new Error('Forwarded field is not ready yet!');
+        }
+        return this._forwardedTo.validator;
+    }
+
+    public set label(label: string) {
+        if (!this._forwardedTo) {
+            this.hasCachedLabel = true;
+            this.cachedLabel = label;
+            return;
+        }
+        this._forwardedTo.label = label;
+    }
+
+    public get label(): string {
+        if (!this._forwardedTo) {
+            if (this.hasCachedLabel && this.cachedLabel !== undefined) return this.cachedLabel;
+            throw new Error('Forwarded field is not ready yet!');
+        }
+        return this._forwardedTo.label;
+    }
+
+    public set errorMessage(errorMessage: string | undefined) {
+        if (!this._forwardedTo) {
+            this.hasCachedErrorMessage = true;
+            this.cachedErrorMessage = errorMessage;
+            return;
+        }
+        this._forwardedTo.errorMessage = errorMessage;
+    }
+
+    public get errorMessage(): string | undefined {
+        if (!this._forwardedTo) {
+            if (this.hasCachedErrorMessage) return this.cachedErrorMessage;
+            throw new Error('Forwarded field is not ready yet!');
+        }
+        return this._forwardedTo.errorMessage;
+    }
+}

--- a/src/app/utils/mixin-helper.ts
+++ b/src/app/utils/mixin-helper.ts
@@ -1,6 +1,8 @@
 import * as t from 'io-ts';
 import { chain } from 'fp-ts/Either';
 import { formatISO, fromUnixTime, getUnixTime, parseISO } from 'date-fns';
+import { Base64 } from 'js-base64';
+import { ErrorSerializer } from './error-serailizer';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Constructor<T = object> = new (...args: any[]) => T;
@@ -26,4 +28,21 @@ export const ISODateDef = new t.Type<Date, string, unknown>(
             return isNaN(res.getTime()) ? t.failure(v, ctx) : t.success(res);
         })(t.string.validate(v, ctx)),
     (v) => formatISO(v)
+);
+
+export const Base64StringDef = new t.Type<string, string | undefined, unknown>(
+    'Base64String',
+    (v): v is string => typeof v == 'string',
+    (v, ctx) => {
+        if (v == undefined) return t.success('');
+        return chain((v: string): t.Validation<string> => {
+            try {
+                const result = Base64.decode(v);
+                return t.success(result);
+            } catch (err: unknown) {
+                return t.failure(v, ctx, ErrorSerializer.serailize(err));
+            }
+        })(t.string.validate(v, ctx));
+    },
+    (v) => Base64.encode(v)
 );

--- a/src/app/utils/pagination/canvas-rest-paginated-result.ts
+++ b/src/app/utils/pagination/canvas-rest-paginated-result.ts
@@ -1,0 +1,60 @@
+import type { IPCCompatibleAxiosResponse } from 'app/services/axios.service';
+import type { PaginatedResult } from './paginated-result';
+
+export class CanvasRESTPaginatedResult<T> implements PaginatedResult<T> {
+    private data: T[];
+    private nextURL: string | undefined;
+    private requestHandler: (url: string) => Promise<IPCCompatibleAxiosResponse>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private dataProcessor: (data: any) => T[];
+
+    constructor(
+        response: IPCCompatibleAxiosResponse,
+        requestHandler: (url: string) => Promise<IPCCompatibleAxiosResponse>,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dataProcessor: (data: any) => T[]
+    ) {
+        this.data = dataProcessor(response.data);
+        this.nextURL = this.extractNextURL(response);
+        this.requestHandler = requestHandler;
+        this.dataProcessor = dataProcessor;
+    }
+
+    private extractNextURL(response: IPCCompatibleAxiosResponse): string | undefined {
+        const linkHeader = response.headers['link'];
+        if (!linkHeader) return undefined;
+        for (const link of (linkHeader as string).split(',')) {
+            if (link.endsWith('rel="next"')) {
+                const rawNextLink = link.split(';')[0];
+                return rawNextLink?.substring(1, rawNextLink.length - 1);
+            }
+        }
+        return undefined;
+    }
+
+    private hasNextPage() {
+        return this.nextURL != undefined;
+    }
+
+    private async fetchNextPage() {
+        if (!this.nextURL) return;
+        const response = await this.requestHandler(this.nextURL);
+        this.data.push(...this.dataProcessor(response.data));
+        this.nextURL = this.extractNextURL(response);
+    }
+
+    private async *generator(): AsyncIterator<T> {
+        let index = 0;
+        while (this.hasNextPage() || index != this.data.length) {
+            if (index == this.data.length) await this.fetchNextPage();
+            if (index == this.data.length) return;
+            const result = this.data[index++];
+            if (result === undefined) throw new Error('Index out of bounds');
+            yield result;
+        }
+    }
+
+    public [Symbol.asyncIterator]() {
+        return this.generator();
+    }
+}

--- a/src/app/utils/pagination/paginated-result.ts
+++ b/src/app/utils/pagination/paginated-result.ts
@@ -1,0 +1,1 @@
+export type PaginatedResult<T> = AsyncIterable<T>;

--- a/src/app/utils/pagination/question-pro-paginated-result.ts
+++ b/src/app/utils/pagination/question-pro-paginated-result.ts
@@ -31,7 +31,7 @@ export class QuestionProPaginatedResult<T> implements PaginatedResult<T> {
     private async fetchNextPage() {
         if (!this.nextURL) return;
         const response = await this.requestHandler(this.nextURL);
-        this.data.push(...this.dataProcessor(response.data));
+        this.data.push(...this.dataProcessor(response.data?.['response']));
         this.nextURL = this.extractNextURL(response);
     }
 

--- a/src/app/utils/pagination/question-pro-paginated-result.ts
+++ b/src/app/utils/pagination/question-pro-paginated-result.ts
@@ -1,6 +1,7 @@
 import type { IPCCompatibleAxiosResponse } from 'app/services/axios.service';
+import type { PaginatedResult } from './paginated-result';
 
-export class PaginatedResult<T> implements AsyncIterable<T> {
+export class QuestionProPaginatedResult<T> implements PaginatedResult<T> {
     private data: T[];
     private nextURL: string | undefined;
     private requestHandler: (url: string) => Promise<IPCCompatibleAxiosResponse>;
@@ -13,22 +14,14 @@ export class PaginatedResult<T> implements AsyncIterable<T> {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         dataProcessor: (data: any) => T[]
     ) {
-        this.data = dataProcessor(response.data);
+        this.data = dataProcessor(response.data?.['response']);
         this.nextURL = this.extractNextURL(response);
         this.requestHandler = requestHandler;
         this.dataProcessor = dataProcessor;
     }
 
     private extractNextURL(response: IPCCompatibleAxiosResponse): string | undefined {
-        const linkHeader = response.headers['link'];
-        if (!linkHeader) return undefined;
-        for (const link of (linkHeader as string).split(',')) {
-            if (link.endsWith('rel="next"')) {
-                const rawNextLink = link.split(';')[0];
-                return rawNextLink?.substring(1, rawNextLink.length - 1);
-            }
-        }
-        return undefined;
+        return response.data?.['pagination']?.['links']?.['next'];
     }
 
     private hasNextPage() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@
 
 // https://stackoverflow.com/a/75264128
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const requireModule = (import.meta as any).webpackContext('./app/credential-handlers', {
+const requireModule = (import.meta as any).webpackContext('./app/credential-handlers/', {
+    recursive: true,
     regExp: /\.ts$/
 });
 requireModule.keys().forEach(requireModule);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,5 +6,5 @@
         "types": ["@angular/localize"]
     },
     "files": ["src/main.ts"],
-    "include": ["src/**/*.d.ts"]
+    "include": ["src/**/*.d.ts", "src/app/credential-handlers/**/*.ts"]
 }


### PR DESCRIPTION
### Description

A new type of token option (earn tokens by taking QuestionPro survey) is implemented in this pull request. This token option type allows a student to earn tokens by taking a QuestionPro survey. In addition to default configurations for a token option, the following configurations are available for this type of token option:

1.  QuestionPro Survey (single selection with options being surveys owned by the QuestionPro user whose credential is provided to Token ATM)
2.  Collect Email From (“Custom Variable” or “Student Response”)
    1.  If “Custom Variable” is selected, Custom Variable Name (text) needs to be configured.
    2.  If “Student Response” is selected, Question for Email (single selection with options of questions in the specified QuestionPro survey) needs to be configured.  
          
        Note: only the following three types of questions will be displayed:
        *   Contact Information: The email entry will be treated as a question
        *   Single Row Text: Each row will be treated as a separate question
        *   Email Address: Each row will be treated as a separate question
3.  Can Request From
4.  Can Request Until

Due to the QuestionPro API call limitation, the following mitigation is implemented:

*   For any configuration that involves communication with QuestionPro, the communication will be delayed until the user manually triggers it. Specifically, there are two configurations fall into this type: QuestionPro Survey and Question for Email. Both of them are single-selection fields, and their options will not be loaded until the user clicks the refresh button.
*   Field validations that requires communication with QuestionPro will be delayed until the token option is being saved. Specifically, after all other validations have been performed, the following two checks will be made:
    *   If the user did not load options for QuestionPro Survey field, the existence of the specified QuestionPro survey will be checked.
    *   If the user selected “Student Response” for the Collect Email From field and did not load options for the Question for Email field, the existence of the specified question will be checked.

A student's request will be approved only if all following conditions met:

1.  The request is submitted at a time no earlier than the start date.
2.  The request is submitted at a time no later than the end date.
3.  The student does not have an approved request for this token option.
4.  The student's email address in Canvas is found in the configured field (either a custom variable or a student's manual response to a question) of a completed survey response.

When approved, Token ATM will apply the configured token balance change.

### Provide QuestionPro Credential

This token option requires communication with QuestionPro, therefore QuestionPro credential needs to be provided. The following three fields are needed:

1.  [Environment (ENV)](https://www.questionpro.com/api/environments.html)
2.  User ID: could be obtained by clicking the avatar on the top-right corner → clicking My Account. Customer ID shown in this page is the User ID.
3.  API Key: could be obtained by clicking any survey → selecting Integration in the menu → clicking API. The API Key is obtainable by activate the API access. The user needs to be allowed by the organization manager to get API access.

Similar to #103, QuestionPro credential is optional, and the behaviors of viewing/editing token option and request processing are the same as described in #103 when QuestionPro credential is missing.

Note: due to the QuestionPro API call limitation, validation of QuestionPro credential will not be performed when saving it or logging in. Instead, a “Validate” button is added to the credential configuration modal for QuestionPro to allow the user to manually validate the provided QuestionPro credential.

### Testing Note

Please test if the new type of token option works as described.