### PR TITLE
Bugfix: Canvas Page Content Truncation

### DIFF
--- a/src/app/services/token-atm-configuration-manager.service.ts
+++ b/src/app/services/token-atm-configuration-manager.service.ts
@@ -38,7 +38,16 @@ export class TokenATMConfigurationManagerService {
             if (entry.type != 'tag' || entry.name != 'p') continue;
             if (entry.children[0]?.type != 'text') continue;
             if (typeof entry.children[0]?.data != 'string') continue;
-            return entry.children[0]?.data;
+
+            let result = entry.children[0].data;
+            let next = entry.children[0].next;
+            while (next) {
+                if (next.type === 'text' && typeof next.data === 'string') {
+                    result += next.data;
+                }
+                next = next.next?.type === 'text' ? next.next : null;
+            }
+            return result;
         }
         throw new Error('Page resolve failed');
     }


### PR DESCRIPTION
### Description

When resolving the Canvas Page content for Token ATM, an `HTMLParse`r is used.
The parser creates DOM Nodes and Token ATM selects the Text Nodes from that.

Text Nodes can have a `next` Node which includes subsequent portions of the original text.

#### Fix Applied

Append data from consecutive Text Nodes to the returned string when resolving Canvas Page content.

### Testing Note

Requires very long Canvas Page content to trigger the parsing into multiple sequential text nodes.