### PR TITLE
Bugfix: Duplicate Student Records in Section Export (Fix 2)

### DIFF
--- a/src/app/components/dev-test/dev-test.component.html
+++ b/src/app/components/dev-test/dev-test.component.html
@@ -68,4 +68,7 @@
     <button class="btn btn-primary my-3" (click)="checkAllAssignmentGroupsTotalPointsPossible()">
         Check Total Points Possible for all Assignment Groups
     </button>
+    <button class="btn btn-primary my-3" (click)="compareUsersAndEnrollments()">
+        Compare Active Student Users and Active StudentEnrollments in Sections
+    </button>
 </div>

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -290,6 +290,13 @@ export class DevTestComponent {
             }
             return count;
         }
+        function difference<T>(a: Set<T>, b: Set<T>) {
+            const result = new Set(a);
+            for (const el of b) {
+                result.delete(el);
+            }
+            return result;
+        }
 
         // Active Student Users
         const courseActiveStudentUsers = await DataConversionHelper.convertAsyncIterableToList(
@@ -365,6 +372,14 @@ export class DevTestComponent {
                 `  And the total number of unique Active StudentEnrollments (${allSectionsStuIds.size}) in sections does not match the number of unique Active Student Users (${courseActiveStudentUserIds.size})`
             );
         }
+        console.log(
+            '  Unique Ids missing from unique Active StudentEnrollments:',
+            difference(courseActiveStudentUserIds, allSectionsStuIds)
+        );
+        console.log(
+            '  Unique Ids missing from unique Active Student Users:',
+            difference(allSectionsStuIds, courseActiveStudentUserIds)
+        );
 
         // Compare enumerating sections based on Users
         const sectionIdUserIdsMap = new Map<string, Set<string>>();

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -12,6 +12,8 @@ import {
 } from 'app/token-options/withdraw-assignment-resubmission/withdraw-assignment-resubmission-token-option';
 import { QualtricsService } from 'app/services/qualtrics.service';
 import formatInTimeZone from 'date-fns-tz/formatInTimeZone';
+import { DataConversionHelper } from 'app/utils/data-conversion-helper';
+import type { Student } from 'app/data/student';
 
 @Component({
     selector: 'app-dev-test',
@@ -275,5 +277,84 @@ export class DevTestComponent {
                 await this.canvasService.getTotalPointsPossibleInAnAssignmentGroup(this.course.id, id, skipIf)
             );
         }
+    }
+
+    async compareUsersAndEnrollments(): Promise<void> {
+        if (!this.course) return;
+        console.log('_______________________________________________');
+        console.log('Canvas Users and Section Enrollment Comparisons');
+        function nonSubset<T>(sub: Set<T>, sup: Set<T>): number {
+            let count = 0;
+            for (const el of sub) {
+                if (!sup.has(el)) count++;
+            }
+            return count;
+        }
+
+        // Active Student Users
+        const courseActiveStudentUsers = await DataConversionHelper.convertAsyncIterableToList(
+            await this.canvasService.getCourseStudentEnrollments(this.course.id)
+        );
+        const courseActiveStudentUserIds = new Set<string>(courseActiveStudentUsers.map((s) => s.id));
+        if (courseActiveStudentUsers.length !== courseActiveStudentUserIds.size)
+            console.log('Warning! Active Student Users do not have unique Ids');
+
+        // Sections and their Students
+        const sections = await DataConversionHelper.convertAsyncIterableToList(
+            await this.canvasService.getSections(this.course.id)
+        );
+        const sectionIdStudentsMap = new Map<string, Student[]>();
+        for (const section of sections) {
+            sectionIdStudentsMap.set(
+                section.id,
+                await this.canvasService.getSectionStudentsWithEmail(this.course.id, section.id)
+            );
+        }
+        const sectionIdStudentIdsMap = new Map<string, Set<string>>(
+            Array.from(sectionIdStudentsMap.entries()).map((entry) => {
+                const [k, v] = entry;
+                return [k, new Set<string>(v.map((s) => s.id))];
+            })
+        );
+        let sectionEnrollmentMismatch = false;
+        for (const [sectionId, students] of sectionIdStudentsMap) {
+            if (students.length !== sectionIdStudentIdsMap.get(sectionId)?.size) {
+                sectionEnrollmentMismatch = true;
+                break;
+            }
+        }
+        if (sectionEnrollmentMismatch)
+            console.log("Warning! A section's Active StudentEnrollments doesn't have unique Ids");
+
+        // Collate and Compare every Section's StuIds
+        const allSectionsStuIds = new Set<string>();
+        for (const [sectionId, stuIdSet] of sectionIdStudentIdsMap) {
+            for (const id of stuIdSet) {
+                allSectionsStuIds.add(id);
+            }
+            const nonSubsetCount = nonSubset(stuIdSet, courseActiveStudentUserIds);
+            if (nonSubsetCount > 0) {
+                console.log(
+                    'Section Id:',
+                    sectionId,
+                    'has',
+                    nonSubsetCount,
+                    'students that are not Active Student Users (Section has Excess Students)'
+                );
+            }
+        }
+
+        const nonSubsetCountAllSections = nonSubset(allSectionsStuIds, courseActiveStudentUserIds);
+        console.log(
+            'Totalling All Sections, there are',
+            nonSubsetCountAllSections,
+            'students that are not Active Student Users'
+        );
+        if (allSectionsStuIds.size !== courseActiveStudentUserIds.size) {
+            console.log(
+                `  And the total number of unique Active StudentEnrollments (${allSectionsStuIds.size}) in sections does not match the number of unique Active Student Users (${courseActiveStudentUserIds.size})`
+            );
+        }
+        console.log('Comparison Completed');
     }
 }

