### PR TITLE
Bugfix: Workaround html encoding with unicode rightwards arrow

### DIFF
--- a/src/app/utils/canvas-grading.spec.ts
+++ b/src/app/utils/canvas-grading.spec.ts
@@ -634,7 +634,7 @@ function testingUpdateMessage(params: testingUpdateMessageParams) {
     });
 }
 function testTemplate(a: string, b: string, orig: string, final: string) {
-    return `Added ${a} to ${b}\nChange: ${orig} => ${final}`;
+    return `Added ${a} to ${b}\nChange: ${orig} → ${final}`;
 }
 
 // Tests for checking the update message when adding to an assignment score.

--- a/src/app/utils/canvas-grading.ts
+++ b/src/app/utils/canvas-grading.ts
@@ -424,7 +424,7 @@ function generatePostedGradeMessage(
     /** Displays the change provided by instructor, and grade display of assignment */
     const firstLine = `Added ${addText} to ${ofPoints(curGrade, target.pointsPossible)}`;
     /** Displays the actual change provided to Canvas via posted_grade */
-    const secondLine = `Change: ${postedGrade.includes('%') ? target.grade : target.score} => ${postedGrade}`;
+    const secondLine = `Change: ${postedGrade.includes('%') ? target.grade : target.score} → ${postedGrade}`;
     return firstLine + '\n' + secondLine;
 }
 


### PR DESCRIPTION
### Description

Fixes other found cases of `>` posted to a canvas comment.
Plaintext on Canvas is now html encoded so `>` used as an arrowhead was changed to `&gt;` when displayed in a Canvas comment.

Fixes #156 for Grade Change Comments.