### PR TITLE
Enhancement: Resize Survey Responses Page Size for QuestionPro HTTP 413 Error Request Entity Too Large

### DIFF
--- a/src/app/services/question-pro.service.spec.ts
+++ b/src/app/services/question-pro.service.spec.ts
@@ -1,16 +1,152 @@
-// import { TestBed } from '@angular/core/testing';
+import { QuestionProService } from './question-pro.service';
+import { type AxiosService } from './axios.service';
 
-// import { QuestionProService } from './question-pro.service';
+describe('QuestionProService', () => {
+    let service: QuestionProService;
+    let fakeAxiosService: jasmine.SpyObj<AxiosService>;
 
-// describe('QuestionProService', () => {
-//     let service: QuestionProService;
+    beforeEach(async () => {
+        fakeAxiosService = jasmine.createSpyObj<AxiosService>('AxiosService', ['request']);
+        service = new QuestionProService(fakeAxiosService);
 
-//     beforeEach(() => {
-//         TestBed.configureTestingModule({});
-//         service = TestBed.inject(QuestionProService);
-//     });
+        // Configure Credentials
+        await service.configureCredential({
+            questionProEnv: 'test',
+            questionProUserId: 'null',
+            questionProAPIKey: 'null'
+        });
+    });
 
-//     it('should be created', () => {
-//         expect(service).toBeTruthy();
-//     });
-// });
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+        expect(fakeAxiosService).toBeTruthy();
+    });
+
+    describe('Testing Survey Response Collection', () => {
+        it('Non- 413 and 404 Errors are passed on', async () => {
+            fakeAxiosService.request.and.returnValue(Promise.reject(new Error('Some Random Error')));
+
+            await expectAsync(
+                service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+            ).toBeRejectedWithError(Error, 'Some Random Error');
+        });
+
+        it('404 Response short-circuits & doesn’t throw error', async () => {
+            const http_404 = {
+                isAxiosError: true,
+                response: { status: 404 }
+            };
+
+            fakeAxiosService.request.and.returnValue(Promise.reject(http_404));
+
+            await expectAsync(
+                service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+            ).not.toBeRejectedWithError();
+            expect(fakeAxiosService.request).toHaveBeenCalledTimes(1);
+        });
+
+        describe('413 Response Errors', () => {
+            const http_413 = {
+                isAxiosError: true,
+                response: { status: 413, data: { response: { error: { httpStatusCode: 413, message: '' } } } }
+            };
+            it('Reaching upper bound of retries throws error', async () => {
+                const MAX_RETRIES = 3;
+
+                fakeAxiosService.request.and.returnValue(Promise.reject(http_413));
+
+                await expectAsync(
+                    service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+                ).toBeRejectedWithError();
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(MAX_RETRIES);
+            });
+
+            it('Single retry defaults to halving page size', async () => {
+                fakeAxiosService.request.and.returnValues(
+                    Promise.reject(http_413),
+                    Promise.resolve({ data: { response: [''] } })
+                );
+
+                await expectAsync(
+                    service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+                ).toBeResolved();
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(2);
+                expect(fakeAxiosService.request.calls.mostRecent().args[0].params.perPage).toBe(500);
+            });
+
+            it('Double retry defaults to quartering page size', async () => {
+                fakeAxiosService.request.and.returnValues(
+                    Promise.reject(http_413),
+                    Promise.reject(http_413),
+                    Promise.resolve({ data: { response: ['', ''] } })
+                );
+
+                await expectAsync(
+                    service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+                ).toBeResolved();
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(3);
+                expect(fakeAxiosService.request.calls.mostRecent().args[0].params.perPage).toBe(250);
+            });
+
+            const message_413 = (message: string): typeof http_413 => {
+                const result = structuredClone(http_413);
+                result.response.data.response.error.message = message;
+                return result;
+            };
+            it('Retry page size with largest suggested number', async () => {
+                fakeAxiosService.request.and.returnValues(
+                    Promise.reject(message_413('1, 5, text text, 80.00, 100, text 750.1')),
+                    Promise.resolve({ data: { response: [''] } })
+                );
+
+                await expectAsync(
+                    service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+                ).toBeResolved();
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(2);
+                expect(fakeAxiosService.request.calls.mostRecent().args[0].params.perPage).toBe(750);
+            });
+
+            it('Retry page size is constrained by previous sizes', async () => {
+                fakeAxiosService.request.and.returnValues(
+                    Promise.reject(http_413),
+                    Promise.reject(message_413('1, 5, text text, 80.00, 100, text 750.1')),
+                    Promise.resolve({ data: { response: [''] } })
+                );
+
+                await expectAsync(
+                    service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+                ).toBeResolved();
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(3);
+                expect(fakeAxiosService.request.calls.mostRecent().args[0].params.perPage).toBe(100);
+            });
+
+            it('Retry page size won’t except 0 as a suggestion', async () => {
+                fakeAxiosService.request.and.returnValues(
+                    Promise.reject(http_413),
+                    Promise.reject(message_413('0, 0000, 0000, 0000000')),
+                    Promise.resolve({ data: { response: [''] } })
+                );
+
+                await expectAsync(
+                    service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+                ).toBeResolved();
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(3);
+                expect(fakeAxiosService.request.calls.mostRecent().args[0].params.perPage).toBe(250);
+            });
+
+            it('Error after a 413 is noted', async () => {
+                fakeAxiosService.request.and.returnValues(
+                    Promise.reject(http_413),
+                    Promise.reject('Some Random Error')
+                );
+
+                await expectAsync(
+                    service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
+                ).toBeRejectedWithError(
+                    Error,
+                    'Error occured while attempting to handle QuestionPro Responses Page Size Change (Attempt: 2)'
+                );
+            });
+        });
+    });
+});

