### PR TITLE
Bugfix: Duplicate Student Records in Section Export (Fix 1)

### DIFF
--- a/src/app/components/export-request-modal/export-request-modal.component.ts
+++ b/src/app/components/export-request-modal/export-request-modal.component.ts
@@ -206,8 +206,12 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
                     break;
                 }
                 case 'course-section': {
+                    /**
+                     * Mapping from `Student` Object Reference to the Section Name that Object Ref is related to.
+                     */
                     const studentSectionMapping = new Map<Student, string>();
                     for await (const section of await this.canvasService.getSections(this.configuration.course.id)) {
+                        // Enumerating Students in a Section returns a Student Obj Ref that is unique for that Section.
                         for (const student of await this.canvasService.getSectionStudentsWithEmail(
                             this.configuration.course.id,
                             section.id
@@ -217,6 +221,7 @@ export class ExportRequestModalComponent implements OnInit, OnDestroy {
                         }
                     }
                     classifier = async (_, student) => {
+                        // TODO: UUID is unique per call, should it be?
                         return studentSectionMapping.get(student) ?? 'others' + uuidv4();
                     };
                     break;

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1546,6 +1546,8 @@ export class CanvasService {
         do {
             if (isFirstPage) isFirstPage = false;
             else studentIds.next();
+            const validIds = [...studentIds];
+            if (validIds.length === 0) continue; // Prevent collecting Students if there are no Ids
             students.push(
                 ...(await DataConversionHelper.convertAsyncIterableToList(
                     new CanvasRESTPaginatedResult<Student>(
@@ -1554,7 +1556,7 @@ export class CanvasService {
                                 enrollment_type: ['student'],
                                 enrollment_state: ['active'],
                                 per_page: 100,
-                                user_ids: [...studentIds]
+                                user_ids: validIds
                             }
                         }),
                         async (url: string) => await this.paginatedRequestHandler(url),

--- a/src/app/services/csvs.service.ts
+++ b/src/app/services/csvs.service.ts
@@ -46,7 +46,7 @@ export class CSVsService {
         if (namesAndContent.size === 0) {
             throw new Error('No filename or data provided to make a file');
         } else if (namesAndContent.size === 1 && zipName === undefined && zipFixes === undefined) {
-            return this.makeCSVFile(namesAndContent.entries().next().value, fixes);
+            return this.makeCSVFile(namesAndContent.entries().next().value!, fixes);
         } else {
             return await this.makeZipFile(namesAndContent, fixes, zipName, zipFixes);
         }


### PR DESCRIPTION
### Description
See issue #140. 

#### Fix applied
Adds check that Paginated Student Ids actually contains Student Ids before collecting `'active'` `'student'`s (enrollment state and type, respectively). Canvas can apply a filter for `user_ids`, but seems to interpret an empty array (`[]`) as return all students instead of return none students.

### Testing Note

1. In previous versions of Token ATM, Export a Section Scoped CSV for a section with no Students enrolled and a CSV will be generated.
2. While testing this pull request, a Section Scoped CSV for a section with no Students enrolled will properly report that no Requests satisfy the restrictions reported above.