--- a/src/app/components/dev-test/dev-test.component.ts
+++ b/src/app/components/dev-test/dev-test.component.ts
@@ -316,15 +316,25 @@ export class DevTestComponent {
                 return [k, new Set<string>(v.map((s) => s.id))];
             })
         );
-        let sectionEnrollmentMismatch = false;
         for (const [sectionId, students] of sectionIdStudentsMap) {
             if (students.length !== sectionIdStudentIdsMap.get(sectionId)?.size) {
-                sectionEnrollmentMismatch = true;
-                break;
+                console.log("Warning! A section's Active StudentEnrollments doesn't have unique Ids");
+                console.log(
+                    `  Section Id: ${sectionId}, Section Name: ${sections
+                        .filter((s) => s.id === sectionId)
+                        .map((s) => s.name)}`
+                );
+                // const repeatedIds: string[] = [];
+                // const foundIds = new Set<string>();
+                // for (const stu of students) {
+                //     if (foundIds.has(stu.id)) {
+                //         repeatedIds.push(stu.id);
+                //     }
+                //     foundIds.add(stu.id);
+                // }
+                // console.log('  Repeated Ids:', repeatedIds);
             }
         }
-        if (sectionEnrollmentMismatch)
-            console.log("Warning! A section's Active StudentEnrollments doesn't have unique Ids");
 
         // Collate and Compare every Section's StuIds
         const allSectionsStuIds = new Set<string>();
@@ -355,6 +365,47 @@ export class DevTestComponent {
                 `  And the total number of unique Active StudentEnrollments (${allSectionsStuIds.size}) in sections does not match the number of unique Active Student Users (${courseActiveStudentUserIds.size})`
             );
         }
