### PR TITLE
Upgrade to Typescript 5.5.4

### DIFF
--- a/custom-schematics/package-lock.json
+++ b/custom-schematics/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@angular-devkit/core": "^18.2.20",
                 "@angular-devkit/schematics": "^18.2.20",
-                "typescript": "~5.4.5"
+                "typescript": "~5.5.4"
             },
             "devDependencies": {
                 "@types/jasmine": "^5.1.9",
@@ -921,9 +921,10 @@
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/typescript": {
-            "version": "5.4.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/custom-schematics/package.json
+++ b/custom-schematics/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@angular-devkit/core": "^18.2.20",
         "@angular-devkit/schematics": "^18.2.20",
-        "typescript": "~5.4.5"
+        "typescript": "~5.5.4"
     },
     "devDependencies": {
         "@types/jasmine": "^5.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
                 "npm-run-all": "^4.1.5",
                 "prettier": "^2.8.8",
                 "prettier-eslint": "^15.0.1",
-                "typescript": "~5.4.5"
+                "typescript": "~5.5.4"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -15468,9 +15468,10 @@
             "dev": true
         },
         "node_modules/typescript": {
-            "version": "5.4.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.8",
         "prettier-eslint": "^15.0.1",
-        "typescript": "~5.4.5"
+        "typescript": "~5.5.4"
     },
     "overrides": {
         "semver": "^7.5.3",


### PR DESCRIPTION
### Description

Upgrades TypeScript to 5.5.4. 

TypeScript 5.5 is the [latest version Angular v18 supports; And is the minimum version required for Angular v19](https://angular.dev/reference/versions#actively-supported-versions).

This upgrade is made in preparation for upgrading Angular in future (most likely by the end of 2025).

#### Breaking Changes and Deprecations

- TypeScript (from 5.4.5 to 5.5.4)
  - [Typescript 5.5](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#notable-behavioral-changes)