### PR TITLE
Bugfix: Missing Student Records in Section Export

### DIFF
--- a/src/app/services/canvas.service.ts
+++ b/src/app/services/canvas.service.ts
@@ -1548,7 +1548,7 @@ export class CanvasService {
         const idStudentMap = new Map<string, Student>();
         do {
             if (isFirstPage) isFirstPage = false;
-            else studentIds.next();
+            else await studentIds.next();
             const validIds = [...studentIds];
             if (validIds.length === 0) continue; // Prevent collecting Students if there are no Ids
             const students = new CanvasRESTPaginatedResult<Student>(


### PR DESCRIPTION
### Description

See #140.

#### Fix Applied

Awaited the Pagination View moving on to the next page. Last page was dropped as the loop finished before async event changed the cached and synchronously used data.

### Testing Note

None needed. Checking Promise resolution/awaiting throughout the code base would be a good preventative step for cases like this in future.