### PR TITLE
Enhancement: Use Embedded Preview of linked Google Docs

### DIFF
--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -133,7 +133,10 @@ export class LoginComponent implements AfterViewInit {
     }
 
     openLink() {
-        window.open('https://docs.google.com/document/d/1H4cvBXV7wwVp1IA2squ0mtrug5HkDVlBf4qKhh1o_vQ/view', '_blank');
+        window.open(
+            'https://docs.google.com/document/d/1H4cvBXV7wwVp1IA2squ0mtrug5HkDVlBf4qKhh1o_vQ/preview?rm=embedded',
+            '_blank'
+        );
     }
 
     getCredentialsFormItemInfoMap(): CanvasCredentialFormItemInfoMap {

--- a/src/app/credential-handlers/qualtrics-credential-handler.ts
+++ b/src/app/credential-handlers/qualtrics-credential-handler.ts
@@ -20,7 +20,8 @@ const QUALTRICS_CREDENTIAL_KEY = 'qualtrics';
 export class QualtricsCredentialHandler implements CredentialHandler<QualtricsCredential> {
     readonly key = QUALTRICS_CREDENTIAL_KEY;
     readonly descriptiveName = 'Qualtrics';
-    readonly documentLink = 'https://docs.google.com/document/d/1H4cvBXV7wwVp1IA2squ0mtrug5HkDVlBf4qKhh1o_vQ/view';
+    readonly documentLink =
+        'https://docs.google.com/document/d/1H4cvBXV7wwVp1IA2squ0mtrug5HkDVlBf4qKhh1o_vQ/preview?rm=embedded';
 
     constructor(@Inject(QualtricsService) private qualtricsService: QualtricsService) {}
 

--- a/src/app/credential-handlers/question-pro-credential-handler.ts
+++ b/src/app/credential-handlers/question-pro-credential-handler.ts
@@ -21,7 +21,8 @@ export const QUESTION_PRO_CREDENTIAL_KEY = 'question_pro';
 export class QuestionProCredentialHandler implements CredentialHandler<QuestionProCredential> {
     readonly key = QUESTION_PRO_CREDENTIAL_KEY;
     readonly descriptiveName = 'QuestionPro';
-    readonly documentLink = 'https://docs.google.com/document/d/1H4cvBXV7wwVp1IA2squ0mtrug5HkDVlBf4qKhh1o_vQ/view';
+    readonly documentLink =
+        'https://docs.google.com/document/d/1H4cvBXV7wwVp1IA2squ0mtrug5HkDVlBf4qKhh1o_vQ/preview?rm=embedded';
 
     constructor(@Inject(QuestionProService) private questionProService: QuestionProService) {}
 


### PR DESCRIPTION
### Description

Changes the linked Google Docs URLs to embedded preview.

The information can still be downloaded in various formats through google docs, but the edit and comment functionality is hidden. This remove some excess visual noise, since when opening the links within Token ATM the docs are meant to be read as a resource without needing to be easily edited in situ.

### Testing Note

All 3 Google Docs links should have been updated to be embedded previews.