### PR TITLE
Update Node LTS (v20)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT=18-bullseye
+ARG VARIANT=20-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
         // Update 'VARIANT' to pick a Node version: 18, 16, 14.
         // Append -bullseye or -buster to pin to an OS version.
         // Use -bullseye variants on local arm64/Apple Silicon.
-        "args": { "VARIANT": "18-bullseye" }
+        "args": { "VARIANT": "20-bullseye" }
     },
 
     // Configure tool-specific properties.


### PR DESCRIPTION
### Description

Upgrades the docker container to use version 20 of Node (the current Maintenance LTS version).

Upgraded in preparation for future Angular upgrades. (Angular v20 enters LTS at the end of 2025 and minimum supported Node is Node v20)