--- a/src/app/services/question-pro.service.spec.ts
+++ b/src/app/services/question-pro.service.spec.ts
@@ -51,14 +51,14 @@ describe('QuestionProService', () => {
                 response: { status: 413, data: { response: { error: { httpStatusCode: 413, message: '' } } } }
             };
             it('Reaching upper bound of retries throws error', async () => {
-                const MAX_RETRIES = 3;
+                const MAX_ATTEMPTS = 3;
 
                 fakeAxiosService.request.and.returnValue(Promise.reject(http_413));
 
                 await expectAsync(
                     service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
                 ).toBeRejectedWithError();
-                expect(fakeAxiosService.request).toHaveBeenCalledTimes(MAX_RETRIES);
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(MAX_ATTEMPTS);
             });
 
             it('Single retry defaults to halving page size', async () => {
@@ -144,7 +144,7 @@ describe('QuestionProService', () => {
                     service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1')
                 ).toBeRejectedWithError(
                     Error,
-                    'Error occured while attempting to handle QuestionPro Responses Page Size Change (Attempt: 2)'
+                    'Error occurred while attempting to handle QuestionPro Responses Page Size Change (Attempt: 2)'
                 );
             });
         });

--- a/src/app/services/question-pro.service.spec.ts
+++ b/src/app/services/question-pro.service.spec.ts
@@ -50,9 +50,8 @@ describe('QuestionProService', () => {
                 isAxiosError: true,
                 response: { status: 413, data: { response: { error: { httpStatusCode: 413, message: '' } } } }
             };
+            const MAX_ATTEMPTS = 3;
             it('Reaching upper bound of retries throws error', async () => {
-                const MAX_ATTEMPTS = 3;
-
                 fakeAxiosService.request.and.returnValue(Promise.reject(http_413));
 
                 await expectAsync(
@@ -146,6 +145,46 @@ describe('QuestionProService', () => {
                     Error,
                     'Error occurred while attempting to handle QuestionPro Responses Page Size Change (Attempt: 2)'
                 );
+            });
+
+            it('Error causes from previous retries are collected', async () => {
+                const mes1 = '1, 5, text text, 80.00, 100, text 750.1';
+                const mes3 = 'Non-Digit containing message';
+                const pageMes = 'QuestionPro Page Size Too Large';
+                fakeAxiosService.request.and.returnValues(
+                    Promise.reject(message_413(mes1)), // Returned after Page Size: 1000
+                    Promise.reject(http_413), // Returned after Page Size: 750
+                    Promise.reject(message_413(mes3)) // Returned after Page Size 375
+                );
+
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                let error: any;
+                try {
+                    await service.checkParticipation('1', { type: 'customVariable', variableName: 'custom4' }, '1');
+                } catch (e: unknown) {
+                    error = e;
+                }
+
+                // Outer Error Wrapper
+                expect(error).toBeTruthy();
+                expect(error?.cause).toBeTruthy();
+                expect(error?.message).toEqual(
+                    `Failed to handle QuestionPro Responses Page Size Change in ${MAX_ATTEMPTS} attempts`
+                );
+
+                // Inner Retry Errors
+                expect(error?.cause?.previous?.message).toEqual(pageMes);
+                expect(error?.cause?.previous?.cause?.error).toEqual(message_413(mes3));
+                expect(error?.cause?.previous?.cause?.previous?.message).toEqual(pageMes);
+                expect(error?.cause?.previous?.cause?.previous?.cause?.error).toEqual(http_413);
+                expect(error?.cause?.previous?.cause?.previous?.cause?.previous?.message).toEqual(pageMes);
+                expect(error?.cause?.previous?.cause?.previous?.cause?.previous?.cause?.error).toEqual(
+                    message_413(mes1)
+                );
+
+                // Axios Service Request Double Check
+                expect(fakeAxiosService.request).toHaveBeenCalledTimes(3);
+                expect(fakeAxiosService.request.calls.mostRecent().args[0].params.perPage).toBe(375);
             });
         });
     });

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -218,7 +218,7 @@ export class QuestionProService {
                 // HTTP 413 means page size needs to be reduced and responses collected again
                 if (
                     err?.isAxiosError &&
-                    err?.reponse?.status === 413 &&
+                    err?.response?.status === 413 &&
                     err?.response?.data?.response?.error?.httpStatusCode === 413
                 ) {
                     responses = undefined;

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -186,24 +186,21 @@ export class QuestionProService {
         let responses: unknown[] | undefined = undefined;
         let curPerPage = QuestionProService.PER_PAGE_MAX;
         let collectedErrors: Error | undefined = undefined;
-        const collectResponses = async (): Promise<unknown[]> => {
-            const pagination = new QuestionProPaginatedResult(
-                await this.#rawAPIRequest(`/surveys/${surveyId}/responses`, {
-                    params: {
-                        perPage: curPerPage,
-                        page: 1
-                    }
-                }),
-                (url: string) => this.#paginatedRequest(url),
-                (v) => v
-            );
-            const responses = [];
-            for await (const response of pagination) responses.push(response);
-            return responses;
-        };
+
         while (responses === undefined) {
             try {
-                responses = await collectResponses();
+                const paginatedResponses = new QuestionProPaginatedResult(
+                    await this.#rawAPIRequest(`/surveys/${surveyId}/responses`, {
+                        params: {
+                            perPage: curPerPage,
+                            page: 1
+                        }
+                    }),
+                    (url: string) => this.#paginatedRequest(url),
+                    (v) => v
+                );
+                responses = [];
+                for await (const response of paginatedResponses) responses.push(response);
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (err: any) {
                 // HTTP 404 means no responses

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -203,12 +203,16 @@ export class QuestionProService {
                 for await (const response of paginatedResponses) responses.push(response);
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (err: any) {
+                // Clear any collected responses
+                if (responses) responses.length = 0;
+
                 // HTTP 404 means no responses
                 if (err?.isAxiosError && err?.response?.status === 404) {
-                    responses = [];
+                    if (responses === undefined) responses = [];
                     break;
                 }
-                // HTTP 413 means page size needs to be reduced and drop any previously collected responses
+
+                // HTTP 413 means page size needs to be reduced and responses collected again
                 if (
                     err?.isAxiosError &&
                     err?.reponse?.status === 413 &&
@@ -220,6 +224,7 @@ export class QuestionProService {
                     )
                         .map((x) => parseInt(x, 10))
                         .filter((x) => Number.isFinite(x) && x < curPerPage && x > 0);
+
                     // 0 < newPerPage < curPerPage
                     curPerPage =
                         suggestedPageSizes.length > 0 ? Math.max(...suggestedPageSizes) : Math.ceil(curPerPage / 2);

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -244,9 +244,11 @@ export class QuestionProService {
                 }
             }
         }
-        return (async function* (responses?: unknown[]) {
+        return (async function* (responses: unknown[] | undefined) {
             if (responses == null) {
-                /* empty */
+                throw new Error(
+                    'Question Pro Survey Responses could not be collected. Try again later, or contact the Token ATM Developers'
+                );
             } else {
                 for (const response of responses) {
                     yield response;

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -15,7 +15,6 @@ export class QuestionProService {
     #apiKey?: string;
 
     static readonly PER_PAGE_MAX = 1000;
-    perPage?: number = 950; // TODO: Improve this band aid fix, so we handle 413 errors in Paginated Requests
 
     private participationCache: Map<string, Map<string, Set<string>>> = new Map<string, Map<string, Set<string>>>();
 
@@ -184,25 +183,74 @@ export class QuestionProService {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private async getResponses(surveyId: string): Promise<PaginatedResult<any>> {
-        try {
-            return new QuestionProPaginatedResult(
+        let responses: unknown[] | undefined = undefined;
+        let curPerPage = QuestionProService.PER_PAGE_MAX;
+        let collectedErrors: Error | undefined = undefined;
+        const collectResponses = async (): Promise<unknown[]> => {
+            const pagination = new QuestionProPaginatedResult(
                 await this.#rawAPIRequest(`/surveys/${surveyId}/responses`, {
                     params: {
-                        perPage: this.perPage ?? QuestionProService.PER_PAGE_MAX,
+                        perPage: curPerPage,
                         page: 1
                     }
                 }),
                 (url: string) => this.#paginatedRequest(url),
                 (v) => v
             );
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
-            if (err?.isAxiosError && err?.response?.status === 404) {
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                return (async function* () {})();
+            const responses = [];
+            for await (const response of pagination) responses.push(response);
+            return responses;
+        };
+        while (responses === undefined) {
+            try {
+                responses = await collectResponses();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } catch (err: any) {
+                // HTTP 404 means no responses
+                if (err?.isAxiosError && err?.response?.status === 404) {
+                    responses = [];
+                    break;
+                }
+                // HTTP 413 means page size needs to be reduced and drop any previously collected responses
+                if (
+                    err?.isAxiosError &&
+                    err?.reponse?.status === 413 &&
+                    err?.response?.data?.response?.error?.httpStatusCode === 413
+                ) {
+                    responses = undefined;
+                    const suggestedPageSizes = (
+                        (err?.response?.data?.response?.error?.message as string | undefined)?.match(/\d+/g) ?? []
+                    )
+                        .map((x) => parseInt(x, 10))
+                        .filter((x) => Number.isFinite(x) && x < curPerPage && x > 0);
+                    // 0 < newPerPage < curPerPage
+                    curPerPage =
+                        suggestedPageSizes.length > 0 ? Math.max(...suggestedPageSizes) : Math.ceil(curPerPage / 2);
+
+                    // HTTP 413 errors could conceivably happen multiple times, so track previous errors
+                    collectedErrors = new Error('QuestionPro Page Size Too Large', {
+                        cause: { error: err, previous: collectedErrors }
+                    });
+                    continue;
+                }
+                if (collectedErrors == null) {
+                    throw err;
+                } else {
+                    throw new Error('Failed to handle QuestionPro Responses Page Size Change', {
+                        cause: { error: err, previous: collectedErrors }
+                    });
+                }
             }
-            throw err;
         }
+        return (async function* (responses?: unknown[]) {
+            if (responses == null) {
+                /* empty */
+            } else {
+                for (const response of responses) {
+                    yield response;
+                }
+            }
+        })(responses);
     }
 
     public async hasQuestion(surveyId: string, questionId: string): Promise<boolean> {

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -186,8 +186,11 @@ export class QuestionProService {
         let responses: unknown[] | undefined = undefined;
         let curPerPage = QuestionProService.PER_PAGE_MAX;
         let collectedErrors: Error | undefined = undefined;
+        let count = 0;
+        const MAX_TRYS = 3;
 
-        while (responses === undefined) {
+        while (responses === undefined && count < MAX_TRYS) {
+            count++;
             try {
                 const paginatedResponses = new QuestionProPaginatedResult(
                     await this.#rawAPIRequest(`/surveys/${surveyId}/responses`, {
@@ -238,11 +241,24 @@ export class QuestionProService {
                 if (collectedErrors == null) {
                     throw err;
                 } else {
-                    throw new Error('Failed to handle QuestionPro Responses Page Size Change', {
-                        cause: { error: err, previous: collectedErrors }
-                    });
+                    throw new Error(
+                        `Error occured while attempting to handle QuestionPro Responses Page Size Change (Attempt: ${count})`,
+                        {
+                            cause: { error: err, previous: collectedErrors }
+                        }
+                    );
                 }
             }
+        }
+        if (count === MAX_TRYS) {
+            throw new Error(
+                `Failed to handle QuestionPro Responses Page Size Change in ${MAX_TRYS} attempts`,
+                collectedErrors != null
+                    ? {
+                          cause: { previous: collectedErrors }
+                      }
+                    : undefined
+            );
         }
         return (async function* (responses: unknown[] | undefined) {
             if (responses == null) {

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -186,11 +186,11 @@ export class QuestionProService {
         let responses: unknown[] | undefined = undefined;
         let curPerPage = QuestionProService.PER_PAGE_MAX;
         let collectedErrors: Error | undefined = undefined;
-        let count = 0;
-        const MAX_TRYS = 3;
+        let attempt = 0;
+        const MAX_ATTEMPTS = 3;
 
-        while (responses === undefined && count < MAX_TRYS) {
-            count++;
+        while (responses === undefined && attempt < MAX_ATTEMPTS) {
+            attempt++;
             try {
                 const paginatedResponses = new QuestionProPaginatedResult(
                     await this.#rawAPIRequest(`/surveys/${surveyId}/responses`, {
@@ -242,7 +242,7 @@ export class QuestionProService {
                     throw err;
                 } else {
                     throw new Error(
-                        `Error occured while attempting to handle QuestionPro Responses Page Size Change (Attempt: ${count})`,
+                        `Error occurred while attempting to handle QuestionPro Responses Page Size Change (Attempt: ${attempt})`,
                         {
                             cause: { error: err, previous: collectedErrors }
                         }
@@ -250,9 +250,9 @@ export class QuestionProService {
                 }
             }
         }
-        if (count === MAX_TRYS && responses === undefined) {
+        if (attempt === MAX_ATTEMPTS && responses === undefined) {
             throw new Error(
-                `Failed to handle QuestionPro Responses Page Size Change in ${MAX_TRYS} attempts`,
+                `Failed to handle QuestionPro Responses Page Size Change in ${attempt} attempts`,
                 collectedErrors != null
                     ? {
                           cause: { previous: collectedErrors }

--- a/src/app/services/question-pro.service.ts
+++ b/src/app/services/question-pro.service.ts
@@ -250,7 +250,7 @@ export class QuestionProService {
                 }
             }
         }
-        if (count === MAX_TRYS) {
+        if (count === MAX_TRYS && responses === undefined) {
             throw new Error(
                 `Failed to handle QuestionPro Responses Page Size Change in ${MAX_TRYS} attempts`,
                 collectedErrors != null

--- a/src/app/utils/error-serializer.ts
+++ b/src/app/utils/error-serializer.ts
@@ -4,7 +4,9 @@ export class ErrorSerializer {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public static serialize(err: any): string {
         let result = '\ntoString() result: \n' + err.toString();
+        if (err.cause != null) result += `\nCause: ` + err.cause.toString();
         result += '\nJSON result: \n' + stringify(err);
+        if (err.cause != null) result += `\nCause: ` + stringify(err.cause);
         return result;
     }
 }

--- a/src/app/utils/global-error-handler.ts
+++ b/src/app/utils/global-error-handler.ts
@@ -6,6 +6,7 @@ export class GlobalErrorHandler implements ErrorHandler {
     public handleError(error: any) {
         if (isDevMode()) {
             console.error(error);
+            if (error.cause != null) console.error('Cause:', error.cause);
             return;
         }
         const win = window.open('about:blank', '_blank');


### PR DESCRIPTION
### Description

Continuation of #127. This bugfix/enhancement automatically resizes the the Survey Responses Page Size based on a suggested size returned in the error message. If a suggested size isn't given or is <= 0 or >= `currentPageSize`, then the `currentPageSize` is halved by default (`Math.ceil` is used to prevent a 0 page size).

If multiple integers are found in the error message, the largest value that is less than the `currentPageSize` is used.

#### Functionality
- Up to three Attempts at gathering student responses is allowed.
- Any error resets the intermediate array of responses to 0.
- Non 413 (and 404) errors are re-thrown.
- All previous errors causing retries are included as Error Causes in subsequent thrown error

This enhancement also includes printing/serializing error causes. If they exist, they are now printed/serialized (either in the error console when in dev mode, or stringified when caught by Token ATM). [This may is a workaround for [chrome not displaying `cause` in the console](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause#browser_compatibility) automatically.]

### Testing Note

Unit tests have been made for specific error cases. Smoke testing is sufficient. Thorough testing requires creating a Question Pro Survey with large/numerous enough responses to result in a 413 error.

- [x] Add Automated tests