### PR TITLE
Enhancement: Make empty defaults in Config into optional props

### DIFF
--- a/src/app/token-options/earn-by-survey/earn-by-survey-token-option.spec.ts
+++ b/src/app/token-options/earn-by-survey/earn-by-survey-token-option.spec.ts
@@ -1,4 +1,4 @@
-import { isLeft } from 'fp-ts/lib/Either';
+import { isLeft, isRight } from 'fp-ts/lib/Either';
 import { Base64 } from 'js-base64';
 import {
     EarnBySurveyTokenOptionDataDef,
@@ -9,6 +9,7 @@ import {
 import { fromUnixTime, getUnixTime } from 'date-fns';
 import type { TokenOptionGroup } from 'app/data/token-option-group';
 import { TO_BE_SUPER_SET_OF_MATCHER } from 'app/utils/test/to-be-super-set-of-matcher';
+import { genRawEarnBySurveyDataEquivs } from 'app/utils/test/generate-raw-equivalents';
 
 describe('EarnBySurveyTokenOption', () => {
     const testDate = fromUnixTime(getUnixTime(new Date()));
@@ -38,6 +39,20 @@ describe('EarnBySurveyTokenOption', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         delete (result as any)['surveyId'];
         return [v, result];
+    });
+
+    it('genRawDataEquivs contains the previous validRawValue(s)', () => {
+        for (const [valid, raw] of validRawValuesPair) {
+            const b = Array.from(genRawEarnBySurveyDataEquivs(valid));
+            let i = 0;
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for (const _ of genRawEarnBySurveyDataEquivs(valid)) {
+                i++;
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect(b).toContain(raw as any);
+            expect(b.length).toBeLessThanOrEqual(i);
+        }
     });
     const invalidValues = [
         {},
@@ -95,13 +110,25 @@ describe('EarnBySurveyTokenOption', () => {
     ];
 
     describe('EarnBySurveyTokenOptionDataDef', () => {
-        validRawValuesPair.forEach(([expected, value]) => {
-            it(`should decode successfully with valid raw value ${JSON.stringify(value)}`, () => {
-                const result = EarnBySurveyTokenOptionDataDef.decode(value);
-                expect(isLeft(result)).toBeFalse();
-                if (!isLeft(result)) expect(result.right).toEqual(expected);
-            });
-        });
+        for (const expected of validValues) {
+            for (const value of genRawEarnBySurveyDataEquivs(expected)) {
+                it(`should decode successfully with valid raw value ${JSON.stringify(value)}`, () => {
+                    const result = EarnBySurveyTokenOptionDataDef.decode(value);
+                    expect(isLeft(result)).toBeFalse();
+                    if (!isLeft(result)) expect(result.right).toEqual(expected);
+                });
+            }
+        }
+
+        for (const expected of validValues) {
+            for (const value of genRawEarnBySurveyDataEquivs(expected, true)) {
+                it(`should decode successfully all extra raw data values based on ${JSON.stringify(value)}`, () => {
+                    const result = EarnBySurveyTokenOptionDataDef.decode(value);
+                    expect(isLeft(result)).toBeFalse();
+                    expect(isRight(result)).toBeTrue();
+                });
+            }
+        }
 
         invalidRawValues.forEach((value) => {
             it(`should fail to decode with invalid raw value ${JSON.stringify(value)}`, () => {
@@ -122,15 +149,13 @@ describe('EarnBySurveyTokenOption', () => {
             });
         });
 
-        validRawValuesPair.forEach(([value, expected]) => {
+        for (const value of validValues) {
             it(`should encode successfully with valid value ${JSON.stringify(value)}`, () => {
                 const result = EarnBySurveyTokenOptionDataDef.encode(value);
-                expect(result).toEqual({
-                    ...expected,
-                    description: expected.description ?? ''
-                });
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect(Array.from(genRawEarnBySurveyDataEquivs(value))).toContain(result as any);
             });
-        });
+        }
     });
 
     describe('EarnBySurveyTokenOption', () => {
@@ -217,11 +242,13 @@ describe('EarnBySurveyTokenOption', () => {
             expect(value.endTime).toEqual(date);
         });
 
-        validRawValuesPair.forEach(([data, rawData]) => {
-            it(`should decode successfully with raw data ${JSON.stringify(rawData)}`, () => {
-                expect(value.fromRawData(rawData)).toBeSupersetOf(data);
-            });
-        });
+        for (const data of validValues) {
+            for (const rawData of genRawEarnBySurveyDataEquivs(data)) {
+                it(`should decode successfully with raw data ${JSON.stringify(rawData)}`, () => {
+                    expect(value.fromRawData(rawData)).toBeSupersetOf(data);
+                });
+            }
+        }
 
         invalidRawValues.forEach((rawData) => {
             it(`should fail to decode with invalid raw data ${JSON.stringify(rawData)}`, () => {
@@ -242,14 +269,12 @@ describe('EarnBySurveyTokenOption', () => {
             });
         });
 
-        validRawValuesPair.forEach(([data, rawData]) => {
+        for (const data of validValues) {
             it(`should encode successfully to raw data with data ${JSON.stringify(data)}`, () => {
                 const result = value.fromData(data).toJSON();
-                expect(result).toEqual({
-                    ...rawData,
-                    description: rawData.description ?? ''
-                });
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect(Array.from(genRawEarnBySurveyDataEquivs(data))).toContain(result as any);
             });
-        });
+        }
     });
 });

--- a/src/app/token-options/earn-by-survey/earn-by-survey-token-option.spec.ts
+++ b/src/app/token-options/earn-by-survey/earn-by-survey-token-option.spec.ts
@@ -9,7 +9,7 @@ import {
 import { fromUnixTime, getUnixTime } from 'date-fns';
 import type { TokenOptionGroup } from 'app/data/token-option-group';
 import { TO_BE_SUPER_SET_OF_MATCHER } from 'app/utils/test/to-be-super-set-of-matcher';
-import { genRawEarnBySurveyDataEquivs } from 'app/utils/test/generate-raw-equivalents';
+import { genRawEarnBySurveyDataEquivalents } from 'app/utils/test/generate-raw-equivalents';
 
 describe('EarnBySurveyTokenOption', () => {
     const testDate = fromUnixTime(getUnixTime(new Date()));
@@ -41,12 +41,12 @@ describe('EarnBySurveyTokenOption', () => {
         return [v, result];
     });
 
-    it('genRawDataEquivs contains the previous validRawValue(s)', () => {
+    it('genRawDataEquivalents contains the previous validRawValue(s)', () => {
         for (const [valid, raw] of validRawValuesPair) {
-            const b = Array.from(genRawEarnBySurveyDataEquivs(valid));
+            const b = Array.from(genRawEarnBySurveyDataEquivalents(valid));
             let i = 0;
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            for (const _ of genRawEarnBySurveyDataEquivs(valid)) {
+            for (const _ of genRawEarnBySurveyDataEquivalents(valid)) {
                 i++;
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -111,7 +111,7 @@ describe('EarnBySurveyTokenOption', () => {
 
     describe('EarnBySurveyTokenOptionDataDef', () => {
         for (const expected of validValues) {
-            for (const value of genRawEarnBySurveyDataEquivs(expected)) {
+            for (const value of genRawEarnBySurveyDataEquivalents(expected)) {
                 it(`should decode successfully with valid raw value ${JSON.stringify(value)}`, () => {
                     const result = EarnBySurveyTokenOptionDataDef.decode(value);
                     expect(isLeft(result)).toBeFalse();
@@ -121,7 +121,7 @@ describe('EarnBySurveyTokenOption', () => {
         }
 
         for (const expected of validValues) {
-            for (const value of genRawEarnBySurveyDataEquivs(expected, true)) {
+            for (const value of genRawEarnBySurveyDataEquivalents(expected, true)) {
                 it(`should decode successfully all extra raw data values based on ${JSON.stringify(value)}`, () => {
                     const result = EarnBySurveyTokenOptionDataDef.decode(value);
                     expect(isLeft(result)).toBeFalse();
@@ -153,7 +153,7 @@ describe('EarnBySurveyTokenOption', () => {
             it(`should encode successfully with valid value ${JSON.stringify(value)}`, () => {
                 const result = EarnBySurveyTokenOptionDataDef.encode(value);
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                expect(Array.from(genRawEarnBySurveyDataEquivs(value))).toContain(result as any);
+                expect(Array.from(genRawEarnBySurveyDataEquivalents(value))).toContain(result as any);
             });
         }
     });
@@ -243,7 +243,7 @@ describe('EarnBySurveyTokenOption', () => {
         });
 
         for (const data of validValues) {
-            for (const rawData of genRawEarnBySurveyDataEquivs(data)) {
+            for (const rawData of genRawEarnBySurveyDataEquivalents(data)) {
                 it(`should decode successfully with raw data ${JSON.stringify(rawData)}`, () => {
                     expect(value.fromRawData(rawData)).toBeSupersetOf(data);
                 });
@@ -273,7 +273,7 @@ describe('EarnBySurveyTokenOption', () => {
             it(`should encode successfully to raw data with data ${JSON.stringify(data)}`, () => {
                 const result = value.fromData(data).toJSON();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                expect(Array.from(genRawEarnBySurveyDataEquivs(data))).toContain(result as any);
+                expect(Array.from(genRawEarnBySurveyDataEquivalents(data))).toContain(result as any);
             });
         }
     });

--- a/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
@@ -1,34 +1,34 @@
 import * as t from 'io-ts';
-// import { chain } from 'fp-ts/Either';
 import { type Constructor, DateDef } from 'app/utils/mixin-helper';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
 
-export const OptionalMultipleSectionEndTimeMixinDataDef = t.strict({
+const MultipleSectionEndTimeMixinDataDef = t.strict({
     endTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
 });
 
-// type MultipleSectionEndTimeMixinData = t.TypeOf<typeof MultipleSectionEndTimeMixinDataDef>;
-// const PartialMultipleSectionEndTimeMixinDataDef = t.exact(t.partial(MultipleSectionEndTimeMixinDataDef.type.props));
-// type PartialMultipleSectionEndTimeMixinData = t.TypeOf<typeof PartialMultipleSectionEndTimeMixinDataDef>;
+type MultipleSectionEndTimeMixinData = t.TypeOf<typeof MultipleSectionEndTimeMixinDataDef>;
+const PartialMultipleSectionEndTimeMixinDataDef = t.exact(t.partial(MultipleSectionEndTimeMixinDataDef.type.props));
+type RawPartialMultipleSectionEndTimeMixinData = t.OutputOf<typeof PartialMultipleSectionEndTimeMixinDataDef>;
 
 // TODO: Make Utility for constructing this kind of `io-ts` Type
 // (see also `optional-multiple-section-start-time-mixin.ts`)
-// export const OptionalMultipleSectionEndTimeMixinDataDef = new t.Type<
-//     MultipleSectionEndTimeMixinData,
-//     PartialMultipleSectionEndTimeMixinData,
-//     unknown
-// >(
-//     'OptionalMultipleSectionEndTimeMixinDataDef',
-//     MultipleSectionEndTimeMixinDataDef.is,
-//     (v, ctx) =>
-//         chain((v: PartialMultipleSectionEndTimeMixinData): t.Validation<MultipleSectionEndTimeMixinData> => {
-//             return v.endTime === undefined
-//                 ? t.success({ endTime: null })
-//                 : MultipleSectionEndTimeMixinDataDef.validate(v, ctx);
-//         })(PartialMultipleSectionEndTimeMixinDataDef.validate(v, ctx)),
-//     (v) => (v.endTime === null ? { endTime: undefined } : { endTime: v.endTime })
-// );
+export const OptionalMultipleSectionEndTimeMixinDataDef = new t.Type<
+    MultipleSectionEndTimeMixinData,
+    RawPartialMultipleSectionEndTimeMixinData,
+    unknown
+>(
+    'OptionalMultipleSectionEndTimeMixinDataDef',
+    MultipleSectionEndTimeMixinDataDef.is,
+    (v, ctx) => {
+        if (PartialMultipleSectionEndTimeMixinDataDef.is(v) && v.endTime === undefined) {
+            return t.success({ endTime: null });
+        } else {
+            return MultipleSectionEndTimeMixinDataDef.validate(v, ctx);
+        }
+    },
+    (v) => (v.endTime === null ? { endTime: undefined } : MultipleSectionEndTimeMixinDataDef.encode(v))
+);
 
 export type OptionalMultipleSectionEndTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;
 export type RawOptionalMultipleSectionEndTimeMixinData = t.OutputOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;

--- a/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
@@ -1,11 +1,34 @@
 import * as t from 'io-ts';
+import { chain } from 'fp-ts/Either';
 import { type Constructor, DateDef } from 'app/utils/mixin-helper';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
 
-export const OptionalMultipleSectionEndTimeMixinDataDef = t.strict({
+const MultipleSectionEndTimeMixinDataDef = t.strict({
     endTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
 });
+
+type MultipleSectionEndTimeMixinData = t.TypeOf<typeof MultipleSectionEndTimeMixinDataDef>;
+const PartialMultipleSectionEndTimeMixinDataDef = t.exact(t.partial(MultipleSectionEndTimeMixinDataDef.type.props));
+type PartialMultipleSectionEndTimeMixinData = t.TypeOf<typeof PartialMultipleSectionEndTimeMixinDataDef>;
+
+// TODO: Make Utility for constructing this kind of `io-ts` Type
+// (see also `optional-multiple-section-start-time-mixin.ts`)
+export const OptionalMultipleSectionEndTimeMixinDataDef = new t.Type<
+    MultipleSectionEndTimeMixinData,
+    PartialMultipleSectionEndTimeMixinData,
+    unknown
+>(
+    'OptionalMultipleSectionEndTimeMixinDataDef',
+    MultipleSectionEndTimeMixinDataDef.is,
+    (v, ctx) =>
+        chain((v: PartialMultipleSectionEndTimeMixinData): t.Validation<MultipleSectionEndTimeMixinData> => {
+            return v.endTime === undefined
+                ? t.success({ endTime: null })
+                : MultipleSectionEndTimeMixinDataDef.validate(v, ctx);
+        })(PartialMultipleSectionEndTimeMixinDataDef.validate(v, ctx)),
+    (v) => (v.endTime === null ? { endTime: undefined } : { endTime: v.endTime })
+);
 
 export type OptionalMultipleSectionEndTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;
 export type RawOptionalMultipleSectionEndTimeMixinData = t.OutputOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;

--- a/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-end-time-mixin.ts
@@ -1,34 +1,34 @@
 import * as t from 'io-ts';
-import { chain } from 'fp-ts/Either';
+// import { chain } from 'fp-ts/Either';
 import { type Constructor, DateDef } from 'app/utils/mixin-helper';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
 
-const MultipleSectionEndTimeMixinDataDef = t.strict({
+export const OptionalMultipleSectionEndTimeMixinDataDef = t.strict({
     endTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
 });
 
-type MultipleSectionEndTimeMixinData = t.TypeOf<typeof MultipleSectionEndTimeMixinDataDef>;
-const PartialMultipleSectionEndTimeMixinDataDef = t.exact(t.partial(MultipleSectionEndTimeMixinDataDef.type.props));
-type PartialMultipleSectionEndTimeMixinData = t.TypeOf<typeof PartialMultipleSectionEndTimeMixinDataDef>;
+// type MultipleSectionEndTimeMixinData = t.TypeOf<typeof MultipleSectionEndTimeMixinDataDef>;
+// const PartialMultipleSectionEndTimeMixinDataDef = t.exact(t.partial(MultipleSectionEndTimeMixinDataDef.type.props));
+// type PartialMultipleSectionEndTimeMixinData = t.TypeOf<typeof PartialMultipleSectionEndTimeMixinDataDef>;
 
 // TODO: Make Utility for constructing this kind of `io-ts` Type
 // (see also `optional-multiple-section-start-time-mixin.ts`)
-export const OptionalMultipleSectionEndTimeMixinDataDef = new t.Type<
-    MultipleSectionEndTimeMixinData,
-    PartialMultipleSectionEndTimeMixinData,
-    unknown
->(
-    'OptionalMultipleSectionEndTimeMixinDataDef',
-    MultipleSectionEndTimeMixinDataDef.is,
-    (v, ctx) =>
-        chain((v: PartialMultipleSectionEndTimeMixinData): t.Validation<MultipleSectionEndTimeMixinData> => {
-            return v.endTime === undefined
-                ? t.success({ endTime: null })
-                : MultipleSectionEndTimeMixinDataDef.validate(v, ctx);
-        })(PartialMultipleSectionEndTimeMixinDataDef.validate(v, ctx)),
-    (v) => (v.endTime === null ? { endTime: undefined } : { endTime: v.endTime })
-);
+// export const OptionalMultipleSectionEndTimeMixinDataDef = new t.Type<
+//     MultipleSectionEndTimeMixinData,
+//     PartialMultipleSectionEndTimeMixinData,
+//     unknown
+// >(
+//     'OptionalMultipleSectionEndTimeMixinDataDef',
+//     MultipleSectionEndTimeMixinDataDef.is,
+//     (v, ctx) =>
+//         chain((v: PartialMultipleSectionEndTimeMixinData): t.Validation<MultipleSectionEndTimeMixinData> => {
+//             return v.endTime === undefined
+//                 ? t.success({ endTime: null })
+//                 : MultipleSectionEndTimeMixinDataDef.validate(v, ctx);
+//         })(PartialMultipleSectionEndTimeMixinDataDef.validate(v, ctx)),
+//     (v) => (v.endTime === null ? { endTime: undefined } : { endTime: v.endTime })
+// );
 
 export type OptionalMultipleSectionEndTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;
 export type RawOptionalMultipleSectionEndTimeMixinData = t.OutputOf<typeof OptionalMultipleSectionEndTimeMixinDataDef>;

--- a/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
@@ -1,33 +1,33 @@
 import * as t from 'io-ts';
-// import { chain } from 'fp-ts/Either';
 import { type Constructor, DateDef } from 'app/utils/mixin-helper';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
 
-export const OptionalMultipleSectionStartTimeMixinDataDef = t.strict({
+const MultipleSectionStartTimeMixinDataDef = t.strict({
     startTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
 });
-// type MultipleSectionStartTimeMixinData = t.TypeOf<typeof MultipleSectionStartTimeMixinDataDef>;
-// const PartialMultipleSectionStartTimeMixinDataDef = t.exact(t.partial(MultipleSectionStartTimeMixinDataDef.type.props));
-// type PartialMultipleSectionStartTimeMixinData = t.TypeOf<typeof PartialMultipleSectionStartTimeMixinDataDef>;
+type MultipleSectionStartTimeMixinData = t.TypeOf<typeof MultipleSectionStartTimeMixinDataDef>;
+const PartialMultipleSectionStartTimeMixinDataDef = t.exact(t.partial(MultipleSectionStartTimeMixinDataDef.type.props));
+type RawPartialMultipleSectionStartTimeMixinData = t.OutputOf<typeof PartialMultipleSectionStartTimeMixinDataDef>;
 
-// // TODO: Make Utility for constructing this kind of `io-ts` Type
-// // (see also `optional-multiple-section-end-time-mixin.ts`)
-// export const OptionalMultipleSectionStartTimeMixinDataDef = new t.Type<
-//     MultipleSectionStartTimeMixinData,
-//     PartialMultipleSectionStartTimeMixinData,
-//     unknown
-// >(
-//     'OptionalMultipleSectionStartTimeMixinDataDef',
-//     MultipleSectionStartTimeMixinDataDef.is,
-//     (v, ctx) =>
-//         chain((v: PartialMultipleSectionStartTimeMixinData): t.Validation<MultipleSectionStartTimeMixinData> => {
-//             return v.startTime === undefined
-//                 ? t.success({ startTime: null })
-//                 : MultipleSectionStartTimeMixinDataDef.validate(v, ctx);
-//         })(PartialMultipleSectionStartTimeMixinDataDef.validate(v, ctx)),
-//     (v) => (v.startTime === null ? { startTime: undefined } : { startTime: v.startTime })
-// );
+// TODO: Make Utility for constructing this kind of `io-ts` Type
+// (see also `optional-multiple-section-end-time-mixin.ts`)
+export const OptionalMultipleSectionStartTimeMixinDataDef = new t.Type<
+    MultipleSectionStartTimeMixinData,
+    RawPartialMultipleSectionStartTimeMixinData,
+    unknown
+>(
+    'OptionalMultipleSectionStartTimeMixinDataDef',
+    MultipleSectionStartTimeMixinDataDef.is,
+    (v, ctx) => {
+        if (PartialMultipleSectionStartTimeMixinDataDef.is(v) && v.startTime === undefined) {
+            return t.success({ startTime: null });
+        } else {
+            return MultipleSectionStartTimeMixinDataDef.validate(v, ctx);
+        }
+    },
+    (v) => (v.startTime === null ? { startTime: undefined } : MultipleSectionStartTimeMixinDataDef.encode(v))
+);
 
 export type OptionalMultipleSectionStartTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionStartTimeMixinDataDef>;
 export type RawOptionalMultipleSectionStartTimeMixinData = t.OutputOf<

--- a/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
@@ -1,33 +1,33 @@
 import * as t from 'io-ts';
-import { chain } from 'fp-ts/Either';
+// import { chain } from 'fp-ts/Either';
 import { type Constructor, DateDef } from 'app/utils/mixin-helper';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
 
-const MultipleSectionStartTimeMixinDataDef = t.strict({
+export const OptionalMultipleSectionStartTimeMixinDataDef = t.strict({
     startTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
 });
-type MultipleSectionStartTimeMixinData = t.TypeOf<typeof MultipleSectionStartTimeMixinDataDef>;
-const PartialMultipleSectionStartTimeMixinDataDef = t.exact(t.partial(MultipleSectionStartTimeMixinDataDef.type.props));
-type PartialMultipleSectionStartTimeMixinData = t.TypeOf<typeof PartialMultipleSectionStartTimeMixinDataDef>;
+// type MultipleSectionStartTimeMixinData = t.TypeOf<typeof MultipleSectionStartTimeMixinDataDef>;
+// const PartialMultipleSectionStartTimeMixinDataDef = t.exact(t.partial(MultipleSectionStartTimeMixinDataDef.type.props));
+// type PartialMultipleSectionStartTimeMixinData = t.TypeOf<typeof PartialMultipleSectionStartTimeMixinDataDef>;
 
-// TODO: Make Utility for constructing this kind of `io-ts` Type
-// (see also `optional-multiple-section-end-time-mixin.ts`)
-export const OptionalMultipleSectionStartTimeMixinDataDef = new t.Type<
-    MultipleSectionStartTimeMixinData,
-    PartialMultipleSectionStartTimeMixinData,
-    unknown
->(
-    'OptionalMultipleSectionStartTimeMixinDataDef',
-    MultipleSectionStartTimeMixinDataDef.is,
-    (v, ctx) =>
-        chain((v: PartialMultipleSectionStartTimeMixinData): t.Validation<MultipleSectionStartTimeMixinData> => {
-            return v.startTime === undefined
-                ? t.success({ startTime: null })
-                : MultipleSectionStartTimeMixinDataDef.validate(v, ctx);
-        })(PartialMultipleSectionStartTimeMixinDataDef.validate(v, ctx)),
-    (v) => (v.startTime === null ? { startTime: undefined } : { startTime: v.startTime })
-);
+// // TODO: Make Utility for constructing this kind of `io-ts` Type
+// // (see also `optional-multiple-section-end-time-mixin.ts`)
+// export const OptionalMultipleSectionStartTimeMixinDataDef = new t.Type<
+//     MultipleSectionStartTimeMixinData,
+//     PartialMultipleSectionStartTimeMixinData,
+//     unknown
+// >(
+//     'OptionalMultipleSectionStartTimeMixinDataDef',
+//     MultipleSectionStartTimeMixinDataDef.is,
+//     (v, ctx) =>
+//         chain((v: PartialMultipleSectionStartTimeMixinData): t.Validation<MultipleSectionStartTimeMixinData> => {
+//             return v.startTime === undefined
+//                 ? t.success({ startTime: null })
+//                 : MultipleSectionStartTimeMixinDataDef.validate(v, ctx);
+//         })(PartialMultipleSectionStartTimeMixinDataDef.validate(v, ctx)),
+//     (v) => (v.startTime === null ? { startTime: undefined } : { startTime: v.startTime })
+// );
 
 export type OptionalMultipleSectionStartTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionStartTimeMixinDataDef>;
 export type RawOptionalMultipleSectionStartTimeMixinData = t.OutputOf<

--- a/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
+++ b/src/app/token-options/mixins/optional-multiple-section-start-time-mixin.ts
@@ -1,11 +1,33 @@
 import * as t from 'io-ts';
+import { chain } from 'fp-ts/Either';
 import { type Constructor, DateDef } from 'app/utils/mixin-helper';
 import type { IGridViewDataSource } from './grid-view-data-source-mixin';
 import { MultipleSectionDateMatcher, MultipleSectionDateMatcherDef } from 'app/utils/multiple-section-date-matcher';
 
-export const OptionalMultipleSectionStartTimeMixinDataDef = t.strict({
+const MultipleSectionStartTimeMixinDataDef = t.strict({
     startTime: t.union([DateDef, MultipleSectionDateMatcherDef, t.null])
 });
+type MultipleSectionStartTimeMixinData = t.TypeOf<typeof MultipleSectionStartTimeMixinDataDef>;
+const PartialMultipleSectionStartTimeMixinDataDef = t.exact(t.partial(MultipleSectionStartTimeMixinDataDef.type.props));
+type PartialMultipleSectionStartTimeMixinData = t.TypeOf<typeof PartialMultipleSectionStartTimeMixinDataDef>;
+
+// TODO: Make Utility for constructing this kind of `io-ts` Type
+// (see also `optional-multiple-section-end-time-mixin.ts`)
+export const OptionalMultipleSectionStartTimeMixinDataDef = new t.Type<
+    MultipleSectionStartTimeMixinData,
+    PartialMultipleSectionStartTimeMixinData,
+    unknown
+>(
+    'OptionalMultipleSectionStartTimeMixinDataDef',
+    MultipleSectionStartTimeMixinDataDef.is,
+    (v, ctx) =>
+        chain((v: PartialMultipleSectionStartTimeMixinData): t.Validation<MultipleSectionStartTimeMixinData> => {
+            return v.startTime === undefined
+                ? t.success({ startTime: null })
+                : MultipleSectionStartTimeMixinDataDef.validate(v, ctx);
+        })(PartialMultipleSectionStartTimeMixinDataDef.validate(v, ctx)),
+    (v) => (v.startTime === null ? { startTime: undefined } : { startTime: v.startTime })
+);
 
 export type OptionalMultipleSectionStartTimeMixinData = t.TypeOf<typeof OptionalMultipleSectionStartTimeMixinDataDef>;
 export type RawOptionalMultipleSectionStartTimeMixinData = t.OutputOf<

--- a/src/app/token-options/placeholder-token-option/placeholder-token-option.spec.ts
+++ b/src/app/token-options/placeholder-token-option/placeholder-token-option.spec.ts
@@ -36,6 +36,18 @@ describe('PlaceholderTokenOption', () => {
             ...validTemplate,
             startTime: new MultipleSectionDateMatcher(testDate),
             endTime: new MultipleSectionDateMatcher(testDate)
+        },
+        {
+            ...validTemplate,
+            startTime: new MultipleSectionDateMatcher(testDate, [
+                { sections: [['', ''] as const, ['a', 'b']], name: '', date: testDate }
+            ])
+        },
+        {
+            ...validTemplate,
+            endTime: new MultipleSectionDateMatcher(testDate, [
+                { sections: [['', ''] as const, ['a', 'b']], name: '', date: testDate }
+            ])
         }
     ];
 

--- a/src/app/token-options/placeholder-token-option/placeholder-token-option.spec.ts
+++ b/src/app/token-options/placeholder-token-option/placeholder-token-option.spec.ts
@@ -1,0 +1,230 @@
+import { isLeft, isRight } from 'fp-ts/lib/Either';
+import {
+    PlaceholderTokenOption,
+    type PlaceholderTokenOptionData,
+    PlaceholderTokenOptionDataDef
+} from './placeholder-token-option';
+import { fromUnixTime, getUnixTime } from 'date-fns';
+import { genRawPlaceholderDataEquivs } from 'app/utils/test/generate-raw-equivalents';
+import { MultipleSectionDateMatcher } from 'app/utils/multiple-section-date-matcher';
+import type { TokenOptionGroup } from 'app/data/token-option-group';
+import { TO_BE_SUPER_SET_OF_MATCHER } from 'app/utils/test/to-be-super-set-of-matcher';
+
+describe('PlaceholderTokenOption', () => {
+    const testDate = fromUnixTime(getUnixTime(new Date()));
+
+    const validTemplate: PlaceholderTokenOptionData = {
+        type: 'placeholder-token-option',
+        id: 1,
+        name: 'A',
+        description: '',
+        tokenBalanceChange: 0,
+        isMigrating: undefined,
+        startTime: null,
+        endTime: null,
+        allowedRequestCnt: 1,
+        excludeTokenOptionIds: []
+    };
+    const validValues: PlaceholderTokenOptionData[] = [
+        validTemplate,
+        {
+            ...validTemplate,
+            startTime: testDate,
+            endTime: testDate
+        },
+        {
+            ...validTemplate,
+            startTime: new MultipleSectionDateMatcher(testDate),
+            endTime: new MultipleSectionDateMatcher(testDate)
+        }
+    ];
+
+    const invalidValues: unknown[] = [
+        {},
+        { ...validTemplate, startTime: undefined },
+        { ...validTemplate, endTime: undefined },
+        { ...validTemplate, excludeTokenOptionIds: undefined }
+    ];
+    const invalidRawValues: unknown[] = [{}];
+
+    describe('PlaceholderTokenOptionDataDef', () => {
+        for (const expected of validValues) {
+            for (const value of genRawPlaceholderDataEquivs(expected)) {
+                it(`should decode successfully with valid raw value ${JSON.stringify(value)}`, () => {
+                    const result = PlaceholderTokenOptionDataDef.decode(value);
+                    if (isLeft(result)) {
+                        console.log('E:', expected);
+                        console.log('V:', value);
+                    }
+                    expect(isLeft(result)).toBeFalse();
+                    if (!isLeft(result)) expect(result.right).toEqual(expected);
+                });
+            }
+        }
+
+        for (const expected of validValues) {
+            for (const value of genRawPlaceholderDataEquivs(expected, true)) {
+                it(`should decode successfully all extra raw data based on ${JSON.stringify(value)}`, () => {
+                    const result = PlaceholderTokenOptionDataDef.decode(value);
+                    expect(isLeft(result)).toBeFalse();
+                    expect(isRight(result)).toBeTrue();
+                });
+            }
+        }
+
+        for (const value of invalidRawValues) {
+            it(`should fail to decode with invalid raw value ${JSON.stringify(value)}`, () => {
+                const result = PlaceholderTokenOptionDataDef.decode(value);
+                expect(isLeft(result)).toBeTrue();
+            });
+        }
+
+        for (const value of validValues) {
+            it(`should validate successfully with valid value ${JSON.stringify(value)}`, () => {
+                expect(PlaceholderTokenOptionDataDef.is(value)).toBeTrue();
+            });
+        }
+
+        for (const value of invalidValues) {
+            it(`should fail to validate with invalid value ${JSON.stringify(value)}`, () => {
+                expect(PlaceholderTokenOptionDataDef.is(value)).toBeFalse();
+            });
+        }
+
+        for (const value of validValues) {
+            it(`should encode successfully with valid value ${JSON.stringify(value)}`, () => {
+                const equalRawValues = Array.from(genRawPlaceholderDataEquivs(value));
+                const result = PlaceholderTokenOptionDataDef.encode(value);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect(equalRawValues).toContain(result as any);
+            });
+        }
+    });
+
+    describe('PlaceholderTokenOption', () => {
+        let value: PlaceholderTokenOption;
+
+        beforeEach(() => {
+            value = new PlaceholderTokenOption();
+            jasmine.addMatchers(TO_BE_SUPER_SET_OF_MATCHER);
+        });
+
+        it('should have property `type`', () => {
+            expect(value.type).toEqual('');
+            value.type = 'A';
+            expect(value.type).toEqual('A');
+        });
+
+        it('should have property `id`', () => {
+            expect(value.id).toEqual(-1);
+            value.id = 1;
+            expect(value.id).toEqual(1);
+        });
+
+        it('should have property `name`', () => {
+            expect(value.name).toEqual('');
+            value.name = 'Name';
+            expect(value.name).toEqual('Name');
+        });
+
+        it('should have property `description`', () => {
+            expect(value.description).toEqual('');
+            value.description = 'Description';
+            expect(value.description).toEqual('Description');
+        });
+
+        it('should have property `tokenBalanceChange`', () => {
+            expect(value.tokenBalanceChange).toEqual(0);
+            value.tokenBalanceChange = 1;
+            expect(value.tokenBalanceChange).toEqual(1);
+        });
+
+        it('should have property `isMigrating`', () => {
+            expect(value.isMigrating).toBeUndefined();
+            value.isMigrating = true;
+            expect(value.isMigrating).toBeTrue();
+        });
+
+        it('should have property `group`', () => {
+            const mockedGroup: TokenOptionGroup = jasmine.createSpyObj(
+                'TokenOptionGroup',
+                [],
+                ['configuration']
+            ) as unknown as TokenOptionGroup;
+            value.group = mockedGroup;
+            expect(value.group).toEqual(mockedGroup);
+        });
+
+        it('should throw error when accessing `group` before `group` is set', () => {
+            expect(() => value.group).toThrowError('Token option group is not set yet!');
+        });
+
+        it('should have property `startTime`', () => {
+            expect(value.startTime).toBe(null);
+            const date = new Date();
+            value.startTime = date;
+            expect(value.startTime).toEqual(date);
+            const matcher = new MultipleSectionDateMatcher(date);
+            value.startTime = matcher;
+            expect(value.startTime).toEqual(matcher);
+        });
+
+        it('should have property `endTime`', () => {
+            expect(value.endTime).toBe(null);
+            const date = new Date();
+            value.endTime = date;
+            expect(value.endTime).toEqual(date);
+            const matcher = new MultipleSectionDateMatcher(date);
+            value.endTime = matcher;
+            expect(value.endTime).toEqual(matcher);
+        });
+
+        it('should have property `allowedRequestCnt`', () => {
+            expect(value.allowedRequestCnt).toEqual(1);
+            value.allowedRequestCnt = 2;
+            expect(value.allowedRequestCnt).toEqual(2);
+        });
+
+        // TODO: Figure out why Jasmine Array matcher assumes `excludeTokenOptionIds` is type `never[]`
+        it('should have property `excludeTokenOptionIds`', () => {
+            expect(value.excludeTokenOptionIds as number[]).toEqual([]);
+            (value.excludeTokenOptionIds as number[]) = [1, 2, 4];
+            expect(value.excludeTokenOptionIds as number[]).toEqual([1, 2, 4]);
+        });
+
+        for (const data of validValues) {
+            for (const rawData of genRawPlaceholderDataEquivs(data)) {
+                it(`should decode successfully with raw data ${JSON.stringify(rawData)}`, () => {
+                    expect(value.fromRawData(rawData)).toBeSupersetOf(data);
+                });
+            }
+        }
+
+        invalidRawValues.forEach((rawData) => {
+            it(`should fail to decode with invalid raw data ${JSON.stringify(rawData)}`, () => {
+                expect(() => value.fromRawData(rawData)).toThrowError();
+            });
+        });
+
+        validValues.forEach((data) => {
+            it(`should construct successfully with data ${JSON.stringify(data)}`, () => {
+                expect(value.fromData(data)).toBeSupersetOf(data);
+            });
+        });
+
+        invalidValues.forEach((data) => {
+            it(`should fail to construct with invalid data ${JSON.stringify(data)}`, () => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect(() => value.fromData(data as any)).toThrowError();
+            });
+        });
+
+        for (const data of validValues) {
+            it(`should encode successfully to raw data with data ${JSON.stringify(data)}`, () => {
+                const result = value.fromData(data).toJSON();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                expect(Array.from(genRawPlaceholderDataEquivs(data))).toContain(result as any);
+            });
+        }
+    });
+});

--- a/src/app/token-options/placeholder-token-option/placeholder-token-option.spec.ts
+++ b/src/app/token-options/placeholder-token-option/placeholder-token-option.spec.ts
@@ -5,7 +5,7 @@ import {
     PlaceholderTokenOptionDataDef
 } from './placeholder-token-option';
 import { fromUnixTime, getUnixTime } from 'date-fns';
-import { genRawPlaceholderDataEquivs } from 'app/utils/test/generate-raw-equivalents';
+import { genRawPlaceholderDataEquivalents } from 'app/utils/test/generate-raw-equivalents';
 import { MultipleSectionDateMatcher } from 'app/utils/multiple-section-date-matcher';
 import type { TokenOptionGroup } from 'app/data/token-option-group';
 import { TO_BE_SUPER_SET_OF_MATCHER } from 'app/utils/test/to-be-super-set-of-matcher';
@@ -49,13 +49,9 @@ describe('PlaceholderTokenOption', () => {
 
     describe('PlaceholderTokenOptionDataDef', () => {
         for (const expected of validValues) {
-            for (const value of genRawPlaceholderDataEquivs(expected)) {
+            for (const value of genRawPlaceholderDataEquivalents(expected)) {
                 it(`should decode successfully with valid raw value ${JSON.stringify(value)}`, () => {
                     const result = PlaceholderTokenOptionDataDef.decode(value);
-                    if (isLeft(result)) {
-                        console.log('E:', expected);
-                        console.log('V:', value);
-                    }
                     expect(isLeft(result)).toBeFalse();
                     if (!isLeft(result)) expect(result.right).toEqual(expected);
                 });
@@ -63,11 +59,20 @@ describe('PlaceholderTokenOption', () => {
         }
 
         for (const expected of validValues) {
-            for (const value of genRawPlaceholderDataEquivs(expected, true)) {
-                it(`should decode successfully all extra raw data based on ${JSON.stringify(value)}`, () => {
+            for (const value of genRawPlaceholderDataEquivalents(expected, true)) {
+                describe(`Test generated raw data (${JSON.stringify(value)})`, () => {
                     const result = PlaceholderTokenOptionDataDef.decode(value);
-                    expect(isLeft(result)).toBeFalse();
-                    expect(isRight(result)).toBeTrue();
+                    it(`should decode successfully`, () => {
+                        expect(isLeft(result)).toBeFalse();
+                        expect(isRight(result)).toBeTrue();
+                    });
+                    if (isRight(result) && (result.right.startTime === null || result.right.startTime === null)) {
+                        it(`decode-encode should strip \`null\` \`startTime\`s and \`endTimes\`s`, () => {
+                            const encode = PlaceholderTokenOptionDataDef.encode(result.right);
+                            expect(encode.startTime).not.toBeNull();
+                            expect(encode.endTime).not.toBeNull();
+                        });
+                    }
                 });
             }
         }
@@ -93,7 +98,7 @@ describe('PlaceholderTokenOption', () => {
 
         for (const value of validValues) {
             it(`should encode successfully with valid value ${JSON.stringify(value)}`, () => {
-                const equalRawValues = Array.from(genRawPlaceholderDataEquivs(value));
+                const equalRawValues = Array.from(genRawPlaceholderDataEquivalents(value));
                 const result = PlaceholderTokenOptionDataDef.encode(value);
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 expect(equalRawValues).toContain(result as any);
@@ -193,7 +198,7 @@ describe('PlaceholderTokenOption', () => {
         });
 
         for (const data of validValues) {
-            for (const rawData of genRawPlaceholderDataEquivs(data)) {
+            for (const rawData of genRawPlaceholderDataEquivalents(data)) {
                 it(`should decode successfully with raw data ${JSON.stringify(rawData)}`, () => {
                     expect(value.fromRawData(rawData)).toBeSupersetOf(data);
                 });
@@ -223,7 +228,7 @@ describe('PlaceholderTokenOption', () => {
             it(`should encode successfully to raw data with data ${JSON.stringify(data)}`, () => {
                 const result = value.fromData(data).toJSON();
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                expect(Array.from(genRawPlaceholderDataEquivs(data))).toContain(result as any);
+                expect(Array.from(genRawPlaceholderDataEquivalents(data))).toContain(result as any);
             });
         }
     });

--- a/src/app/token-options/placeholder-token-option/placeholder-token-option.ts
+++ b/src/app/token-options/placeholder-token-option/placeholder-token-option.ts
@@ -26,6 +26,7 @@ export const PlaceholderTokenOptionDataDef = t.intersection([
 ]);
 
 export type PlaceholderTokenOptionData = t.TypeOf<typeof PlaceholderTokenOptionDataDef>;
+export type RawPlaceholderTokenOptionData = t.OutputOf<typeof PlaceholderTokenOptionDataDef>;
 
 export class PlaceholderTokenOption extends FromDataMixin(
     ToJSONMixin(

--- a/src/app/utils/multiple-section-date-matcher.ts
+++ b/src/app/utils/multiple-section-date-matcher.ts
@@ -127,7 +127,7 @@ export const MultipleSectionDateMatcherDef = new t.Type<
  * @param o valid Multiple Section Date Matcher Data or undefined
  * @param genExtra flag for generating valid but not equal raw data
  */
-function* genMultipleSectionValues(
+export function* genMultipleSectionDateMatcherValues(
     o?: MultipleSectionDateMatcherData,
     genExtra = false
 ): Generator<RawMultipleSectionDateMatcherData, void, unknown> {
@@ -155,35 +155,5 @@ function* genMultipleSectionValues(
                 ? undefined
                 : [{ sections: [['', ''] as [string, string]], name: '', date: getUnixTime(o.defaultDate) }]
         };
-    }
-}
-
-/**
- * Generate Raw values for MultipleSectionTimeOverrides Data
- * @param v valid value
- * @param genExtra flag for generating valid but not equal Raw values
- */
-export function* genRawMultipleSectionTimeValues(
-    v: Date | MultipleSectionDateMatcherData | null,
-    genExtra = false
-): Generator<number | RawMultipleSectionDateMatcherData | null, void, unknown> {
-    if (v === null) {
-        yield null;
-        if (genExtra) {
-            yield getUnixTime(new Date());
-            yield* genMultipleSectionValues(undefined, genExtra);
-        }
-    } else if (v && Object.prototype.toString.call(v) === '[object Date]') {
-        yield getUnixTime(v as Date);
-        if (genExtra) {
-            yield null;
-            yield* genMultipleSectionValues(undefined, genExtra);
-        }
-    } else if ((v as MultipleSectionDateMatcherData)?.defaultDate !== undefined) {
-        yield* genMultipleSectionValues(v as MultipleSectionDateMatcherData, genExtra);
-        if (genExtra) {
-            yield null;
-            yield getUnixTime(new Date());
-        }
     }
 }

--- a/src/app/utils/multiple-section-date-matcher.ts
+++ b/src/app/utils/multiple-section-date-matcher.ts
@@ -117,3 +117,73 @@ export const MultipleSectionDateMatcherDef = new t.Type<
             overrides: v.overrides
         })
 );
+
+/**
+ * Generates valid Raw Multiple Section Date Matcher Data values
+ *
+ * Note: passing (`undefined`, `false`) will result in early termination.
+ * No values will be returned for this case.
+ *
+ * @param o valid Multiple Section Date Matcher Data or undefined
+ * @param genExtra flag for generating valid but not equal raw data
+ */
+function* genMultipleSectionValues(
+    o?: MultipleSectionDateMatcherData,
+    genExtra = false
+): Generator<RawMultipleSectionDateMatcherData, void, unknown> {
+    if (o === undefined && !genExtra) {
+        return;
+    }
+    o = o
+        ? o
+        : {
+              defaultDate: new Date(),
+              overrides: undefined
+          };
+    yield {
+        defaultDate: getUnixTime(o.defaultDate),
+        overrides: o.overrides
+            ? o.overrides.map((x) => {
+                  return { ...x, date: getUnixTime(x.date) };
+              })
+            : undefined
+    };
+    if (genExtra) {
+        yield {
+            defaultDate: getUnixTime(o.defaultDate),
+            overrides: o.overrides
+                ? undefined
+                : [{ sections: [['', ''] as [string, string]], name: '', date: getUnixTime(o.defaultDate) }]
+        };
+    }
+}
+
+/**
+ * Generate Raw values for MultipleSectionTimeOverrides Data
+ * @param v valid value
+ * @param genExtra flag for generating valid but not equal Raw values
+ */
+export function* genRawMultipleSectionTimeValues(
+    v: Date | MultipleSectionDateMatcherData | null,
+    genExtra = false
+): Generator<number | RawMultipleSectionDateMatcherData | null, void, unknown> {
+    if (v === null) {
+        yield null;
+        if (genExtra) {
+            yield getUnixTime(new Date());
+            yield* genMultipleSectionValues(undefined, genExtra);
+        }
+    } else if (v && Object.prototype.toString.call(v) === '[object Date]') {
+        yield getUnixTime(v as Date);
+        if (genExtra) {
+            yield null;
+            yield* genMultipleSectionValues(undefined, genExtra);
+        }
+    } else if ((v as MultipleSectionDateMatcherData)?.defaultDate !== undefined) {
+        yield* genMultipleSectionValues(v as MultipleSectionDateMatcherData, genExtra);
+        if (genExtra) {
+            yield null;
+            yield getUnixTime(new Date());
+        }
+    }
+}

--- a/src/app/utils/test/generate-raw-equivalents.ts
+++ b/src/app/utils/test/generate-raw-equivalents.ts
@@ -1,17 +1,21 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
     EarnBySurveyTokenOptionData,
     RawEarnBySurveyTokenOptionData
 } from 'app/token-options/earn-by-survey/earn-by-survey-token-option';
-// import type { PlaceholderTokenOptionData } from 'app/token-options/placeholder-token-option/placeholder-token-option';
+import type {
+    PlaceholderTokenOptionData,
+    RawPlaceholderTokenOptionData
+} from 'app/token-options/placeholder-token-option/placeholder-token-option';
 import type { RawTokenOptionData, TokenOptionData } from 'app/token-options/token-option';
 import { getUnixTime } from 'date-fns';
 import { Base64 } from 'js-base64';
+import { genRawMultipleSectionTimeValues } from '../multiple-section-date-matcher';
+import type { RawExcludeTokenOptionIdsMixinData } from 'app/token-options/mixins/exclude-token-option-ids-mixin';
 
 function* genRawTokenOptionDataEquivs<T extends TokenOptionData>(
     v: T,
     genExtra = false
-): Generator<T & RawTokenOptionData, void, any> {
+): Generator<T & RawTokenOptionData, void, unknown> {
     const descriptionData = {
         *[Symbol.iterator]() {
             if (v.description === '') {
@@ -53,7 +57,7 @@ export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionD
 ): Generator<
     ((T | Omit<T, 'surveyId'>) & RawEarnBySurveyTokenOptionData) | (T & Omit<RawEarnBySurveyTokenOptionData, 'quizId'>),
     void,
-    any
+    unknown
 > {
     const result: Omit<T, 'surveyId'> & RawEarnBySurveyTokenOptionData = {
         ...v,
@@ -61,6 +65,7 @@ export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionD
         startTime: getUnixTime(v.startTime),
         endTime: getUnixTime(v.endTime)
     };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (result as any)['surveyId'];
     yield* genRawTokenOptionDataEquivs(result, genExtra);
     if (genExtra) {
@@ -84,7 +89,32 @@ export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionD
     }
 }
 
-// export function* genRawPlaceholderDataEquivs<T extends PlaceholderTokenOptionData>(
-//     v: T,
-//     genExtra = false
-// ): Generator<T, void, any> {}
+export function* genRawPlaceholderDataEquivs<T extends PlaceholderTokenOptionData>(
+    v: T,
+    genExtra = false
+): Generator<T & RawPlaceholderTokenOptionData, void, unknown> {
+    const excludeIdsData = {
+        *[Symbol.iterator](): Generator<T & RawExcludeTokenOptionIdsMixinData, void, unknown> {
+            if (v.excludeTokenOptionIds.length === 0 || genExtra) {
+                const r = { ...v };
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                delete (r as any)['excludeTokenOptionIds'];
+                yield { ...v, excludeTokenOptionIds: undefined };
+                yield r;
+            }
+            if (genExtra && v.excludeTokenOptionIds.length === 0) {
+                yield { ...v, excludeTokenOptionIds: [1, 2, 3] };
+            }
+        }
+    };
+    for (const rawExcludesData of excludeIdsData) {
+        for (const startTimeValues of genRawMultipleSectionTimeValues(rawExcludesData.startTime, genExtra)) {
+            for (const endTimeValues of genRawMultipleSectionTimeValues(rawExcludesData.endTime, genExtra)) {
+                yield* genRawTokenOptionDataEquivs(
+                    { ...rawExcludesData, startTime: startTimeValues, endTime: endTimeValues },
+                    genExtra
+                );
+            }
+        }
+    }
+}

--- a/src/app/utils/test/generate-raw-equivalents.ts
+++ b/src/app/utils/test/generate-raw-equivalents.ts
@@ -4,11 +4,14 @@ import type {
     RawEarnBySurveyTokenOptionData
 } from 'app/token-options/earn-by-survey/earn-by-survey-token-option';
 // import type { PlaceholderTokenOptionData } from 'app/token-options/placeholder-token-option/placeholder-token-option';
-import type { TokenOptionData } from 'app/token-options/token-option';
+import type { RawTokenOptionData, TokenOptionData } from 'app/token-options/token-option';
 import { getUnixTime } from 'date-fns';
 import { Base64 } from 'js-base64';
 
-function* genRawTokenOptionDataEquivs<T extends TokenOptionData>(v: T, genExtra = false): Generator<T, void, any> {
+function* genRawTokenOptionDataEquivs<T extends TokenOptionData>(
+    v: T,
+    genExtra = false
+): Generator<T & RawTokenOptionData, void, any> {
     const descriptionData = {
         *[Symbol.iterator]() {
             if (v.description === '') {
@@ -47,24 +50,28 @@ function* genRawTokenOptionDataEquivs<T extends TokenOptionData>(v: T, genExtra 
 export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionData>(
     v: T,
     genExtra = false
-): Generator<T, void, any> {
-    const result: RawEarnBySurveyTokenOptionData = {
+): Generator<
+    ((T | Omit<T, 'surveyId'>) & RawEarnBySurveyTokenOptionData) | (T & Omit<RawEarnBySurveyTokenOptionData, 'quizId'>),
+    void,
+    any
+> {
+    const result: Omit<T, 'surveyId'> & RawEarnBySurveyTokenOptionData = {
         ...v,
         quizId: v.surveyId,
         startTime: getUnixTime(v.startTime),
         endTime: getUnixTime(v.endTime)
     };
     delete (result as any)['surveyId'];
-    yield* genRawTokenOptionDataEquivs<T>(result as any, genExtra);
+    yield* genRawTokenOptionDataEquivs(result, genExtra);
     if (genExtra) {
-        // Preserves the 'surveyId' field
-        yield* genRawTokenOptionDataEquivs<T>(
+        // Preserves only the 'surveyId' field
+        yield* genRawTokenOptionDataEquivs<T & Omit<RawEarnBySurveyTokenOptionData, 'quizId'>>(
             { ...v, surveyId: 'New surveyId Format', startTime: result.startTime, endTime: result.endTime },
             genExtra
         );
         // Includes both `surveyId` and `quizId` field. both are accepted in the Raw Data
         // `surveyId` should be the priority pick
-        yield* genRawTokenOptionDataEquivs<T>(
+        yield* genRawTokenOptionDataEquivs<T & RawEarnBySurveyTokenOptionData>(
             {
                 ...v,
                 surveyId: 'Prioritized surveyId value',

--- a/src/app/utils/test/generate-raw-equivalents.ts
+++ b/src/app/utils/test/generate-raw-equivalents.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type {
+    EarnBySurveyTokenOptionData,
+    RawEarnBySurveyTokenOptionData
+} from 'app/token-options/earn-by-survey/earn-by-survey-token-option';
+// import type { PlaceholderTokenOptionData } from 'app/token-options/placeholder-token-option/placeholder-token-option';
+import type { TokenOptionData } from 'app/token-options/token-option';
+import { getUnixTime } from 'date-fns';
+import { Base64 } from 'js-base64';
+
+function* genRawTokenOptionDataEquivs<T extends TokenOptionData>(v: T, genExtra = false): Generator<T, void, any> {
+    const descriptionData = {
+        *[Symbol.iterator]() {
+            if (v.description === '') {
+                yield { ...v, description: undefined };
+                yield { ...v, description: Base64.encode('') };
+            } else if (typeof v.description === 'string') {
+                yield { ...v, description: Base64.encode(v.description) };
+            }
+        }
+    };
+
+    yield* descriptionData;
+
+    if (genExtra) {
+        const invertDescription = {
+            *[Symbol.iterator]() {
+                for (const d of descriptionData) {
+                    yield { ...d, description: d.description ? undefined : Base64.encode('test string') };
+                }
+            }
+        };
+
+        for (const iD of invertDescription) {
+            yield { ...iD, isMigrating: iD.isMigrating === undefined ? true : undefined };
+        }
+    }
+}
+
+/**
+ * Converts valid EarnBySurveyTokenOptionData into equivalent RawEarnBySurveyTokenOptionData.
+ * And with a boolean flag, can generate additional valid but not-necessarily equal RawEarnBySurveyTokenOptionData's
+ *
+ * @param v an object to use as a baseline
+ * @param genExtra boolean flag for generating extra non-equal but valid transformations
+ */
+export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionData>(
+    v: T,
+    genExtra = false
+): Generator<T, void, any> {
+    const result: RawEarnBySurveyTokenOptionData = {
+        ...v,
+        quizId: v.surveyId,
+        startTime: getUnixTime(v.startTime),
+        endTime: getUnixTime(v.endTime)
+    };
+    delete (result as any)['surveyId'];
+    yield* genRawTokenOptionDataEquivs<T>(result as any, genExtra);
+    if (genExtra) {
+        // Preserves the 'surveyId' field
+        yield* genRawTokenOptionDataEquivs<T>(
+            { ...v, surveyId: 'New surveyId Format', startTime: result.startTime, endTime: result.endTime },
+            genExtra
+        );
+        // Includes both `surveyId` and `quizId` field. both are accepted in the Raw Data
+        // `surveyId` should be the priority pick
+        yield* genRawTokenOptionDataEquivs<T>(
+            {
+                ...v,
+                surveyId: 'Prioritized surveyId value',
+                quizId: 'Prioritized quizID value',
+                startTime: result.startTime,
+                endTime: result.endTime
+            },
+            genExtra
+        );
+    }
+}
+
+// export function* genRawPlaceholderDataEquivs<T extends PlaceholderTokenOptionData>(
+//     v: T,
+//     genExtra = false
+// ): Generator<T, void, any> {}

--- a/src/app/utils/test/generate-raw-equivalents.ts
+++ b/src/app/utils/test/generate-raw-equivalents.ts
@@ -9,10 +9,21 @@ import type {
 import type { RawTokenOptionData, TokenOptionData } from 'app/token-options/token-option';
 import { getUnixTime } from 'date-fns';
 import { Base64 } from 'js-base64';
-import { genRawMultipleSectionTimeValues } from '../multiple-section-date-matcher';
+import {
+    genMultipleSectionDateMatcherValues,
+    MultipleSectionDateMatcherDataDef
+} from '../multiple-section-date-matcher';
 import type { RawExcludeTokenOptionIdsMixinData } from 'app/token-options/mixins/exclude-token-option-ids-mixin';
+import type {
+    OptionalMultipleSectionEndTimeMixinData,
+    RawOptionalMultipleSectionEndTimeMixinData
+} from 'app/token-options/mixins/optional-multiple-section-end-time-mixin';
+import type {
+    OptionalMultipleSectionStartTimeMixinData,
+    RawOptionalMultipleSectionStartTimeMixinData
+} from 'app/token-options/mixins/optional-multiple-section-start-time-mixin';
 
-function* genRawTokenOptionDataEquivs<T extends TokenOptionData>(
+function* genRawTokenOptionDataEquivalents<T extends TokenOptionData>(
     v: T,
     genExtra = false
 ): Generator<T & RawTokenOptionData, void, unknown> {
@@ -51,7 +62,7 @@ function* genRawTokenOptionDataEquivs<T extends TokenOptionData>(
  * @param v an object to use as a baseline
  * @param genExtra boolean flag for generating extra non-equal but valid transformations
  */
-export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionData>(
+export function* genRawEarnBySurveyDataEquivalents<T extends EarnBySurveyTokenOptionData>(
     v: T,
     genExtra = false
 ): Generator<
@@ -67,16 +78,16 @@ export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionD
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (result as any)['surveyId'];
-    yield* genRawTokenOptionDataEquivs(result, genExtra);
+    yield* genRawTokenOptionDataEquivalents(result, genExtra);
     if (genExtra) {
         // Preserves only the 'surveyId' field
-        yield* genRawTokenOptionDataEquivs<T & Omit<RawEarnBySurveyTokenOptionData, 'quizId'>>(
+        yield* genRawTokenOptionDataEquivalents<T & Omit<RawEarnBySurveyTokenOptionData, 'quizId'>>(
             { ...v, surveyId: 'New surveyId Format', startTime: result.startTime, endTime: result.endTime },
             genExtra
         );
         // Includes both `surveyId` and `quizId` field. both are accepted in the Raw Data
         // `surveyId` should be the priority pick
-        yield* genRawTokenOptionDataEquivs<T & RawEarnBySurveyTokenOptionData>(
+        yield* genRawTokenOptionDataEquivalents<T & RawEarnBySurveyTokenOptionData>(
             {
                 ...v,
                 surveyId: 'Prioritized surveyId value',
@@ -89,7 +100,7 @@ export function* genRawEarnBySurveyDataEquivs<T extends EarnBySurveyTokenOptionD
     }
 }
 
-export function* genRawPlaceholderDataEquivs<T extends PlaceholderTokenOptionData>(
+export function* genRawPlaceholderDataEquivalents<T extends PlaceholderTokenOptionData>(
     v: T,
     genExtra = false
 ): Generator<T & RawPlaceholderTokenOptionData, void, unknown> {
@@ -108,13 +119,55 @@ export function* genRawPlaceholderDataEquivs<T extends PlaceholderTokenOptionDat
         }
     };
     for (const rawExcludesData of excludeIdsData) {
-        for (const startTimeValues of genRawMultipleSectionTimeValues(rawExcludesData.startTime, genExtra)) {
-            for (const endTimeValues of genRawMultipleSectionTimeValues(rawExcludesData.endTime, genExtra)) {
-                yield* genRawTokenOptionDataEquivs(
+        for (const startTimeValues of genRawOptionalMultipleSectionTimeValues(rawExcludesData.startTime, genExtra)) {
+            for (const endTimeValues of genRawOptionalMultipleSectionTimeValues(rawExcludesData.endTime, genExtra)) {
+                yield* genRawTokenOptionDataEquivalents(
                     { ...rawExcludesData, startTime: startTimeValues, endTime: endTimeValues },
                     genExtra
                 );
             }
         }
+    }
+}
+
+type OptionalSectionTimeValues =
+    | OptionalMultipleSectionEndTimeMixinData['endTime']
+    | OptionalMultipleSectionStartTimeMixinData['startTime'];
+type RawOptionalSectionTimeValues =
+    | RawOptionalMultipleSectionEndTimeMixinData['endTime']
+    | RawOptionalMultipleSectionStartTimeMixinData['startTime'];
+
+/**
+ * Generate Raw values for MultipleSectionTimeOverrides Data
+ * @param v valid value
+ * @param genExtra flag for generating valid but not equal Raw values
+ */
+export function* genRawOptionalMultipleSectionTimeValues(
+    v: OptionalSectionTimeValues,
+    genExtra = false
+): Generator<RawOptionalSectionTimeValues, void, unknown> {
+    if (v === null) {
+        yield null;
+        yield undefined;
+        if (genExtra) {
+            yield getUnixTime(new Date());
+            yield* genMultipleSectionDateMatcherValues(undefined, genExtra);
+        }
+    } else if (v instanceof Date || Object.prototype.toString.call(v) === '[object Date]') {
+        yield getUnixTime(v as Date);
+        if (genExtra) {
+            yield null;
+            yield undefined;
+            yield* genMultipleSectionDateMatcherValues(undefined, genExtra);
+        }
+    } else if (MultipleSectionDateMatcherDataDef.is(v)) {
+        yield* genMultipleSectionDateMatcherValues(v, genExtra);
+        if (genExtra) {
+            yield null;
+            yield undefined;
+            yield getUnixTime(new Date());
+        }
+    } else {
+        throw Error(`Unimplemented Generator for Raw Multiple Section Time Values of type: (${typeof v})`);
     }
 }


### PR DESCRIPTION
### Description

`startTime` and `endTime` have a default/unused/unset/empty value of `null`.

The Multiple Section Start/End Time setting for the changed mixins are optional. Currently the UI has a checkbox that when clicked reveals the forms to collect Single and/or Multiple Section info.

This pull request changes the constructed Optional Types to include whether or not the the forms are used/viewable.

The UI form's viewability (or user disinterest in the optional config) is represented by the property being Optional (either absent or set as undefined). This stands in for the unchecked boolean nature of the checkbox.

Once viewable (or user has expressed interest) then the form's default state is shown.

The functionality added here is a backwards compatible way to make the `startTime` and `endTime` optional properties in the stored Token ATM Configuration.

The goal is to reduce the stored JSON length since undefined props are stripped when stringified. This is a useful change for possibly adding `startTime` and `endTime` configuration to the baseline Token Option Mixin. Which means they would be included as a choice in all Token Options.

Adding a required `startTime: null` & `endTime: null` to every Token Option would needlessly increase the length/size of the Token ATM Configuration.

The backwards compatible change adds:
- acceptance of undefined/absent `startTime` or `endTime` in the Token ATM Configuration,
- converts these optionals into their default `null` property for use at runtime, and
- changes `null`s into `undefined` when writing them back to the Token ATM Configuration. This will strip `null`s from existing Token Option configurations when they are next saved.

The stripping of `null`s will break the Token ATM Configuration's compatibility with earlier versions of Token ATM. So while this change is backwards compatible, previous version are not forward compatible with this change.

In addition to implementing optional props for `startTime` & `endTime` this pull request also includes, 2 enhancements:
1. Raw Token Option Data generators to improve the test surface for Token Options. Implemented to have full parity with the existing `EarnBySurvey` Token Option tests and automatically increase the test space of valid tests. The raw data generators create valid raw data equivalents of valid data examples. An optional boolean flag can be provided to generate valid but not equal raw data. This combination allows gradually increasing the token option data values that are tested for proper encoding/decoding, using a minimal number of valid examples to tests the breadth of possible data situations, and provides a baseline for ensuring backwards compatibility with existing Token ATM Configurations and runtimes. 
2. Automated tests for the `Placeholder` Token Option following the `EarnBySurvey` tests as a template and using raw data generators for Placeholder Token Option Data.

### Testing Note

Test if the enhancement works as described. Perform all tests for both Optional Multiple Section Start Times and Optional Multiple Section End Times. Currently these 2 mixins are only used by the Placeholder Token Option.

Some Specific Baseline Tests:
1. ~Applicable property can have null value in Token ATM Configuration~ Included in automated tests
3. Token Option UI continues to be viewable as described in #105 
4. Token Option UI still allows editing, validating, and saving applicable Token Option
5. Saving Placeholder Token Options, strips `property -> null` pairs from the saved Token ATM Configuration (Automated tests show this should be the case, but also should also be verified on Canvas)
6. Start Time and End Time UI defaults continue to follow the description in #105 
7. Both properties continue to save time and multi-section values in the Token ATM Configuration (Automated tests show this should be the case, but should also be verified on Canvas)