### PR TITLE
Enhancement: Make TimeZone Optional for DateTimeField

### DIFF
--- a/src/app/components/export-request-modal/export-request-modal.component.ts
+++ b/src/app/components/export-request-modal/export-request-modal.component.ts
@@ -100,7 +100,7 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         OptionalFieldComponent<
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            FormField<[Date, string, [Date, string]], [Date, Date], any>
+                            FormField<[Date | [Date, string], Date | [Date, string]], [Date, Date], any>
                         >,
                         'Specify a time range for requests',
                         this.environmentInjector
@@ -110,6 +110,7 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
                             'Include Requests Since',
                             this.environmentInjector
                         )
+                            .transformSrc((v: [Date | [Date, string]]) => v[0])
                             .appendBuilder(
                                 createFieldComponentWithLabel(
                                     DateTimeFieldComponent,
@@ -120,7 +121,7 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
                             .appendVP(
                                 async (field) =>
                                     <[DateTimeFieldComponent, DateTimeFieldComponent, [Date, Date]]>[
-                                        field.fieldA,
+                                        field.fieldA.field,
                                         field.fieldB,
                                         await field.destValue
                                     ]
@@ -160,8 +161,7 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
                 [
                     ExportRequestModalComponent.IS_TIME_RANGE_FILTER_ENABLED,
                     [
-                        ExportRequestModalComponent.SAVED_START_TIME,
-                        this.configuration.course.timeZone,
+                        [ExportRequestModalComponent.SAVED_START_TIME, this.configuration.course.timeZone],
                         [ExportRequestModalComponent.SAVED_END_TIME, this.configuration.course.timeZone]
                     ]
                 ],

--- a/src/app/components/form-fields/date-time-field/date-time-field.component.ts
+++ b/src/app/components/form-fields/date-time-field/date-time-field.component.ts
@@ -9,7 +9,7 @@ import formatInTimeZone from 'date-fns-tz/formatInTimeZone';
     styleUrls: ['./date-time-field.component.sass']
 })
 export class DateTimeFieldComponent extends BaseFormField<
-    [Date, string],
+    Date | [Date, string],
     Date,
     [DateTimeFieldComponent, Date, boolean]
 > {
@@ -56,7 +56,7 @@ export class DateTimeFieldComponent extends BaseFormField<
         this.courseTime = `Course Time: ${formatInTimeZone(this.value, this.courseTimeZone, 'MMM dd, yyyy HH:mm:ss')}`;
     }
 
-    public override set srcValue(srcValue: [Date, string]) {
+    public override set srcValue(srcValue: Date | [Date, string]) {
         if (Array.isArray(srcValue)) {
             this.value = srcValue[0];
             this.courseTimeZone = srcValue[1];

--- a/src/app/components/form-fields/multiple-section-date-field/multiple-section-date-field.component.ts
+++ b/src/app/components/form-fields/multiple-section-date-field/multiple-section-date-field.component.ts
@@ -32,7 +32,7 @@ export class MultipleSectionDateFieldComponent
     fieldId = v4();
     @Input() dateFieldBuilderFactory?: () => FormFieldComponentBuilder<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        FormField<[Date, string], Date, any>
+        FormField<Date | [Date, string], Date, any>
     >;
 
     @Input() defaultDateValueProvider?: () => Date;
@@ -50,7 +50,11 @@ export class MultipleSectionDateFieldComponent
     private _label = '';
     private _isReadOnly = false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private _defaultDateField?: FormField<[Date, string], Date, [FormField<[Date, string], Date, any>, Date, boolean]>;
+    private _defaultDateField?: FormField<
+        Date | [Date, string],
+        Date,
+        [FormField<Date | [Date, string], Date, any>, Date, boolean]
+    >;
     private isInitialized = false;
     private _delayedInitValue?: [string, string, Date | MultipleSectionDateMatcher];
 

--- a/src/app/data/assignment-group.ts
+++ b/src/app/data/assignment-group.ts
@@ -16,7 +16,7 @@ export class AssignmentGroup implements AssignmentGroupData {
 }
 
 export const AssignmentGroupDef = new t.Type<AssignmentGroup, unknown, unknown>(
-    'Assignment',
+    'AssignmentGroup',
     (v): v is AssignmentGroup => v instanceof AssignmentGroup,
     (v, ctx) =>
         chain((v: AssignmentGroupData) => t.success(Object.assign(new AssignmentGroup(), v)))(

--- a/src/app/data/canvas-identifier.ts
+++ b/src/app/data/canvas-identifier.ts
@@ -16,7 +16,7 @@ export class CanvasIdentifier implements CanvasIdentifierData {
 }
 
 export const CanvasIdentifierDef = new t.Type<CanvasIdentifier, unknown, unknown>(
-    'Assignment',
+    'CanvasIdentifier',
     (v): v is CanvasIdentifier => v instanceof CanvasIdentifier,
     (v, ctx) =>
         chain((v: CanvasIdentifierData) => t.success(Object.assign(new CanvasIdentifier(), v)))(

--- a/src/app/data/course.ts
+++ b/src/app/data/course.ts
@@ -23,7 +23,7 @@ export class Course implements CourseData {
 }
 
 export const CourseDef = new t.Type<Course, unknown, unknown>(
-    'Assignment',
+    'Course',
     (v): v is Course => v instanceof Course,
     (v, ctx) =>
         chain((v: CourseData) => t.success(Object.assign(new Course(), v)))(

--- a/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
+++ b/src/app/token-option-field-component-factories/token-option-field-component-factory.ts
@@ -254,7 +254,7 @@ export function createNewDueTimeComponentBuilder(
 
 export function createMultipleSectionDateComponentBuilder(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dateFieldBuilderFactory: () => FormFieldComponentBuilder<FormField<[Date, string], Date, any>>,
+    dateFieldBuilderFactory: () => FormFieldComponentBuilder<FormField<Date | [Date, string], Date, any>>,
     label: string,
     environmentInjector: EnvironmentInjector,
     defaultDateProvider?: () => Date

--- a/src/app/utils/form-field/form-field-src-transformer.ts
+++ b/src/app/utils/form-field/form-field-src-transformer.ts
@@ -4,7 +4,7 @@ import type { ExtractDest, ExtractSrc, ExtractVP, FormField } from './form-field
 export class FormFieldSrcTransformer<F extends FormField<any, any, any>, S1>
     implements FormField<S1, ExtractDest<F>, ExtractVP<F>>
 {
-    constructor(private field: F, private srcTransformer: (value: S1) => ExtractSrc<F>) {}
+    constructor(public field: F, private srcTransformer: (value: S1) => ExtractSrc<F>) {}
 
     public set label(label: string) {
         this.field.label = label;


### PR DESCRIPTION
### Description

This pull request changes `srcValue` of `DateTimeFieldComponent` to support `Date`, which makes the TimeZone argument optional. It also includes fixes to several io-ts type name typos.

### Testing Note
Please test if the enhancement works as described.