+
+        // Compare enumerating sections based on Users
+        const sectionIdUserIdsMap = new Map<string, Set<string>>();
+        // Collect Sections based on Users
+        for (const stuId of courseActiveStudentUserIds) {
+            let noStuSections = true;
+            for await (const stuSection of await this.canvasService.getStudentSectionEnrollments(
+                this.course.id,
+                stuId
+            )) {
+                if (noStuSections) noStuSections = false;
+                if (!sectionIdUserIdsMap.has(stuSection)) sectionIdUserIdsMap.set(stuSection, new Set<string>());
+                sectionIdUserIdsMap.get(stuSection)?.add(stuId);
+            }
+            if (noStuSections)
+                console.log(`Warning! An Active Student User (id: ${stuId}) isn't enrolled in any sections`);
+        }
+        // Compare Enumerated Sections
+        if (sectionIdUserIdsMap.size - sectionIdStudentIdsMap.size !== 0) {
+            console.log(
+                `When enumerating sections by Active Student Users, ${
+                    sectionIdUserIdsMap.size - sectionIdStudentIdsMap.size
+                } more are found.`
+            );
+            if (sectionIdUserIdsMap.size - sectionIdStudentIdsMap.size < 0)
+                console.log(
+                    'Warning! Assumption that User based enumeration of sections returns all sections has been broken.'
+                );
+        }
+        for (const [sectionId, stuUserIds] of sectionIdUserIdsMap) {
+            const sectionStus = sectionIdStudentIdsMap.get(sectionId) ?? new Set();
+            const secSubUser = nonSubset(sectionStus, stuUserIds);
+            const userSubSec = nonSubset(stuUserIds, sectionStus);
+
+            if (secSubUser !== 0 || userSubSec !== 0) {
+                console.log(`== Students in Section Id (${sectionId}) Comparison ==`);
+                console.log(`   ${secSubUser} students in Section missing from Users`);
+                console.log(`   ${userSubSec} students in Users missing from Section`);
+            }
+        }
+
         console.log('Comparison Completed');
     }
 }

--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1528,6 +1528,9 @@ export class CanvasService {
         );
     }
 
+    /**
+     * @returns An array of unique active Students with an active StudentEnrollment in a Section (uniqueness based on Student Id)
+     */
     public async getSectionStudentsWithEmail(courseId: string, sectionId: string): Promise<Student[]> {
         const studentIds = new PaginatedView<string>(
             await this.rawAPIRequest(`/api/v1/sections/${sectionId}/enrollments`, {
@@ -1542,31 +1545,30 @@ export class CanvasService {
             (data: any) => data.map((entry: any) => entry.user.id)
         );
         let isFirstPage = true;
-        const students = [];
+        const idStudentMap = new Map<string, Student>();
         do {
             if (isFirstPage) isFirstPage = false;
             else studentIds.next();
             const validIds = [...studentIds];
             if (validIds.length === 0) continue; // Prevent collecting Students if there are no Ids
-            students.push(
-                ...(await DataConversionHelper.convertAsyncIterableToList(
-                    new CanvasRESTPaginatedResult<Student>(
-                        await this.rawAPIRequest(`/api/v1/courses/${courseId}/users`, {
-                            params: {
-                                enrollment_type: ['student'],
-                                enrollment_state: ['active'],
-                                per_page: 100,
-                                user_ids: validIds
-                            }
-                        }),
-                        async (url: string) => await this.paginatedRequestHandler(url),
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        (data: any) => data.map((entry: any) => Student.deserialize(entry))
-                    )
-                ))
+            const students = new CanvasRESTPaginatedResult<Student>(
+                await this.rawAPIRequest(`/api/v1/courses/${courseId}/users`, {
+                    params: {
+                        enrollment_type: ['student'],
+                        enrollment_state: ['active'],
+                        per_page: 100,
+                        user_ids: validIds
+                    }
+                }),
+                async (url: string) => await this.paginatedRequestHandler(url),
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (data: any) => data.map((entry: any) => Student.deserialize(entry))
             );
+            for await (const student of students) {
+                idStudentMap.set(student.id, student);
+            }
         } while (studentIds.hasNextPage());
-        return students;
+        return Array.from(idStudentMap.values());
     }
 
     public async isPagePublished(courseId: string, pageId: string): Promise<boolean | undefined> {


### PR DESCRIPTION
### Description

See issue #140.

#### Fix Applied

Updates `getSectionStudentsWithEmail` to collect Student data in a Map with key => Student Id and value => Student Data pairs. An array of the unique values are returned at the end.

A map is used rather than a set since it's possible to have a duplicate across a pagination boundary and the collected student data (id, name, and email) is the same across duplicates so setting the last occurrence is equivalent to the earlier occurrences.

#### Also Includes

Testing button in Development Testing page that console logs checks and comparisons that helped diagnose and test the fix against a running Canvas Instance.

### Testing Note

Smoke testing sufficient. Tested with issue reporting Canvas Course, fixes duplication portion of #140.