### PR TITLE
Enhancement check credentials before api calls

### DIFF
--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -83,6 +83,7 @@ export class CanvasService {
         config?: AxiosRequestConfig
     ): Promise<IPCCompatibleAxiosResponse<T>> {
         const executor = async () => {
+            if (!this.hasCredentialConfigured()) throw new Error('Canvas credential is not configured!');
             return await this.axiosService.request<T>({
                 ...config,
                 url: this.#url + endpoint,
@@ -108,6 +109,7 @@ export class CanvasService {
 
     private async paginatedRequestHandler<T>(url: string): Promise<IPCCompatibleAxiosResponse<T>> {
         const executor = async () => {
+            if (!this.hasCredentialConfigured()) throw new Error('Canvas credential is not configured!');
             return await this.axiosService.request<T>({
                 url: url,
                 headers: {

--- a/src/app/services/qualtrics.service.ts
+++ b/src/app/services/qualtrics.service.ts
@@ -121,6 +121,7 @@ export class QualtricsService {
         while (true) {
             try {
                 const executor = async () => {
+                    if (!this.hasCredentialConfigured()) throw new Error('Qualtrics credential is not configured!');
                     const result = await this.axiosService.request<T>({
                         ...config,
                         url: this.#qualtricsURL + endpoint,


### PR DESCRIPTION
Enhancement that adds checking for the existence of credentials before performing any API call (implemented for Canvas and Qualtrics).

#### Testing Notes

Check that before an axios request the necessary credentials exist.